### PR TITLE
release: automate Homebrew tap updates on published releases

### DIFF
--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -1,0 +1,125 @@
+name: Update Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  update-homebrew-tap:
+    name: Update Formula In Tap
+    runs-on: ubuntu-latest
+    if: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN != '' }}
+    env:
+      REPO: ${{ github.repository }}
+      TAG: ${{ github.event.release.tag_name }}
+      TAP_REPO: burakdede/homebrew-tap
+      GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+    steps:
+      - name: Validate release tag
+        shell: bash
+        run: |
+          case "$TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "Skipping: unsupported tag format '$TAG'"
+              exit 1
+              ;;
+          esac
+          echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
+
+      - name: Download release checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="https://github.com/${REPO}/releases/download/${TAG}"
+
+          curl -fsSL "${BASE}/aisw-aarch64-apple-darwin.sha256" -o darwin_arm.sha256
+          curl -fsSL "${BASE}/aisw-x86_64-apple-darwin.sha256" -o darwin_amd.sha256
+          curl -fsSL "${BASE}/aisw-aarch64-unknown-linux-gnu.sha256" -o linux_arm.sha256
+          curl -fsSL "${BASE}/aisw-x86_64-unknown-linux-gnu.sha256" -o linux_amd.sha256
+
+          {
+            echo "SHA_DARWIN_ARM=$(tr -d '[:space:]' < darwin_arm.sha256)"
+            echo "SHA_DARWIN_AMD=$(tr -d '[:space:]' < darwin_amd.sha256)"
+            echo "SHA_LINUX_ARM=$(tr -d '[:space:]' < linux_arm.sha256)"
+            echo "SHA_LINUX_AMD=$(tr -d '[:space:]' < linux_amd.sha256)"
+          } >> "$GITHUB_ENV"
+
+      - name: Generate Formula
+        shell: bash
+        run: |
+          cat > aisw.rb <<EOF
+          class Aisw < Formula
+            desc "AI and coding agent account manager and account switcher"
+            homepage "https://github.com/${REPO}"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/${REPO}/releases/download/${TAG}/aisw-aarch64-apple-darwin"
+                sha256 "${SHA_DARWIN_ARM}"
+              else
+                url "https://github.com/${REPO}/releases/download/${TAG}/aisw-x86_64-apple-darwin"
+                sha256 "${SHA_DARWIN_AMD}"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm?
+                url "https://github.com/${REPO}/releases/download/${TAG}/aisw-aarch64-unknown-linux-gnu"
+                sha256 "${SHA_LINUX_ARM}"
+              else
+                url "https://github.com/${REPO}/releases/download/${TAG}/aisw-x86_64-unknown-linux-gnu"
+                sha256 "${SHA_LINUX_AMD}"
+              end
+            end
+
+            def install
+              bin.install Dir["aisw-*"].first => "aisw"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/aisw --version")
+            end
+          end
+          EOF
+
+      - name: Checkout tap repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.TAP_REPO }}
+          token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          path: tap
+
+      - name: Update tap formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp aisw.rb tap/Formula/aisw.rb
+          cd tap
+
+          if git diff --quiet -- Formula/aisw.rb; then
+            echo "No Homebrew formula changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/aisw.rb
+          git commit -m "aisw ${VERSION}"
+          git push origin HEAD
+
+  homebrew-token-missing:
+    name: Homebrew Tap Token Missing
+    runs-on: ubuntu-latest
+    if: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN == '' }}
+    steps:
+      - name: Explain missing secret
+        run: |
+          echo "HOMEBREW_TAP_GITHUB_TOKEN is not configured."
+          echo "Skipping Homebrew formula update."

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Full install and setup details: [Quickstart](https://burakdede.github.io/aisw/qu
 curl -fsSL https://raw.githubusercontent.com/burakdede/aisw/main/install.sh | sh
 ```
 
+**Homebrew (macOS, Linux):**
+
+```sh
+brew tap burakdede/tap
+brew install aisw
+```
+
 **Cargo:**
 
 ```sh

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -40,6 +40,9 @@ Pre-release suffixes are not supported by the release workflow; use a separate t
 6. Once all five build jobs pass, open the draft release on the
    [Releases page](https://github.com/burakdede/aisw/releases), review the
    generated changelog, and click **Publish release**.
+7. After publishing, the Homebrew workflow
+   (`.github/workflows/homebrew-release.yml`) runs automatically and updates
+   `burakdede/homebrew-tap` `Formula/aisw.rb` for that version.
 
 ## What the release workflow does
 
@@ -55,6 +58,26 @@ Pre-release suffixes are not supported by the release workflow; use a separate t
 | Release | Downloads all artifacts; creates a **draft** GitHub Release with release notes and all assets |
 
 The release is always created as a draft. A human must publish it.
+
+## Homebrew publishing
+
+Homebrew is published by a separate workflow:
+
+- Trigger: GitHub Release `published` event
+- Workflow: `.github/workflows/homebrew-release.yml`
+- Target tap repository: `burakdede/homebrew-tap`
+- Updated file: `Formula/aisw.rb`
+
+Required repository secret in `burakdede/aisw`:
+
+- `HOMEBREW_TAP_GITHUB_TOKEN` (PAT with write access to `burakdede/homebrew-tap`)
+
+After that job succeeds, users can install with:
+
+```sh
+brew tap burakdede/tap
+brew install aisw
+```
 
 ## Build targets
 


### PR DESCRIPTION
## Summary
- add a release-published workflow to update the homebrew tap formula in burakdede/homebrew-tap
- document Homebrew release flow and required secret
- add Homebrew install instructions to README

## Validation
- local pre-commit/pre-push hooks passed (fmt, clippy, tests, release build)
