### PR TITLE
Fix #19: Claude OAuth dedup for multi-org accounts

### DIFF
--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -500,6 +500,73 @@ mod tests {
 
     #[test]
     #[cfg(all(unix, not(target_os = "macos")))]
+    fn oauth_duplicate_identity_allows_same_email_with_different_org() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("home");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&bin_dir).unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let bin = bin_dir.join("claude");
+        fs::write(
+            &bin,
+            "#!/bin/sh\n\
+             mkdir -p \"$HOME/.claude\"\n\
+             printf '%s' '{\"oauthToken\":\"tok\",\"account\":{\"email\":\"burak@example.com\"}}' > \"$HOME/.claude/.credentials.json\"\n\
+             printf '%s' '{\"oauthAccount\":{\"emailAddress\":\"burak@example.com\",\"organizationUuid\":\"org-b\"}}' > \"$HOME/.claude.json\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (ps, cs) = stores(dir.path());
+        ps.create(Tool::Claude, "work").unwrap();
+        ps.write_file(
+            Tool::Claude,
+            "work",
+            CREDENTIALS_FILE,
+            br#"{"oauthToken":"tok","account":{"email":"burak@example.com"}}"#,
+        )
+        .unwrap();
+        ps.write_file(
+            Tool::Claude,
+            "work",
+            OAUTH_ACCOUNT_FILE,
+            br#"{"emailAddress":"burak@example.com","organizationUuid":"org-a"}"#,
+        )
+        .unwrap();
+        cs.add_profile(
+            Tool::Claude,
+            "work",
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method: AuthMethod::OAuth,
+                credential_backend: CredentialBackend::File,
+                label: None,
+            },
+        )
+        .unwrap();
+
+        oauth::add_oauth_with(
+            &ps,
+            &cs,
+            "alias",
+            None,
+            &bin,
+            std::time::Duration::from_secs(2),
+            TEST_POLL,
+        )
+        .unwrap();
+
+        assert!(ps.exists(Tool::Claude, "alias"));
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
     fn oauth_flow_errors_when_claude_exits_without_credentials() {
         let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");

--- a/src/auth/identity.rs
+++ b/src/auth/identity.rs
@@ -11,6 +11,16 @@ const CLAUDE_OAUTH_ACCOUNT_FILE: &str = "oauth-account.json";
 const CODEX_AUTH_FILE: &str = "auth.json";
 const GEMINI_OAUTH_FILES: &[&str] = &["settings.json", "oauth_creds.json"];
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum OAuthIdentity {
+    Claude {
+        email: Option<String>,
+        organization_uuid: Option<String>,
+        fallback: Option<String>,
+    },
+    Generic(String),
+}
+
 pub fn ensure_unique_oauth_identity(
     profile_store: &ProfileStore,
     config_store: &ConfigStore,
@@ -37,11 +47,11 @@ pub fn ensure_unique_oauth_identity(
             continue;
         };
 
-        if existing_identity == identity {
+        if existing_identity.matches(&identity) {
             bail!(
                 "A {} OAuth profile for {} already exists as '{}'.\n  Use that profile or remove it before creating another alias for the same account.",
                 tool,
-                identity,
+                identity.display(),
                 existing_name
             );
         }
@@ -56,7 +66,31 @@ pub fn existing_oauth_profile_for_json_bytes(
     tool: Tool,
     bytes: &[u8],
 ) -> Result<Option<String>> {
-    let Some(identity) = resolve_identity_from_json_bytes(bytes)? else {
+    existing_oauth_profile_for_identity(
+        profile_store,
+        config_store,
+        tool,
+        resolve_identity_from_json_bytes_for_tool(tool, bytes)?,
+    )
+}
+
+pub fn existing_claude_oauth_profile_for_live_state(
+    profile_store: &ProfileStore,
+    config_store: &ConfigStore,
+    credential_bytes: &[u8],
+    account_bytes: Option<&[u8]>,
+) -> Result<Option<String>> {
+    let identity = resolve_claude_identity(Some(credential_bytes), account_bytes)?;
+    existing_oauth_profile_for_identity(profile_store, config_store, Tool::Claude, identity)
+}
+
+fn existing_oauth_profile_for_identity(
+    profile_store: &ProfileStore,
+    config_store: &ConfigStore,
+    tool: Tool,
+    identity: Option<OAuthIdentity>,
+) -> Result<Option<String>> {
+    let Some(identity) = identity else {
         return Ok(None);
     };
 
@@ -69,7 +103,7 @@ pub fn existing_oauth_profile_for_json_bytes(
             continue;
         };
 
-        if existing_identity == identity {
+        if existing_identity.matches(&identity) {
             return Ok(Some(existing_name.to_owned()));
         }
     }
@@ -143,36 +177,70 @@ fn resolve_oauth_identity(
     tool: Tool,
     profile_name: &str,
     backend: CredentialBackend,
-) -> Result<Option<String>> {
+) -> Result<Option<OAuthIdentity>> {
+    match tool {
+        Tool::Claude => {
+            let credential_bytes = if backend == CredentialBackend::SystemKeyring {
+                secure_store::read_profile_secret(tool, profile_name)?
+            } else {
+                read_optional_profile_file(
+                    profile_store,
+                    tool,
+                    profile_name,
+                    CLAUDE_CREDENTIALS_FILE,
+                )?
+            };
+            let account_bytes = read_optional_profile_file(
+                profile_store,
+                tool,
+                profile_name,
+                CLAUDE_OAUTH_ACCOUNT_FILE,
+            )?;
+            resolve_claude_identity(credential_bytes.as_deref(), account_bytes.as_deref())
+        }
+        Tool::Codex => resolve_identity_from_optional_profile_files(
+            profile_store,
+            tool,
+            profile_name,
+            backend,
+            &[CODEX_AUTH_FILE],
+        ),
+        Tool::Gemini => resolve_identity_from_optional_profile_files(
+            profile_store,
+            tool,
+            profile_name,
+            backend,
+            GEMINI_OAUTH_FILES,
+        ),
+    }
+}
+
+fn resolve_identity_from_optional_profile_files(
+    profile_store: &ProfileStore,
+    tool: Tool,
+    profile_name: &str,
+    backend: CredentialBackend,
+    filenames: &[&str],
+) -> Result<Option<OAuthIdentity>> {
     if backend == CredentialBackend::SystemKeyring {
         let bytes = match tool {
             Tool::Claude | Tool::Codex => secure_store::read_profile_secret(tool, profile_name)?,
             Tool::Gemini => None,
         };
         return match bytes {
-            Some(bytes) => resolve_identity_from_json_bytes(&bytes),
+            Some(bytes) => resolve_identity_from_json_bytes_for_tool(tool, &bytes),
             None => Ok(None),
         };
     }
 
-    let mut candidates = Vec::new();
-    match tool {
-        Tool::Claude => {
-            candidates.push(CLAUDE_CREDENTIALS_FILE);
-            candidates.push(CLAUDE_OAUTH_ACCOUNT_FILE);
-        }
-        Tool::Codex => candidates.push(CODEX_AUTH_FILE),
-        Tool::Gemini => candidates.extend_from_slice(GEMINI_OAUTH_FILES),
-    }
-
-    for filename in candidates {
+    for filename in filenames {
         let path = profile_store.profile_dir(tool, profile_name).join(filename);
         if !path.exists() {
             continue;
         }
 
         let bytes = profile_store.read_file(tool, profile_name, filename)?;
-        if let Some(identity) = resolve_identity_from_json_bytes(&bytes)? {
+        if let Some(identity) = resolve_identity_from_json_bytes_for_tool(tool, &bytes)? {
             return Ok(Some(identity));
         }
     }
@@ -180,19 +248,105 @@ fn resolve_oauth_identity(
     Ok(None)
 }
 
+fn read_optional_profile_file(
+    profile_store: &ProfileStore,
+    tool: Tool,
+    profile_name: &str,
+    filename: &str,
+) -> Result<Option<Vec<u8>>> {
+    let path = profile_store.profile_dir(tool, profile_name).join(filename);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    profile_store
+        .read_file(tool, profile_name, filename)
+        .map(Some)
+}
+
+#[cfg(test)]
 pub(crate) fn resolve_identity_from_json_bytes(bytes: &[u8]) -> Result<Option<String>> {
+    Ok(
+        resolve_identity_from_json_bytes_for_tool(Tool::Codex, bytes)?.map(
+            |identity| match identity {
+                OAuthIdentity::Claude { .. } => unreachable!(),
+                OAuthIdentity::Generic(identity) => identity,
+            },
+        ),
+    )
+}
+
+fn resolve_identity_from_json_bytes_for_tool(
+    tool: Tool,
+    bytes: &[u8],
+) -> Result<Option<OAuthIdentity>> {
     let value: Value = match serde_json::from_slice(bytes) {
         Ok(value) => value,
         Err(_) => return Ok(None),
     };
 
-    Ok(resolve_identity_from_value(&value))
+    Ok(resolve_identity_from_value(tool, &value))
 }
 
-fn resolve_identity_from_value(value: &Value) -> Option<String> {
-    find_email(value)
-        .or_else(|| find_subject(value))
-        .map(normalize_identity)
+fn resolve_claude_identity(
+    credential_bytes: Option<&[u8]>,
+    account_bytes: Option<&[u8]>,
+) -> Result<Option<OAuthIdentity>> {
+    let credential_value = credential_bytes
+        .map(serde_json::from_slice::<Value>)
+        .transpose()
+        .ok()
+        .flatten();
+    let account_value = account_bytes
+        .map(serde_json::from_slice::<Value>)
+        .transpose()
+        .ok()
+        .flatten();
+
+    let email = account_value
+        .as_ref()
+        .and_then(find_email)
+        .or_else(|| credential_value.as_ref().and_then(find_email));
+    let organization_uuid = account_value
+        .as_ref()
+        .and_then(find_claude_organization_uuid);
+    let fallback = credential_value
+        .as_ref()
+        .and_then(find_subject)
+        .or_else(|| account_value.as_ref().and_then(find_subject))
+        .map(normalize_identity);
+
+    if email.is_none() && organization_uuid.is_none() && fallback.is_none() {
+        return Ok(None);
+    }
+
+    Ok(Some(OAuthIdentity::Claude {
+        email: email.map(normalize_identity),
+        organization_uuid: organization_uuid.map(normalize_identity),
+        fallback,
+    }))
+}
+
+fn resolve_identity_from_value(tool: Tool, value: &Value) -> Option<OAuthIdentity> {
+    match tool {
+        Tool::Claude => {
+            let email = find_email(value).map(normalize_identity);
+            let organization_uuid = find_claude_organization_uuid(value).map(normalize_identity);
+            let fallback = find_subject(value).map(normalize_identity);
+            if email.is_none() && organization_uuid.is_none() && fallback.is_none() {
+                return None;
+            }
+            Some(OAuthIdentity::Claude {
+                email,
+                organization_uuid,
+                fallback,
+            })
+        }
+        Tool::Codex | Tool::Gemini => find_email(value)
+            .or_else(|| find_subject(value))
+            .map(normalize_identity)
+            .map(OAuthIdentity::Generic),
+    }
 }
 
 fn find_email(value: &Value) -> Option<String> {
@@ -236,6 +390,15 @@ fn find_subject(value: &Value) -> Option<String> {
         }
 
         None
+    })
+}
+
+fn find_claude_organization_uuid(value: &Value) -> Option<String> {
+    walk_json(value, &|key, raw| {
+        matches!(key, Some("organizationUuid"))
+            .then(|| raw.trim())
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
     })
 }
 
@@ -293,6 +456,52 @@ fn decode_jwt_payload(token: &str) -> Result<Option<Value>> {
     Ok(crate::util::jwt::decode_jwt_payload(token))
 }
 
+impl OAuthIdentity {
+    fn matches(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                OAuthIdentity::Claude {
+                    email: left_email,
+                    organization_uuid: left_org,
+                    fallback: left_fallback,
+                },
+                OAuthIdentity::Claude {
+                    email: right_email,
+                    organization_uuid: right_org,
+                    fallback: right_fallback,
+                },
+            ) => {
+                if let (Some(left_email), Some(right_email)) = (left_email, right_email) {
+                    if left_email != right_email {
+                        return false;
+                    }
+
+                    return match (left_org, right_org) {
+                        (Some(left_org), Some(right_org)) => left_org == right_org,
+                        _ => true,
+                    };
+                }
+
+                left_fallback.is_some() && left_fallback == right_fallback
+            }
+            (OAuthIdentity::Generic(left), OAuthIdentity::Generic(right)) => left == right,
+            _ => false,
+        }
+    }
+
+    fn display(&self) -> &str {
+        match self {
+            OAuthIdentity::Claude {
+                email, fallback, ..
+            } => email
+                .as_deref()
+                .or(fallback.as_deref())
+                .unwrap_or("unknown account"),
+            OAuthIdentity::Generic(identity) => identity,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,8 +511,8 @@ mod tests {
         let value: Value =
             serde_json::from_str(r#"{"account":{"email":"Burak@Example.com"}}"#).unwrap();
         assert_eq!(
-            resolve_identity_from_value(&value),
-            Some("burak@example.com".to_owned())
+            resolve_identity_from_value(Tool::Codex, &value),
+            Some(OAuthIdentity::Generic("burak@example.com".to_owned()))
         );
     }
 
@@ -313,8 +522,12 @@ mod tests {
             serde_json::from_str(r#"{"oauthAccount":{"emailAddress":"Burak@Example.com"}}"#)
                 .unwrap();
         assert_eq!(
-            resolve_identity_from_value(&value),
-            Some("burak@example.com".to_owned())
+            resolve_identity_from_value(Tool::Claude, &value),
+            Some(OAuthIdentity::Claude {
+                email: Some("burak@example.com".to_owned()),
+                organization_uuid: None,
+                fallback: None,
+            })
         );
     }
 
@@ -323,8 +536,8 @@ mod tests {
         let token = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJVU0VSLTEyMyJ9.sig";
         let value: Value = serde_json::from_str(&format!(r#"{{"id_token":"{}"}}"#, token)).unwrap();
         assert_eq!(
-            resolve_identity_from_value(&value),
-            Some("user-123".to_owned())
+            resolve_identity_from_value(Tool::Codex, &value),
+            Some(OAuthIdentity::Generic("user-123".to_owned()))
         );
     }
 
@@ -345,8 +558,8 @@ mod tests {
         let token = format!("eyJhbGciOiJub25lIn0.{payload}.sig");
         let value: Value = serde_json::from_str(&format!(r#"{{"id_token":"{}"}}"#, token)).unwrap();
         assert_eq!(
-            resolve_identity_from_value(&value),
-            Some("user-1234".to_owned())
+            resolve_identity_from_value(Tool::Codex, &value),
+            Some(OAuthIdentity::Generic("user-1234".to_owned()))
         );
     }
 
@@ -354,6 +567,69 @@ mod tests {
     fn invalid_base64url_payload_is_ignored() {
         let value: Value =
             serde_json::from_str(r#"{"id_token":"eyJhbGciOiJub25lIn0.bad$payload.sig"}"#).unwrap();
-        assert_eq!(resolve_identity_from_value(&value), None);
+        assert_eq!(resolve_identity_from_value(Tool::Codex, &value), None);
+    }
+
+    #[test]
+    fn resolves_claude_identity_with_org_uuid() {
+        let identity = resolve_claude_identity(
+            Some(br#"{"account":{"email":"Work@Example.com"}}"#),
+            Some(br#"{"emailAddress":"Work@Example.com","organizationUuid":"ORG-123"}"#),
+        )
+        .unwrap();
+
+        assert_eq!(
+            identity,
+            Some(OAuthIdentity::Claude {
+                email: Some("work@example.com".to_owned()),
+                organization_uuid: Some("org-123".to_owned()),
+                fallback: None,
+            })
+        );
+    }
+
+    #[test]
+    fn claude_identity_matches_same_email_and_same_org() {
+        let left = OAuthIdentity::Claude {
+            email: Some("work@example.com".to_owned()),
+            organization_uuid: Some("org-123".to_owned()),
+            fallback: None,
+        };
+        let right = OAuthIdentity::Claude {
+            email: Some("work@example.com".to_owned()),
+            organization_uuid: Some("org-123".to_owned()),
+            fallback: None,
+        };
+        assert!(left.matches(&right));
+    }
+
+    #[test]
+    fn claude_identity_allows_same_email_with_different_org() {
+        let left = OAuthIdentity::Claude {
+            email: Some("work@example.com".to_owned()),
+            organization_uuid: Some("org-123".to_owned()),
+            fallback: None,
+        };
+        let right = OAuthIdentity::Claude {
+            email: Some("work@example.com".to_owned()),
+            organization_uuid: Some("org-456".to_owned()),
+            fallback: None,
+        };
+        assert!(!left.matches(&right));
+    }
+
+    #[test]
+    fn claude_identity_preserves_email_only_matching_when_org_is_missing() {
+        let left = OAuthIdentity::Claude {
+            email: Some("work@example.com".to_owned()),
+            organization_uuid: Some("org-123".to_owned()),
+            fallback: None,
+        };
+        let right = OAuthIdentity::Claude {
+            email: Some("work@example.com".to_owned()),
+            organization_uuid: None,
+            fallback: None,
+        };
+        assert!(left.matches(&right));
     }
 }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1126,6 +1126,18 @@ mod tests {
         fs::set_permissions(&creds, fs::Permissions::from_mode(0o600)).unwrap();
     }
 
+    fn write_claude_oauth_account(user_home: &Path, email: &str, org: Option<&str>) {
+        let content = match org {
+            Some(org) => {
+                format!(
+                    r#"{{"oauthAccount":{{"emailAddress":"{email}","organizationUuid":"{org}"}}}}"#
+                )
+            }
+            None => format!(r#"{{"oauthAccount":{{"emailAddress":"{email}"}}}}"#),
+        };
+        fs::write(user_home.join(".claude.json"), content).unwrap();
+    }
+
     fn write_codex_credentials(user_home: &Path, token: &str) {
         let codex_dir = user_home.join(".codex");
         fs::create_dir_all(&codex_dir).unwrap();
@@ -1261,6 +1273,72 @@ mod tests {
             err.to_string().contains("no live credentials"),
             "unexpected: {err}"
         );
+    }
+
+    #[test]
+    fn from_live_claude_allows_same_email_with_different_org() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        write_claude_credentials(&user_home, "tok-org-a");
+        write_claude_oauth_account(&user_home, "test@example.com", Some("org-a"));
+        run_in(
+            from_live_args(Tool::Claude, "org-a"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        write_claude_credentials(&user_home, "tok-org-b");
+        write_claude_oauth_account(&user_home, "test@example.com", Some("org-b"));
+        run_in(
+            from_live_args(Tool::Claude, "org-b"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let ps = ProfileStore::new(&aisw_home);
+        assert!(ps.exists(Tool::Claude, "org-a"));
+        assert!(ps.exists(Tool::Claude, "org-b"));
+    }
+
+    #[test]
+    fn from_live_claude_rejects_same_email_when_org_is_missing() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(&aisw_home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        write_claude_credentials(&user_home, "tok-org-a");
+        write_claude_oauth_account(&user_home, "test@example.com", Some("org-a"));
+        run_in(
+            from_live_args(Tool::Claude, "org-a"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        write_claude_credentials(&user_home, "tok-no-org");
+        write_claude_oauth_account(&user_home, "test@example.com", None);
+        let err = run_in(
+            from_live_args(Tool::Claude, "no-org"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("already exists as 'org-a'"));
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -480,11 +480,13 @@ fn import_claude(
     } else {
         AuthMethod::OAuth
     };
+    let account_bytes = auth::claude::read_live_oauth_account_metadata_for_import(user_home)?;
     if imported_method == AuthMethod::OAuth {
         if let Some(existing_name) = existing_claude_profile_for_exact_credentials(
             &profile_store,
             &config_store,
             &source_bytes,
+            account_bytes.as_deref(),
         )? {
             output::print_kv("Credentials", &source_desc);
             print_already_managed_live_match(Tool::Claude, &config_store, "oauth", &existing_name)?;
@@ -508,29 +510,15 @@ fn import_claude(
             return Ok(());
         }
     }
-    if let Some(existing_name) = auth::identity::existing_oauth_profile_for_json_bytes(
+    if let Some(existing_name) = auth::identity::existing_claude_oauth_profile_for_live_state(
         &profile_store,
         &config_store,
-        Tool::Claude,
         &source_bytes,
+        account_bytes.as_deref(),
     )? {
         output::print_kv("Credentials", &source_desc);
         print_already_managed_live_match(Tool::Claude, &config_store, "oauth", &existing_name)?;
         return Ok(());
-    }
-    if let Some(account_bytes) =
-        auth::claude::read_live_oauth_account_metadata_for_import(user_home)?
-    {
-        if let Some(existing_name) = auth::identity::existing_oauth_profile_for_json_bytes(
-            &profile_store,
-            &config_store,
-            Tool::Claude,
-            &account_bytes,
-        )? {
-            output::print_kv("Credentials", &source_desc);
-            print_already_managed_live_match(Tool::Claude, &config_store, "oauth", &existing_name)?;
-            return Ok(());
-        }
     }
 
     if confirmed && profile_store.exists(Tool::Claude, "default") {
@@ -615,6 +603,7 @@ fn existing_claude_profile_for_exact_credentials(
     profile_store: &ProfileStore,
     config_store: &ConfigStore,
     live_bytes: &[u8],
+    live_account_bytes: Option<&[u8]>,
 ) -> Result<Option<String>> {
     let config = config_store.load()?;
     for (name, meta) in config.profiles_for(Tool::Claude) {
@@ -632,7 +621,15 @@ fn existing_claude_profile_for_exact_credentials(
         };
 
         if stored.as_deref() == Some(live_bytes) {
-            return Ok(Some(name.clone()));
+            let account_match = auth::identity::existing_claude_oauth_profile_for_live_state(
+                profile_store,
+                config_store,
+                live_bytes,
+                live_account_bytes,
+            )?;
+            if account_match.as_deref() == Some(name.as_str()) || live_account_bytes.is_none() {
+                return Ok(Some(name.clone()));
+            }
         }
     }
 

--- a/tests/init_cmd.rs
+++ b/tests/init_cmd.rs
@@ -190,6 +190,70 @@ fn init_is_idempotent_for_claude_oauth_import() {
 }
 
 #[test]
+fn init_imports_claude_profile_when_same_email_has_different_org() {
+    let env = TestEnv::new();
+    let claude_dir = env.fake_home.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join(".credentials.json"),
+        br#"{"account":{"email":"burak@example.com"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        env.fake_home.join(".claude.json"),
+        br#"{"oauthAccount":{"emailAddress":"burak@example.com","organizationUuid":"org-b"}}"#,
+    )
+    .unwrap();
+
+    fs::create_dir_all(&env.aisw_home).unwrap();
+    std::fs::write(
+        env.aisw_home.join("config.json"),
+        serde_json::json!({
+            "version": 1,
+            "active": { "claude": null, "codex": null, "gemini": null },
+            "profiles": {
+                "claude": {
+                    "work": {
+                        "added_at": "2026-03-25T00:00:00Z",
+                        "auth_method": "o_auth",
+                        "label": null
+                    }
+                },
+                "codex": {},
+                "gemini": {}
+            },
+            "settings": { "backup_on_switch": true, "max_backups": 10 }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let profile_dir = env.aisw_home.join("profiles").join("claude").join("work");
+    fs::create_dir_all(&profile_dir).unwrap();
+    fs::write(
+        profile_dir.join(".credentials.json"),
+        br#"{"account":{"email":"burak@example.com"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        profile_dir.join("oauth-account.json"),
+        br#"{"emailAddress":"burak@example.com","organizationUuid":"org-a"}"#,
+    )
+    .unwrap();
+
+    run_init(&env).success().stdout(contains(
+        "Imported Claude Code credentials as profile 'default' and marked it active.",
+    ));
+
+    assert!(env
+        .aisw_home
+        .join("profiles")
+        .join("claude")
+        .join("default")
+        .exists());
+}
+
+#[test]
 fn init_is_idempotent_for_claude_oauth_import_without_identity_fields() {
     let env = TestEnv::new();
     let claude_dir = env.fake_home.join(".claude");
@@ -860,6 +924,74 @@ fn init_blocks_import_of_duplicate_oauth_identity() {
         ))
         .stdout(contains(
             "aisw does not currently record an active profile for claude.",
+        ));
+
+    assert!(!env
+        .aisw_home
+        .join("profiles")
+        .join("claude")
+        .join("default")
+        .exists());
+}
+
+#[test]
+fn init_blocks_import_of_duplicate_oauth_identity_when_org_is_missing() {
+    let env = TestEnv::new();
+
+    fs::create_dir_all(&env.aisw_home).unwrap();
+    std::fs::write(
+        env.aisw_home.join("config.json"),
+        serde_json::json!({
+            "version": 1,
+            "active": { "claude": null, "codex": null, "gemini": null },
+            "profiles": {
+                "claude": {
+                    "work": {
+                        "added_at": "2026-03-25T00:00:00Z",
+                        "auth_method": "o_auth",
+                        "label": null
+                    }
+                },
+                "codex": {},
+                "gemini": {}
+            },
+            "settings": { "backup_on_switch": true, "max_backups": 10 }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let profile_dir = env.aisw_home.join("profiles").join("claude").join("work");
+    fs::create_dir_all(&profile_dir).unwrap();
+    fs::write(
+        profile_dir.join(".credentials.json"),
+        br#"{"account":{"email":"burak@example.com"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        profile_dir.join("oauth-account.json"),
+        br#"{"emailAddress":"burak@example.com","organizationUuid":"org-a"}"#,
+    )
+    .unwrap();
+
+    let claude_dir = env.fake_home.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join(".credentials.json"),
+        br#"{"account":{"email":"burak@example.com"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        env.fake_home.join(".claude.json"),
+        br#"{"oauthAccount":{"emailAddress":"burak@example.com"}}"#,
+    )
+    .unwrap();
+
+    run_init(&env)
+        .success()
+        .stdout(contains("already managed"))
+        .stdout(contains(
+            "Current live credentials match stored profile 'work'.",
         ));
 
     assert!(!env


### PR DESCRIPTION
## Summary

- Make Claude OAuth duplicate detection org-aware when `oauth-account.json` includes `organizationUuid`.
- Allow separate Claude profiles for the same email when they belong to different org/workspace contexts.
- Preserve backward compatibility by falling back to the existing email-only duplicate behavior when org metadata is missing.
- Add regression coverage for `add --from-live`, `init`, and Claude OAuth add flows.

## User Impact

This fixes false duplicate-account rejections for Claude users whose login email belongs to multiple Anthropic orgs/workspaces. Affected users can now import and manage separate Claude OAuth profiles for each org without `aisw` treating them as aliases of the same account.

## CLI / UX Changes

- New flags/options: none
- Changed defaults: none
- New/updated output: none
- Error message changes: none intended; duplicate-account errors still render the account email, but the matching logic is now org-aware for Claude when org metadata is available

## Backward Compatibility
Call out any breaking changes or migration concerns.

- [x] No breaking changes
- [ ] Breaking change (describe below)

Existing stored profiles, config format, and command surface are unchanged. **When Claude org metadata is missing on either side, behavior intentionally falls back to the previous email-only duplicate check.**

## Implementation Notes

- The OAuth identity layer now resolves a structured internal identity for Claude: normalized email plus optional `organizationUuid`.
- Claude duplicate matching compares both email and org when both org IDs exist; otherwise it preserves the legacy email-only behavior.
- Codex and Gemini continue using the existing generic OAuth identity path with no behavior change.
- Claude `init` matching was consolidated so credential bytes and `.claude.json` metadata are evaluated together instead of via separate email-only checks.

## Tests & Validation

```bash
cargo build
cargo test auth::identity::tests -- --nocapture
cargo test from_live_claude -- --nocapture
cargo test --test init_cmd init_imports_claude_profile_when_same_email_has_different_org -- --nocapture
cargo test --test init_cmd init_blocks_import_of_duplicate_oauth_identity_when_org_is_missing -- --nocapture
cargo test --test init_cmd init_is_idempotent_for_claude_oauth_import -- --nocapture
cargo test --test init_cmd init_skips_duplicate_claude_keychain_oauth_using_account_metadata -- --nocapture
```


```bash
# Verified with an isolated HOME/AISW_HOME using the built binary:
# - org-a import with user@company.com + organizationUuid=org-A succeeded
# - org-b import with user@company.com + organizationUuid=org-B succeeded
# - same email with missing organizationUuid was still rejected
```

## Manual Verification

```bash
tmp="$(mktemp -d)"
export AISW_HOME="$tmp/aisw"
export HOME="$tmp/home"
export AISW_CLAUDE_AUTH_STORAGE=file
mkdir -p "$AISW_HOME" "$HOME/.claude"

printf '%s' '{"oauthToken":"tok-a","account":{"email":"user@company.com"}}' > "$HOME/.claude/.credentials.json"
printf '%s' '{"oauthAccount":{"emailAddress":"user@company.com","organizationUuid":"org-A"}}' > "$HOME/.claude.json"
./target/debug/aisw add claude org-a --from-live

printf '%s' '{"oauthToken":"tok-b","account":{"email":"user@company.com"}}' > "$HOME/.claude/.credentials.json"
printf '%s' '{"oauthAccount":{"emailAddress":"user@company.com","organizationUuid":"org-B"}}' > "$HOME/.claude.json"
./target/debug/aisw add claude org-b --from-live

# Backward-compatible fallback check:
printf '%s' '{"oauthToken":"tok-c","account":{"email":"user@company.com"}}' > "$HOME/.claude/.credentials.json"
printf '%s' '{"oauthAccount":{"emailAddress":"user@company.com"}}' > "$HOME/.claude.json"
./target/debug/aisw add claude org-missing --from-live
```

## Documentation

- [x] No docs needed
- [ ] Docs updated (README / CONTRIBUTING / command help)

## Security & Privacy Checklist

- [x] No secrets/tokens/credentials committed
- [x] Logs and screenshots are redacted
- [x] Sensitive output paths are reviewed

## Release Notes
Allow separate Claude OAuth profiles for the same email when they belong to different orgs, while preserving legacy duplicate checks when org metadata is missing.

## Linked Issues
Closes #19
