### PR TITLE
add --from-live flag to aisw add

### DIFF
--- a/completions/_aisw
+++ b/completions/_aisw
@@ -33,6 +33,9 @@ _arguments "${_arguments_options[@]}" : \
 '--api-key=[API key — skips the interactive auth method prompt]:KEY:_default' \
 '--label=[Human-readable label for this profile]:TEXT:_default' \
 '--set-active[Switch to this profile immediately after adding]' \
+'(--api-key --from-live)--from-env[Use the tool'\''s standard environment variable instead of interactive prompts]' \
+'(--api-key --from-env)--from-live[Capture live credentials from the tool'\''s current config without launching a login flow]' \
+'--yes[Overwrite an existing profile without prompting (only used with --from-live)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \

--- a/completions/aisw.bash
+++ b/completions/aisw.bash
@@ -121,7 +121,7 @@ _aisw() {
             return 0
             ;;
         aisw__add)
-            opts="-h -V --api-key --label --set-active --help --version claude codex gemini <PROFILE_NAME>"
+            opts="-h -V --api-key --label --set-active --from-env --from-live --yes --help --version claude codex gemini <PROFILE_NAME>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/aisw.fish
+++ b/completions/aisw.fish
@@ -39,6 +39,9 @@ complete -c aisw -n "__fish_aisw_needs_command" -f -a "help" -d 'Print this mess
 complete -c aisw -n "__fish_aisw_using_subcommand add" -l api-key -d 'API key — skips the interactive auth method prompt' -r
 complete -c aisw -n "__fish_aisw_using_subcommand add" -l label -d 'Human-readable label for this profile' -r
 complete -c aisw -n "__fish_aisw_using_subcommand add" -l set-active -d 'Switch to this profile immediately after adding'
+complete -c aisw -n "__fish_aisw_using_subcommand add" -l from-env -d 'Use the tool\'s standard environment variable instead of interactive prompts'
+complete -c aisw -n "__fish_aisw_using_subcommand add" -l from-live -d 'Capture live credentials from the tool\'s current config without launching a login flow'
+complete -c aisw -n "__fish_aisw_using_subcommand add" -l yes -d 'Overwrite an existing profile without prompting (only used with --from-live)'
 complete -c aisw -n "__fish_aisw_using_subcommand add" -s h -l help -d 'Print help'
 complete -c aisw -n "__fish_aisw_using_subcommand add" -s V -l version -d 'Print version'
 complete -c aisw -n "__fish_aisw_using_subcommand use" -l emit-env -d 'Print shell export statements to stdout instead of applying them directly. Used internally by the shell hook — not intended for direct use'

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -45,6 +45,13 @@ Bootstrap command:
 - offers shell hook setup
 - offers importing existing live credentials
 
+Notes:
+- For Gemini, when both `.env` and OAuth cache files are present under `~/.gemini/`, import precedence is `.env` first.
+- `aisw init` reports current live upstream state, not a full inventory of every stored `~/.aisw` profile.
+- If a tool's live account was changed outside `aisw`, `init` reports that current live account and whether it matches the profile `aisw` records as active.
+- For Claude Code, `init` distinguishes local Claude state from importable auth and reports when local state exists without importable credentials.
+- When imported credentials are OAuth-based and aisw can resolve the authenticated account identity, it blocks importing a duplicate alias for an already stored account.
+
 Examples:
 
 ```sh
@@ -75,11 +82,11 @@ Notes:
 - In `--non-interactive` mode, interactive add fails by design.
 - `--from-live` reads the current native tool credentials and stores them as an aisw-managed profile.
 - `--from-live` always activates the captured profile because those credentials are already live.
-
 Live credential sources:
 - Claude: `~/.claude/.credentials.json`, or the system keyring on macOS
 - Codex: `~/.codex/auth.json`
 - Gemini: `~/.gemini/.env` or OAuth files in `~/.gemini/`
+- When both Gemini `.env` and OAuth cache files are present, `aisw` uses `.env` first by design.
 
 Examples:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,7 +18,7 @@ aisw [--no-color] [--non-interactive] [--quiet] <command> ...
 
 ```text
 aisw init [--yes]
-aisw add <tool> <profile> [--api-key KEY] [--from-env] [--label TEXT] [--set-active]
+aisw add <tool> <profile> [--api-key KEY] [--from-env] [--from-live] [--label TEXT] [--set-active]
 aisw use <tool> <profile> [--state-mode isolated|shared]
 aisw use --all --profile <profile>
 aisw list [tool] [--json]
@@ -52,22 +52,35 @@ aisw init
 aisw init --yes
 ```
 
+## Automation and scripting
+
+For prompt behavior, JSON interfaces, stdout/stderr expectations, and automation-safe usage patterns, see [Automation and Scripting](automation.md).
+
 ## `aisw add`
 
 ```text
-aisw add <tool> <profile> [--api-key KEY] [--from-env] [--label TEXT] [--set-active]
+aisw add <tool> <profile> [--api-key KEY] [--from-env] [--from-live] [--label TEXT] [--set-active]
 ```
 
 | Flag | Purpose |
 |---|---|
 | `--api-key KEY` | Add with explicit API key |
 | `--from-env` | Read key from tool env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) |
+| `--from-live` | Import the tool's current live credentials into aisw without launching login |
 | `--label TEXT` | Add human-readable label |
 | `--set-active` | Activate immediately after add |
+| `--yes` | Overwrite existing profile name when used with `--from-live` |
 
 Notes:
-- Without `--api-key` and `--from-env`, add uses interactive auth flow.
+- Without `--api-key`, `--from-env`, or `--from-live`, add uses interactive auth flow.
 - In `--non-interactive` mode, interactive add fails by design.
+- `--from-live` reads the current native tool credentials and stores them as an aisw-managed profile.
+- `--from-live` always activates the captured profile because those credentials are already live.
+
+Live credential sources:
+- Claude: `~/.claude/.credentials.json`, or the system keyring on macOS
+- Codex: `~/.codex/auth.json`
+- Gemini: `~/.gemini/.env` or OAuth files in `~/.gemini/`
 
 Examples:
 
@@ -75,6 +88,8 @@ Examples:
 aisw add claude work --api-key "$ANTHROPIC_API_KEY"
 aisw add codex ci --from-env
 aisw add gemini personal --label "Personal" --set-active
+aisw add claude work --from-live
+aisw add codex work --from-live --yes
 ```
 
 ## `aisw use`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -70,7 +70,6 @@ aisw add <tool> <profile> [--api-key KEY] [--from-env] [--from-live] [--label TE
 | `--label TEXT` | Add human-readable label |
 | `--set-active` | Activate immediately after add |
 | `--yes` | Overwrite existing profile name when used with `--from-live` |
-
 Notes:
 - Without `--api-key`, `--from-env`, or `--from-live`, add uses interactive auth flow.
 - In `--non-interactive` mode, interactive add fails by design.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -82,6 +82,7 @@ Notes:
 - In `--non-interactive` mode, interactive add fails by design.
 - `--from-live` reads the current native tool credentials and stores them as an aisw-managed profile.
 - `--from-live` always activates the captured profile because those credentials are already live.
+- With `--from-live --yes`, overwrite updates the existing profile in place; aisw does not delete the profile entry before capture succeeds.
 Live credential sources:
 - Claude: `~/.claude/.credentials.json`, or the system keyring on macOS
 - Codex: `~/.codex/auth.json`

--- a/src/auth/gemini.rs
+++ b/src/auth/gemini.rs
@@ -31,6 +31,46 @@ pub fn live_dir(user_home: &Path) -> PathBuf {
     user_home.join(GEMINI_CACHE_DIR)
 }
 
+#[derive(Debug, Clone)]
+pub struct LiveImportSelection {
+    pub method: AuthMethod,
+    pub source_description: String,
+    pub env_file: PathBuf,
+    pub oauth_files: Vec<files::RegularFile>,
+    pub has_both_sources: bool,
+}
+
+pub fn detect_live_import_selection(user_home: &Path) -> Result<Option<LiveImportSelection>> {
+    let gemini_dir = live_dir(user_home);
+    let env_file = gemini_dir.join(ENV_FILE);
+    let oauth_files = live_oauth_files_for_import(user_home)?;
+    let has_env = env_file.exists();
+    let has_oauth = !oauth_files.is_empty();
+
+    if !has_env && !has_oauth {
+        return Ok(None);
+    }
+
+    let (method, source_description) = if has_env {
+        (AuthMethod::ApiKey, format!("found {}", env_file.display()))
+    } else {
+        let primary_file = preferred_live_oauth_file(&oauth_files)
+            .context("could not determine primary Gemini OAuth credential file")?;
+        (
+            AuthMethod::OAuth,
+            live_import_source_description(&primary_file.path, oauth_files.len()),
+        )
+    };
+
+    Ok(Some(LiveImportSelection {
+        method,
+        source_description,
+        env_file,
+        oauth_files,
+        has_both_sources: has_env && has_oauth,
+    }))
+}
+
 pub fn live_oauth_files_for_import(user_home: &Path) -> Result<Vec<files::RegularFile>> {
     let gemini_dir = live_dir(user_home);
     if !gemini_dir.exists() {
@@ -1243,6 +1283,33 @@ mod tests {
         let preferred = preferred_live_oauth_file(&files).expect("preferred file");
 
         assert_eq!(preferred.file_name, "settings.json");
+    }
+
+    #[test]
+    fn detect_live_import_selection_prefers_env_when_both_sources_exist() {
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("home");
+        let gemini_dir = user_home.join(".gemini");
+        std::fs::create_dir_all(&gemini_dir).unwrap();
+        std::fs::write(gemini_dir.join(".env"), "GEMINI_API_KEY=test\n").unwrap();
+        std::fs::write(gemini_dir.join("oauth_creds.json"), "{}").unwrap();
+
+        let selection = detect_live_import_selection(&user_home)
+            .unwrap()
+            .expect("selection should be present");
+        assert_eq!(selection.method, AuthMethod::ApiKey);
+        assert!(selection.has_both_sources);
+        assert_eq!(selection.oauth_files.len(), 1);
+    }
+
+    #[test]
+    fn detect_live_import_selection_returns_none_when_empty() {
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("home");
+        std::fs::create_dir_all(user_home.join(".gemini")).unwrap();
+
+        let selection = detect_live_import_selection(&user_home).unwrap();
+        assert!(selection.is_none());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -119,9 +119,7 @@ pub struct AddArgs {
     #[arg(long, conflicts_with = "api_key")]
     pub from_env: bool,
 
-    /// Capture whatever live credentials the tool currently has and store them as a new profile
-    /// without launching any login flow. Useful after a native `claude login` / `codex login` /
-    /// `gemini login` when you want aisw to manage those credentials going forward.
+    /// Capture live credentials from the tool's current config — no login flow launched
     #[arg(long, conflicts_with_all = ["api_key", "from_env"])]
     pub from_live: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,6 +118,16 @@ pub struct AddArgs {
     /// Use the tool's standard environment variable instead of interactive prompts
     #[arg(long, conflicts_with = "api_key")]
     pub from_env: bool,
+
+    /// Capture whatever live credentials the tool currently has and store them as a new profile
+    /// without launching any login flow. Useful after a native `claude login` / `codex login` /
+    /// `gemini login` when you want aisw to manage those credentials going forward.
+    #[arg(long, conflicts_with_all = ["api_key", "from_env"])]
+    pub from_live: bool,
+
+    /// Overwrite an existing profile without prompting (only meaningful with --from-live)
+    #[arg(long)]
+    pub yes: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -707,6 +707,7 @@ mod tests {
     }
 
     fn with_env_lock<T>(f: impl FnOnce() -> T) -> T {
+        let _spawn_lock = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let _lock = env_lock().lock().unwrap();
         f()
     }
@@ -796,6 +797,7 @@ mod tests {
 
     #[test]
     fn tool_not_found_errors() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let home = tmp.path().join("home");
         let bin_dir = tmp.path().join("bin");
@@ -813,6 +815,7 @@ mod tests {
 
     #[test]
     fn api_key_claude_creates_profile() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let home = tmp.path().join("home");
         let bin_dir = tmp.path().join("bin");
@@ -829,6 +832,7 @@ mod tests {
 
     #[test]
     fn set_active_marks_profile_active() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let home = tmp.path().join("home");
         let bin_dir = tmp.path().join("bin");
@@ -846,6 +850,7 @@ mod tests {
 
     #[test]
     fn label_stored_in_config() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let home = tmp.path().join("home");
         let bin_dir = tmp.path().join("bin");
@@ -866,6 +871,7 @@ mod tests {
 
     #[test]
     fn invalid_profile_name_errors() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let home = tmp.path().join("home");
         let bin_dir = tmp.path().join("bin");
@@ -879,6 +885,7 @@ mod tests {
 
     #[test]
     fn codex_api_key_creates_profile() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let home = tmp.path().join("home");
         let bin_dir = tmp.path().join("bin");
@@ -895,6 +902,7 @@ mod tests {
 
     #[test]
     fn gemini_api_key_creates_profile() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let home = tmp.path().join("home");
         let bin_dir = tmp.path().join("bin");
@@ -1124,6 +1132,7 @@ mod tests {
 
     #[test]
     fn from_live_claude_creates_profile() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1151,6 +1160,7 @@ mod tests {
 
     #[test]
     fn from_live_claude_always_activates() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1174,6 +1184,7 @@ mod tests {
 
     #[test]
     fn from_live_claude_overwrites_with_yes() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1208,6 +1219,7 @@ mod tests {
 
     #[test]
     fn from_live_claude_fails_without_credentials() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1230,6 +1242,7 @@ mod tests {
 
     #[test]
     fn from_live_codex_creates_profile() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1254,6 +1267,7 @@ mod tests {
 
     #[test]
     fn from_live_codex_always_activates() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1276,6 +1290,7 @@ mod tests {
 
     #[test]
     fn from_live_codex_fails_without_credentials() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1298,6 +1313,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn from_live_codex_overwrite_keeps_profile_when_parent_not_writable() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1343,6 +1359,7 @@ mod tests {
 
     #[test]
     fn from_live_gemini_creates_profile() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1368,6 +1385,7 @@ mod tests {
 
     #[test]
     fn from_live_gemini_always_activates() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1391,6 +1409,7 @@ mod tests {
 
     #[test]
     fn from_live_gemini_prefers_env_when_both_sources_exist() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1425,6 +1444,7 @@ mod tests {
 
     #[test]
     fn from_live_gemini_fails_without_credentials() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -332,15 +332,13 @@ fn from_live_claude(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
         return Err(e);
     }
 
-    if args.set_active {
-        auth::claude::apply_live_credentials(
-            &profile_store,
-            &args.profile_name,
-            stored_backend,
-            user_home,
-        )?;
-        config_store.activate_profile(Tool::Claude, &args.profile_name, None)?;
-    }
+    auth::claude::apply_live_credentials(
+        &profile_store,
+        &args.profile_name,
+        stored_backend,
+        user_home,
+    )?;
+    config_store.activate_profile(Tool::Claude, &args.profile_name, None)?;
 
     finalize_from_live(&args, Tool::Claude, stored_backend, AuthMethod::OAuth)
 }
@@ -447,10 +445,8 @@ fn from_live_codex(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> {
         return Err(e);
     }
 
-    if args.set_active {
-        auth::codex::apply_live_files(&profile_store, &args.profile_name, user_home)?;
-        config_store.activate_profile(Tool::Codex, &args.profile_name, None)?;
-    }
+    auth::codex::apply_live_files(&profile_store, &args.profile_name, user_home)?;
+    config_store.activate_profile(Tool::Codex, &args.profile_name, None)?;
 
     finalize_from_live(&args, Tool::Codex, CredentialBackend::File, auth_method)
 }
@@ -559,17 +555,15 @@ fn from_live_gemini(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
         return Err(e);
     }
 
-    if args.set_active {
-        match auth_method {
-            AuthMethod::OAuth => {
-                auth::gemini::apply_token_cache(&profile_store, &args.profile_name, &gemini_dir)?
-            }
-            AuthMethod::ApiKey => {
-                auth::gemini::apply_env_file(&profile_store, &args.profile_name, &gemini_dir)?
-            }
+    match auth_method {
+        AuthMethod::OAuth => {
+            auth::gemini::apply_token_cache(&profile_store, &args.profile_name, &gemini_dir)?
         }
-        config_store.activate_profile(Tool::Gemini, &args.profile_name, None)?;
+        AuthMethod::ApiKey => {
+            auth::gemini::apply_env_file(&profile_store, &args.profile_name, &gemini_dir)?
+        }
     }
+    config_store.activate_profile(Tool::Gemini, &args.profile_name, None)?;
 
     finalize_from_live(&args, Tool::Gemini, CredentialBackend::File, auth_method)
 }
@@ -591,23 +585,14 @@ fn finalize_from_live(
         },
     );
     output::print_kv("Backend", backend.display_name());
-    output::print_kv(
-        "Activation",
-        if args.set_active { "active" } else { "stored" },
-    );
+    output::print_kv("Activation", "active");
     output::print_blank_line();
     output::print_effects_header();
     output::print_effect("Profile credentials stored in aisw.");
-    if args.set_active {
-        output::print_effect("Live tool configuration updated.");
-        output::print_effect("Active profile updated.");
-    }
+    output::print_effect("Live tool configuration updated.");
+    output::print_effect("Active profile updated.");
     output::print_blank_line();
-    output::print_next_step(output::next_step_after_add(
-        tool,
-        &args.profile_name,
-        args.set_active,
-    ));
+    output::print_next_step(output::next_step_after_add(tool, &args.profile_name, true));
     Ok(())
 }
 
@@ -1084,7 +1069,7 @@ mod tests {
     }
 
     #[test]
-    fn from_live_claude_stored_not_active_by_default() {
+    fn from_live_claude_always_activates() {
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1103,7 +1088,7 @@ mod tests {
 
         let config = ConfigStore::new(&aisw_home).load().unwrap();
         assert!(config.profiles_for(Tool::Claude).contains_key("personal"));
-        assert_eq!(config.active_for(Tool::Claude), None);
+        assert_eq!(config.active_for(Tool::Claude), Some("personal"));
     }
 
     #[test]
@@ -1187,7 +1172,7 @@ mod tests {
     }
 
     #[test]
-    fn from_live_codex_stored_not_active_by_default() {
+    fn from_live_codex_always_activates() {
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1205,7 +1190,7 @@ mod tests {
 
         let config = ConfigStore::new(&aisw_home).load().unwrap();
         assert!(config.profiles_for(Tool::Codex).contains_key("personal"));
-        assert_eq!(config.active_for(Tool::Codex), None);
+        assert_eq!(config.active_for(Tool::Codex), Some("personal"));
     }
 
     #[test]
@@ -1255,7 +1240,7 @@ mod tests {
     }
 
     #[test]
-    fn from_live_gemini_stored_not_active_by_default() {
+    fn from_live_gemini_always_activates() {
         let tmp = tempdir().unwrap();
         let aisw_home = tmp.path().join("aisw");
         let user_home = tmp.path().join("user");
@@ -1274,7 +1259,7 @@ mod tests {
         let config = ConfigStore::new(&aisw_home).load().unwrap();
         let meta = &config.profiles_for(Tool::Gemini)["personal"];
         assert_eq!(meta.auth_method, crate::config::AuthMethod::OAuth);
-        assert_eq!(config.active_for(Tool::Gemini), None);
+        assert_eq!(config.active_for(Tool::Gemini), Some("personal"));
     }
 
     #[test]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,11 +1,13 @@
 use std::ffi::OsString;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use chrono::Utc;
 
 use crate::auth;
+use crate::auth::identity;
 use crate::cli::AddArgs;
-use crate::config::ConfigStore;
+use crate::config::{AuthMethod, ConfigStore, CredentialBackend, ProfileMeta};
 use crate::output;
 use crate::profile::ProfileStore;
 use crate::runtime;
@@ -21,6 +23,14 @@ pub fn run(args: AddArgs, home: &Path) -> Result<()> {
 }
 
 pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<()> {
+    // --from-live captures live credentials without launching any login flow.
+    // Tool detection is intentionally skipped: the tool is already installed
+    // and logged in, which is the prerequisite for --from-live to succeed.
+    if args.from_live {
+        let user_home = dirs::home_dir().context("could not determine home directory")?;
+        return from_live(args, home, &user_home);
+    }
+
     let profile_store = ProfileStore::new(home);
     let config_store = ConfigStore::new(home);
     let config = config_store.load()?;
@@ -202,6 +212,417 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
     Ok(())
 }
 
+// ---- --from-live implementation --------------------------------------------
+
+fn confirm_overwrite(tool: Tool, name: &str, yes: bool) -> Result<()> {
+    if yes {
+        return Ok(());
+    }
+    if runtime::is_non_interactive() {
+        bail!(
+            "profile '{}' already exists for {}.\n  \
+             Re-run with --yes to overwrite, or choose a different name.",
+            name,
+            tool,
+        );
+    }
+    eprint!(
+        "Profile '{}' already exists for {}. Overwrite? [y/N] ",
+        name, tool
+    );
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .context("could not read confirmation from stdin")?;
+    if !matches!(line.trim(), "y" | "Y") {
+        bail!("operation cancelled by user.");
+    }
+    Ok(())
+}
+
+fn from_live(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> {
+    match args.tool {
+        Tool::Claude => from_live_claude(args, home, user_home),
+        Tool::Codex => from_live_codex(args, home, user_home),
+        Tool::Gemini => from_live_gemini(args, home, user_home),
+    }
+}
+
+fn from_live_claude(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> {
+    let profile_store = ProfileStore::new(home);
+    let config_store = ConfigStore::new(home);
+
+    let snapshot =
+        auth::claude::live_credentials_snapshot_for_import(user_home)?.with_context(|| {
+            format!(
+                "no live credentials found — run 'claude login' first, \
+                 then retry 'aisw add claude {} --from-live'.",
+                args.profile_name,
+            )
+        })?;
+
+    let stored_backend = auth::claude::preferred_import_backend(&snapshot.source);
+
+    if profile_store.exists(Tool::Claude, &args.profile_name) {
+        confirm_overwrite(Tool::Claude, &args.profile_name, args.yes)?;
+        config_store.remove_profile(Tool::Claude, &args.profile_name)?;
+        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+    }
+
+    profile_store.create(Tool::Claude, &args.profile_name)?;
+
+    let write_result = match stored_backend {
+        CredentialBackend::File => profile_store.write_file(
+            Tool::Claude,
+            &args.profile_name,
+            ".credentials.json",
+            &snapshot.bytes,
+        ),
+        CredentialBackend::SystemKeyring => crate::auth::secure_store::write_profile_secret(
+            Tool::Claude,
+            &args.profile_name,
+            &snapshot.bytes,
+        ),
+    };
+
+    if let Err(e) = write_result {
+        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        return Err(e);
+    }
+
+    if let Err(e) = auth::claude::capture_live_oauth_account_metadata(
+        &profile_store,
+        &args.profile_name,
+        user_home,
+    ) {
+        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        return Err(e);
+    }
+
+    if let Err(e) = identity::ensure_unique_oauth_identity(
+        &profile_store,
+        &config_store,
+        Tool::Claude,
+        &args.profile_name,
+        stored_backend,
+    ) {
+        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        if stored_backend == CredentialBackend::SystemKeyring {
+            let _ =
+                crate::auth::secure_store::delete_profile_secret(Tool::Claude, &args.profile_name);
+        }
+        return Err(e);
+    }
+
+    if let Err(e) = config_store.add_profile(
+        Tool::Claude,
+        &args.profile_name,
+        ProfileMeta {
+            added_at: Utc::now(),
+            auth_method: AuthMethod::OAuth,
+            credential_backend: stored_backend,
+            label: args.label.clone(),
+        },
+    ) {
+        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        if stored_backend == CredentialBackend::SystemKeyring {
+            let _ =
+                crate::auth::secure_store::delete_profile_secret(Tool::Claude, &args.profile_name);
+        }
+        return Err(e);
+    }
+
+    if args.set_active {
+        auth::claude::apply_live_credentials(
+            &profile_store,
+            &args.profile_name,
+            stored_backend,
+            user_home,
+        )?;
+        config_store.activate_profile(Tool::Claude, &args.profile_name, None)?;
+    }
+
+    finalize_from_live(&args, Tool::Claude, stored_backend, AuthMethod::OAuth)
+}
+
+fn from_live_codex(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> {
+    let profile_store = ProfileStore::new(home);
+    let config_store = ConfigStore::new(home);
+
+    let snapshot =
+        auth::codex::live_credentials_snapshot_for_import(user_home)?.with_context(|| {
+            format!(
+                "no live credentials found — run 'codex login' first, \
+                 then retry 'aisw add codex {} --from-live'.",
+                args.profile_name,
+            )
+        })?;
+
+    let is_api_key = json_string_field(&snapshot.bytes, "token").is_some();
+    let auth_method = if is_api_key {
+        AuthMethod::ApiKey
+    } else {
+        AuthMethod::OAuth
+    };
+
+    if is_api_key {
+        if let Some(secret) = json_string_field(&snapshot.bytes, "token") {
+            if let Some(existing) = identity::existing_api_key_profile_for_secret(
+                &profile_store,
+                &config_store,
+                Tool::Codex,
+                &secret,
+            )? {
+                if existing != args.profile_name {
+                    bail!(
+                        "A Codex API key profile for this account already exists as '{}'.\n  \
+                         Use that profile or remove it before saving another alias.",
+                        existing
+                    );
+                }
+            }
+        }
+    } else if let Some(existing) = identity::existing_oauth_profile_for_json_bytes(
+        &profile_store,
+        &config_store,
+        Tool::Codex,
+        &snapshot.bytes,
+    )? {
+        if existing != args.profile_name {
+            bail!(
+                "A Codex OAuth profile for this account already exists as '{}'.\n  \
+                 Use that profile or remove it before saving another alias.",
+                existing
+            );
+        }
+    }
+
+    if profile_store.exists(Tool::Codex, &args.profile_name) {
+        confirm_overwrite(Tool::Codex, &args.profile_name, args.yes)?;
+        config_store.remove_profile(Tool::Codex, &args.profile_name)?;
+        let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+    }
+
+    profile_store.create(Tool::Codex, &args.profile_name)?;
+
+    if let Err(e) = auth::codex::write_file_store_config(&profile_store, &args.profile_name) {
+        let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+        return Err(e);
+    }
+
+    if let Err(e) = profile_store.write_file(
+        Tool::Codex,
+        &args.profile_name,
+        auth::codex::AUTH_FILE,
+        &snapshot.bytes,
+    ) {
+        let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+        return Err(e);
+    }
+
+    if auth_method == AuthMethod::OAuth {
+        if let Err(e) = identity::ensure_unique_oauth_identity(
+            &profile_store,
+            &config_store,
+            Tool::Codex,
+            &args.profile_name,
+            CredentialBackend::File,
+        ) {
+            let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+            return Err(e);
+        }
+    }
+
+    if let Err(e) = config_store.add_profile(
+        Tool::Codex,
+        &args.profile_name,
+        ProfileMeta {
+            added_at: Utc::now(),
+            auth_method,
+            credential_backend: CredentialBackend::File,
+            label: args.label.clone(),
+        },
+    ) {
+        let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+        return Err(e);
+    }
+
+    if args.set_active {
+        auth::codex::apply_live_files(&profile_store, &args.profile_name, user_home)?;
+        config_store.activate_profile(Tool::Codex, &args.profile_name, None)?;
+    }
+
+    finalize_from_live(&args, Tool::Codex, CredentialBackend::File, auth_method)
+}
+
+fn from_live_gemini(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> {
+    let profile_store = ProfileStore::new(home);
+    let config_store = ConfigStore::new(home);
+
+    let gemini_dir = auth::gemini::live_dir(user_home);
+    let env_file = gemini_dir.join(".env");
+    let oauth_files = auth::gemini::live_oauth_files_for_import(user_home)?;
+
+    let auth_method = if env_file.exists() {
+        AuthMethod::ApiKey
+    } else if !oauth_files.is_empty() {
+        AuthMethod::OAuth
+    } else {
+        bail!(
+            "no live credentials found in {} — run 'gemini login' first, \
+             then retry 'aisw add gemini {} --from-live'.",
+            gemini_dir.display(),
+            args.profile_name,
+        )
+    };
+
+    if auth_method == AuthMethod::ApiKey {
+        let source_bytes = std::fs::read(&env_file)
+            .with_context(|| format!("could not read {}", env_file.display()))?;
+        if let Some(api_key) = gemini_api_key_from_env(&source_bytes) {
+            if let Some(existing) = identity::existing_api_key_profile_for_secret(
+                &profile_store,
+                &config_store,
+                Tool::Gemini,
+                &api_key,
+            )? {
+                if existing != args.profile_name {
+                    bail!(
+                        "A Gemini API key profile for this account already exists as '{}'.\n  \
+                         Use that profile or remove it before saving another alias.",
+                        existing
+                    );
+                }
+            }
+        }
+    } else if let Some(existing) = auth::gemini::existing_oauth_profile_for_live_files(
+        &profile_store,
+        &config_store,
+        &oauth_files,
+    )? {
+        if existing != args.profile_name {
+            bail!(
+                "A Gemini OAuth profile for this account already exists as '{}'.\n  \
+                 Use that profile or remove it before saving another alias.",
+                existing
+            );
+        }
+    }
+
+    if profile_store.exists(Tool::Gemini, &args.profile_name) {
+        confirm_overwrite(Tool::Gemini, &args.profile_name, args.yes)?;
+        config_store.remove_profile(Tool::Gemini, &args.profile_name)?;
+        let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+    }
+
+    profile_store.create(Tool::Gemini, &args.profile_name)?;
+
+    let copy_result = if auth_method == AuthMethod::OAuth {
+        auth::gemini::copy_live_oauth_files_into_profile(
+            &profile_store,
+            &args.profile_name,
+            &oauth_files,
+        )
+    } else {
+        profile_store.copy_file_into(Tool::Gemini, &args.profile_name, &env_file, ".env")
+    };
+
+    if let Err(e) = copy_result {
+        let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+        return Err(e);
+    }
+
+    if auth_method == AuthMethod::OAuth {
+        if let Err(e) = identity::ensure_unique_oauth_identity(
+            &profile_store,
+            &config_store,
+            Tool::Gemini,
+            &args.profile_name,
+            CredentialBackend::File,
+        ) {
+            let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+            return Err(e);
+        }
+    }
+
+    if let Err(e) = config_store.add_profile(
+        Tool::Gemini,
+        &args.profile_name,
+        ProfileMeta {
+            added_at: Utc::now(),
+            auth_method,
+            credential_backend: CredentialBackend::File,
+            label: args.label.clone(),
+        },
+    ) {
+        let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+        return Err(e);
+    }
+
+    if args.set_active {
+        match auth_method {
+            AuthMethod::OAuth => {
+                auth::gemini::apply_token_cache(&profile_store, &args.profile_name, &gemini_dir)?
+            }
+            AuthMethod::ApiKey => {
+                auth::gemini::apply_env_file(&profile_store, &args.profile_name, &gemini_dir)?
+            }
+        }
+        config_store.activate_profile(Tool::Gemini, &args.profile_name, None)?;
+    }
+
+    finalize_from_live(&args, Tool::Gemini, CredentialBackend::File, auth_method)
+}
+
+fn finalize_from_live(
+    args: &AddArgs,
+    tool: Tool,
+    backend: CredentialBackend,
+    auth_method: AuthMethod,
+) -> Result<()> {
+    output::print_title("Added profile");
+    output::print_kv("Tool", tool.display_name());
+    output::print_kv("Profile", &args.profile_name);
+    output::print_kv(
+        "Auth",
+        match auth_method {
+            AuthMethod::OAuth => "oauth",
+            AuthMethod::ApiKey => "api_key",
+        },
+    );
+    output::print_kv("Backend", backend.display_name());
+    output::print_kv(
+        "Activation",
+        if args.set_active { "active" } else { "stored" },
+    );
+    output::print_blank_line();
+    output::print_effects_header();
+    output::print_effect("Profile credentials stored in aisw.");
+    if args.set_active {
+        output::print_effect("Live tool configuration updated.");
+        output::print_effect("Active profile updated.");
+    }
+    output::print_blank_line();
+    output::print_next_step(output::next_step_after_add(
+        tool,
+        &args.profile_name,
+        args.set_active,
+    ));
+    Ok(())
+}
+
+fn json_string_field(bytes: &[u8], field: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    value.get(field)?.as_str().map(ToOwned::to_owned)
+}
+
+fn gemini_api_key_from_env(bytes: &[u8]) -> Option<String> {
+    std::str::from_utf8(bytes)
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("GEMINI_API_KEY=").map(ToOwned::to_owned))
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
@@ -297,6 +718,21 @@ mod tests {
             label: None,
             set_active: false,
             from_env: false,
+            from_live: false,
+            yes: false,
+        }
+    }
+
+    fn from_live_args(tool: Tool, name: &str) -> AddArgs {
+        AddArgs {
+            tool,
+            profile_name: name.to_owned(),
+            api_key: None,
+            label: None,
+            set_active: false,
+            from_env: false,
+            from_live: true,
+            yes: true,
         }
     }
 
@@ -423,6 +859,8 @@ mod tests {
             label: None,
             set_active: false,
             from_env: true,
+            from_live: false,
+            yes: false,
         }
     }
 
@@ -559,6 +997,8 @@ mod tests {
                 label: None,
                 set_active: false,
                 from_env: false,
+                from_live: false,
+                yes: false,
             };
             run_in(args, &aisw_home, path_of(&bin_dir)).unwrap();
 
@@ -583,5 +1023,278 @@ mod tests {
                 "old@example.com"
             );
         });
+    }
+
+    // ---- --from-live tests -------------------------------------------------
+
+    fn write_claude_credentials(user_home: &Path, token: &str) {
+        let claude_dir = user_home.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        let creds = claude_dir.join(".credentials.json");
+        let content =
+            format!(r#"{{"oauthToken":"{token}","account":{{"email":"test@example.com"}}}}"#);
+        fs::write(&creds, content).unwrap();
+        fs::set_permissions(&creds, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    fn write_codex_credentials(user_home: &Path, token: &str) {
+        let codex_dir = user_home.join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let auth = codex_dir.join("auth.json");
+        let content = format!(
+            r#"{{"primaryEmail":"test@example.com","oauthToken":"{token}","refreshToken":"refresh"}}"#
+        );
+        fs::write(&auth, content).unwrap();
+        fs::set_permissions(&auth, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    fn write_gemini_oauth(user_home: &Path) {
+        let gemini_dir = user_home.join(".gemini");
+        fs::create_dir_all(&gemini_dir).unwrap();
+        let creds = gemini_dir.join("oauth_creds.json");
+        fs::write(&creds, r#"{"token":"gemini-tok","expiry":"2099-01-01"}"#).unwrap();
+        fs::set_permissions(&creds, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    #[test]
+    fn from_live_claude_creates_profile() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        write_claude_credentials(&user_home, "tok-abc");
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        run_in(
+            from_live_args(Tool::Claude, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let ps = ProfileStore::new(&aisw_home);
+        assert!(ps.exists(Tool::Claude, "work"));
+        let stored = ps
+            .read_file(Tool::Claude, "work", ".credentials.json")
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&stored).unwrap();
+        assert_eq!(json["oauthToken"], "tok-abc");
+    }
+
+    #[test]
+    fn from_live_claude_stored_not_active_by_default() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        write_claude_credentials(&user_home, "tok-xyz");
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        run_in(
+            from_live_args(Tool::Claude, "personal"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let config = ConfigStore::new(&aisw_home).load().unwrap();
+        assert!(config.profiles_for(Tool::Claude).contains_key("personal"));
+        assert_eq!(config.active_for(Tool::Claude), None);
+    }
+
+    #[test]
+    fn from_live_claude_overwrites_with_yes() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        write_claude_credentials(&user_home, "tok-v1");
+        run_in(
+            from_live_args(Tool::Claude, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        write_claude_credentials(&user_home, "tok-v2");
+        run_in(
+            from_live_args(Tool::Claude, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let ps = ProfileStore::new(&aisw_home);
+        let stored = ps
+            .read_file(Tool::Claude, "work", ".credentials.json")
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&stored).unwrap();
+        assert_eq!(json["oauthToken"], "tok-v2");
+    }
+
+    #[test]
+    fn from_live_claude_fails_without_credentials() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        let err = run_in(
+            from_live_args(Tool::Claude, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("no live credentials"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn from_live_codex_creates_profile() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        write_codex_credentials(&user_home, "codex-tok");
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+
+        run_in(
+            from_live_args(Tool::Codex, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let ps = ProfileStore::new(&aisw_home);
+        assert!(ps.exists(Tool::Codex, "work"));
+        let stored = ps.read_file(Tool::Codex, "work", "auth.json").unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&stored).unwrap();
+        assert_eq!(json["oauthToken"], "codex-tok");
+    }
+
+    #[test]
+    fn from_live_codex_stored_not_active_by_default() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        write_codex_credentials(&user_home, "codex-reg");
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+
+        run_in(
+            from_live_args(Tool::Codex, "personal"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let config = ConfigStore::new(&aisw_home).load().unwrap();
+        assert!(config.profiles_for(Tool::Codex).contains_key("personal"));
+        assert_eq!(config.active_for(Tool::Codex), None);
+    }
+
+    #[test]
+    fn from_live_codex_fails_without_credentials() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+
+        let err = run_in(
+            from_live_args(Tool::Codex, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("no live credentials"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn from_live_gemini_creates_profile() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        write_gemini_oauth(&user_home);
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+
+        run_in(
+            from_live_args(Tool::Gemini, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let ps = ProfileStore::new(&aisw_home);
+        assert!(ps.exists(Tool::Gemini, "work"));
+        assert!(ps
+            .profile_dir(Tool::Gemini, "work")
+            .join("oauth_creds.json")
+            .exists());
+    }
+
+    #[test]
+    fn from_live_gemini_stored_not_active_by_default() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        write_gemini_oauth(&user_home);
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+
+        run_in(
+            from_live_args(Tool::Gemini, "personal"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let config = ConfigStore::new(&aisw_home).load().unwrap();
+        let meta = &config.profiles_for(Tool::Gemini)["personal"];
+        assert_eq!(meta.auth_method, crate::config::AuthMethod::OAuth);
+        assert_eq!(config.active_for(Tool::Gemini), None);
+    }
+
+    #[test]
+    fn from_live_gemini_fails_without_credentials() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+
+        let err = run_in(
+            from_live_args(Tool::Gemini, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("no live credentials"),
+            "unexpected: {err}"
+        );
     }
 }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -240,6 +240,21 @@ fn confirm_overwrite(tool: Tool, name: &str, yes: bool) -> Result<()> {
     Ok(())
 }
 
+fn prepare_from_live_target(
+    profile_store: &ProfileStore,
+    tool: Tool,
+    name: &str,
+    yes: bool,
+) -> Result<bool> {
+    let overwriting = profile_store.exists(tool, name);
+    if overwriting {
+        confirm_overwrite(tool, name, yes)?;
+    } else {
+        profile_store.create(tool, name)?;
+    }
+    Ok(overwriting)
+}
+
 fn from_live(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> {
     match args.tool {
         Tool::Claude => from_live_claude(args, home, user_home),
@@ -262,14 +277,8 @@ fn from_live_claude(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
         })?;
 
     let stored_backend = auth::claude::preferred_import_backend(&snapshot.source);
-
-    if profile_store.exists(Tool::Claude, &args.profile_name) {
-        confirm_overwrite(Tool::Claude, &args.profile_name, args.yes)?;
-        config_store.remove_profile(Tool::Claude, &args.profile_name)?;
-        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
-    }
-
-    profile_store.create(Tool::Claude, &args.profile_name)?;
+    let overwriting =
+        prepare_from_live_target(&profile_store, Tool::Claude, &args.profile_name, args.yes)?;
 
     let write_result = match stored_backend {
         CredentialBackend::File => profile_store.write_file(
@@ -286,7 +295,13 @@ fn from_live_claude(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
     };
 
     if let Err(e) = write_result {
-        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        if !overwriting {
+            let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        }
+        if !overwriting && stored_backend == CredentialBackend::SystemKeyring {
+            let _ =
+                crate::auth::secure_store::delete_profile_secret(Tool::Claude, &args.profile_name);
+        }
         return Err(e);
     }
 
@@ -295,7 +310,9 @@ fn from_live_claude(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
         &args.profile_name,
         user_home,
     ) {
-        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        if !overwriting {
+            let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        }
         return Err(e);
     }
 
@@ -306,26 +323,45 @@ fn from_live_claude(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
         &args.profile_name,
         stored_backend,
     ) {
-        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
-        if stored_backend == CredentialBackend::SystemKeyring {
+        if !overwriting {
+            let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        }
+        if !overwriting && stored_backend == CredentialBackend::SystemKeyring {
             let _ =
                 crate::auth::secure_store::delete_profile_secret(Tool::Claude, &args.profile_name);
         }
         return Err(e);
     }
 
-    if let Err(e) = config_store.add_profile(
-        Tool::Claude,
-        &args.profile_name,
-        ProfileMeta {
-            added_at: Utc::now(),
-            auth_method: AuthMethod::OAuth,
-            credential_backend: stored_backend,
-            label: args.label.clone(),
-        },
-    ) {
-        let _ = profile_store.delete(Tool::Claude, &args.profile_name);
-        if stored_backend == CredentialBackend::SystemKeyring {
+    let add_result = if overwriting {
+        config_store.upsert_profile(
+            Tool::Claude,
+            &args.profile_name,
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method: AuthMethod::OAuth,
+                credential_backend: stored_backend,
+                label: args.label.clone(),
+            },
+        )
+    } else {
+        config_store.add_profile(
+            Tool::Claude,
+            &args.profile_name,
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method: AuthMethod::OAuth,
+                credential_backend: stored_backend,
+                label: args.label.clone(),
+            },
+        )
+    };
+
+    if let Err(e) = add_result {
+        if !overwriting {
+            let _ = profile_store.delete(Tool::Claude, &args.profile_name);
+        }
+        if !overwriting && stored_backend == CredentialBackend::SystemKeyring {
             let _ =
                 crate::auth::secure_store::delete_profile_secret(Tool::Claude, &args.profile_name);
         }
@@ -395,16 +431,13 @@ fn from_live_codex(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> {
         }
     }
 
-    if profile_store.exists(Tool::Codex, &args.profile_name) {
-        confirm_overwrite(Tool::Codex, &args.profile_name, args.yes)?;
-        config_store.remove_profile(Tool::Codex, &args.profile_name)?;
-        let _ = profile_store.delete(Tool::Codex, &args.profile_name);
-    }
-
-    profile_store.create(Tool::Codex, &args.profile_name)?;
+    let overwriting =
+        prepare_from_live_target(&profile_store, Tool::Codex, &args.profile_name, args.yes)?;
 
     if let Err(e) = auth::codex::write_file_store_config(&profile_store, &args.profile_name) {
-        let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+        if !overwriting {
+            let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+        }
         return Err(e);
     }
 
@@ -414,7 +447,9 @@ fn from_live_codex(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> {
         auth::codex::AUTH_FILE,
         &snapshot.bytes,
     ) {
-        let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+        if !overwriting {
+            let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+        }
         return Err(e);
     }
 
@@ -426,22 +461,41 @@ fn from_live_codex(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> {
             &args.profile_name,
             CredentialBackend::File,
         ) {
-            let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+            if !overwriting {
+                let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+            }
             return Err(e);
         }
     }
 
-    if let Err(e) = config_store.add_profile(
-        Tool::Codex,
-        &args.profile_name,
-        ProfileMeta {
-            added_at: Utc::now(),
-            auth_method,
-            credential_backend: CredentialBackend::File,
-            label: args.label.clone(),
-        },
-    ) {
-        let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+    let add_result = if overwriting {
+        config_store.upsert_profile(
+            Tool::Codex,
+            &args.profile_name,
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method,
+                credential_backend: CredentialBackend::File,
+                label: args.label.clone(),
+            },
+        )
+    } else {
+        config_store.add_profile(
+            Tool::Codex,
+            &args.profile_name,
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method,
+                credential_backend: CredentialBackend::File,
+                label: args.label.clone(),
+            },
+        )
+    };
+
+    if let Err(e) = add_result {
+        if !overwriting {
+            let _ = profile_store.delete(Tool::Codex, &args.profile_name);
+        }
         return Err(e);
     }
 
@@ -501,13 +555,8 @@ fn from_live_gemini(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
         }
     }
 
-    if profile_store.exists(Tool::Gemini, &args.profile_name) {
-        confirm_overwrite(Tool::Gemini, &args.profile_name, args.yes)?;
-        config_store.remove_profile(Tool::Gemini, &args.profile_name)?;
-        let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
-    }
-
-    profile_store.create(Tool::Gemini, &args.profile_name)?;
+    let overwriting =
+        prepare_from_live_target(&profile_store, Tool::Gemini, &args.profile_name, args.yes)?;
 
     let copy_result = if auth_method == AuthMethod::OAuth {
         auth::gemini::copy_live_oauth_files_into_profile(
@@ -520,7 +569,9 @@ fn from_live_gemini(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
     };
 
     if let Err(e) = copy_result {
-        let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+        if !overwriting {
+            let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+        }
         return Err(e);
     }
 
@@ -532,22 +583,41 @@ fn from_live_gemini(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
             &args.profile_name,
             CredentialBackend::File,
         ) {
-            let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+            if !overwriting {
+                let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+            }
             return Err(e);
         }
     }
 
-    if let Err(e) = config_store.add_profile(
-        Tool::Gemini,
-        &args.profile_name,
-        ProfileMeta {
-            added_at: Utc::now(),
-            auth_method,
-            credential_backend: CredentialBackend::File,
-            label: args.label.clone(),
-        },
-    ) {
-        let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+    let add_result = if overwriting {
+        config_store.upsert_profile(
+            Tool::Gemini,
+            &args.profile_name,
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method,
+                credential_backend: CredentialBackend::File,
+                label: args.label.clone(),
+            },
+        )
+    } else {
+        config_store.add_profile(
+            Tool::Gemini,
+            &args.profile_name,
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method,
+                credential_backend: CredentialBackend::File,
+                label: args.label.clone(),
+            },
+        )
+    };
+
+    if let Err(e) = add_result {
+        if !overwriting {
+            let _ = profile_store.delete(Tool::Gemini, &args.profile_name);
+        }
         return Err(e);
     }
 
@@ -1223,6 +1293,52 @@ mod tests {
             err.to_string().contains("no live credentials"),
             "unexpected: {err}"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn from_live_codex_overwrite_keeps_profile_when_parent_not_writable() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        write_codex_credentials(&user_home, "codex-v1");
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+
+        run_in(
+            from_live_args(Tool::Codex, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let codex_profiles = aisw_home.join("profiles").join(Tool::Codex.dir_name());
+        let original_mode = fs::metadata(&codex_profiles).unwrap().permissions().mode() & 0o777;
+        fs::set_permissions(&codex_profiles, fs::Permissions::from_mode(0o500)).unwrap();
+
+        write_codex_credentials(&user_home, "codex-v2");
+        let result = run_in(
+            from_live_args(Tool::Codex, "work"),
+            &aisw_home,
+            OsString::new(),
+        );
+
+        fs::set_permissions(
+            &codex_profiles,
+            fs::Permissions::from_mode(original_mode.max(0o700)),
+        )
+        .unwrap();
+
+        result.unwrap();
+
+        let ps = ProfileStore::new(&aisw_home);
+        let stored = ps.read_file(Tool::Codex, "work", "auth.json").unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&stored).unwrap();
+        assert_eq!(json["oauthToken"], "codex-v2");
+
+        let config = ConfigStore::new(&aisw_home).load().unwrap();
+        assert!(config.profiles_for(Tool::Codex).contains_key("work"));
     }
 
     #[test]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -455,22 +455,18 @@ fn from_live_gemini(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
     let profile_store = ProfileStore::new(home);
     let config_store = ConfigStore::new(home);
 
-    let gemini_dir = auth::gemini::live_dir(user_home);
-    let env_file = gemini_dir.join(".env");
-    let oauth_files = auth::gemini::live_oauth_files_for_import(user_home)?;
-
-    let auth_method = if env_file.exists() {
-        AuthMethod::ApiKey
-    } else if !oauth_files.is_empty() {
-        AuthMethod::OAuth
-    } else {
-        bail!(
+    let selection = auth::gemini::detect_live_import_selection(user_home)?.with_context(|| {
+        format!(
             "no live credentials found in {} — run 'gemini login' first, \
              then retry 'aisw add gemini {} --from-live'.",
-            gemini_dir.display(),
+            auth::gemini::live_dir(user_home).display(),
             args.profile_name,
         )
-    };
+    })?;
+    let gemini_dir = auth::gemini::live_dir(user_home);
+    let env_file = selection.env_file;
+    let oauth_files = selection.oauth_files;
+    let auth_method = selection.method;
 
     if auth_method == AuthMethod::ApiKey {
         let source_bytes = std::fs::read(&env_file)
@@ -559,12 +555,19 @@ fn from_live_gemini(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
         AuthMethod::OAuth => {
             auth::gemini::apply_token_cache(&profile_store, &args.profile_name, &gemini_dir)?
         }
-        AuthMethod::ApiKey => {
-            auth::gemini::apply_env_file(&profile_store, &args.profile_name, &gemini_dir)?
-        }
+        AuthMethod::ApiKey => auth::gemini::apply_env_file(
+            &profile_store,
+            &args.profile_name,
+            &gemini_dir.join(".env"),
+        )?,
     }
     config_store.activate_profile(Tool::Gemini, &args.profile_name, None)?;
 
+    if selection.has_both_sources {
+        output::print_info(
+            "Both Gemini API key (.env) and OAuth cache were found. Imported .env by precedence.",
+        );
+    }
     finalize_from_live(&args, Tool::Gemini, CredentialBackend::File, auth_method)
 }
 
@@ -1041,6 +1044,14 @@ mod tests {
         fs::set_permissions(&creds, fs::Permissions::from_mode(0o600)).unwrap();
     }
 
+    fn write_gemini_env(user_home: &Path, key: &str) {
+        let gemini_dir = user_home.join(".gemini");
+        fs::create_dir_all(&gemini_dir).unwrap();
+        let env = gemini_dir.join(".env");
+        fs::write(&env, format!("GEMINI_API_KEY={key}\n")).unwrap();
+        fs::set_permissions(&env, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
     #[test]
     fn from_live_claude_creates_profile() {
         let tmp = tempdir().unwrap();
@@ -1260,6 +1271,40 @@ mod tests {
         let meta = &config.profiles_for(Tool::Gemini)["personal"];
         assert_eq!(meta.auth_method, crate::config::AuthMethod::OAuth);
         assert_eq!(config.active_for(Tool::Gemini), Some("personal"));
+    }
+
+    #[test]
+    fn from_live_gemini_prefers_env_when_both_sources_exist() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        write_gemini_oauth(&user_home);
+        write_gemini_env(&user_home, "AIza-priority-key");
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+
+        run_in(
+            from_live_args(Tool::Gemini, "priority"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let ps = ProfileStore::new(&aisw_home);
+        assert!(ps
+            .profile_dir(Tool::Gemini, "priority")
+            .join(".env")
+            .exists());
+        assert!(!ps
+            .profile_dir(Tool::Gemini, "priority")
+            .join("oauth_creds.json")
+            .exists());
+        let config = ConfigStore::new(&aisw_home).load().unwrap();
+        assert_eq!(
+            config.profiles_for(Tool::Gemini)["priority"].auth_method,
+            crate::config::AuthMethod::ApiKey
+        );
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -795,22 +795,16 @@ fn import_gemini(
     confirmed: bool,
 ) -> Result<()> {
     print_import_header(Tool::Gemini, detected);
-    let gemini_dir = auth::gemini::live_dir(user_home);
-    let env_file = gemini_dir.join(".env");
-    let oauth_files = auth::gemini::live_oauth_files_for_import(user_home)?;
-
-    let (src_desc, method) = if env_file.exists() {
-        (format!("found {}", env_file.display()), AuthMethod::ApiKey)
-    } else if let Some(primary_file) = auth::gemini::preferred_live_oauth_file(&oauth_files) {
-        (
-            auth::gemini::live_import_source_description(&primary_file.path, oauth_files.len()),
-            AuthMethod::OAuth,
-        )
-    } else {
+    let Some(selection) = auth::gemini::detect_live_import_selection(user_home)? else {
         output::print_kv("Credentials", "not found");
         output::print_blank_line();
         return Ok(());
     };
+    let src_desc = selection.source_description;
+    let method = selection.method;
+    let env_file = selection.env_file;
+    let oauth_files = selection.oauth_files;
+    let has_both_sources = selection.has_both_sources;
 
     let profile_store = ProfileStore::new(aisw_home);
     let config_store = ConfigStore::new(aisw_home);
@@ -859,6 +853,11 @@ fn import_gemini(
     }
 
     output::print_kv("Credentials", &src_desc);
+    if has_both_sources {
+        output::print_info(
+            "Both Gemini API key (.env) and OAuth cache were found. Import precedence is .env first.",
+        );
+    }
     output::print_kv(
         "Auth",
         if method == AuthMethod::ApiKey {
@@ -1080,6 +1079,39 @@ mod tests {
 
         let ps = ProfileStore::new(&aisw_home);
         assert!(ps.exists(Tool::Gemini, "default"));
+        let config = ConfigStore::new(&aisw_home).load().unwrap();
+        assert_eq!(
+            config.profiles_for(Tool::Gemini)["default"].auth_method,
+            AuthMethod::ApiKey
+        );
+    }
+
+    #[test]
+    fn imports_gemini_prefers_env_when_both_sources_exist() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("home");
+        let gemini_dir = user_home.join(".gemini");
+        fs::create_dir_all(&gemini_dir).unwrap();
+        fs::write(gemini_dir.join(".env"), b"GEMINI_API_KEY=abc123\n").unwrap();
+        fs::write(
+            gemini_dir.join("oauth_creds.json"),
+            b"{\"token\":\"oauth\"}",
+        )
+        .unwrap();
+
+        run(&aisw_home, &user_home, None).unwrap();
+
+        let ps = ProfileStore::new(&aisw_home);
+        assert!(ps.exists(Tool::Gemini, "default"));
+        assert!(ps
+            .profile_dir(Tool::Gemini, "default")
+            .join(".env")
+            .exists());
+        assert!(!ps
+            .profile_dir(Tool::Gemini, "default")
+            .join("oauth_creds.json")
+            .exists());
         let config = ConfigStore::new(&aisw_home).load().unwrap();
         assert_eq!(
             config.profiles_for(Tool::Gemini)["default"].auth_method,


### PR DESCRIPTION
## Problem

`aisw add` runs a full interactive login flow. When it fails or is interrupted, the native `claude login` / `codex login` / `gemini login` is always available as a fallback — but there was no way to hand those credentials over to aisw afterward.

## Solution

`aisw add <tool> <profile_name> --from-live` captures whatever credentials the tool currently has in its live config and stores them as a new aisw-managed profile — no login flow launched. The profile is **always activated immediately**, since those credentials are already live by definition.

```
aisw add claude work --from-live
aisw add codex personal --from-live --label "Personal OpenAI account"
aisw add gemini work --from-live
```

This is the recovery/adoption path for cases where a native tool login already succeeded but aisw was not used. `--from-live` fits within the existing `add` model alongside `--api-key`, `--from-env`, and interactive OAuth.

## Scope

Supports all three tools, reading from each tool's live config location:

| Tool | Source |
|---|---|
| claude | ~/.claude/.credentials.json or system keyring (macOS) |
| codex | ~/.codex/auth.json |
| gemini | ~/.gemini/.env (API key) or OAuth files in ~/.gemini/ |

`--yes` skips the overwrite prompt when a same-name profile already exists. Deduplication identity checks match existing `add` behavior.

## Changes

- `src/cli.rs` — `--from-live` and `--yes` added to `AddArgs`
- `src/commands/add.rs` — `--from-live` branch + per-tool capture functions + 12 new tests
- `completions/` — bash, zsh, fish updated for new flags
- `docs/commands.md` — `--from-live` documented under `aisw add`

All 369 existing tests pass. New tests cover profile creation, auto-activation, overwrite with `--yes`, and the no-credentials error path for all three tools.

Closes #6