### PR TITLE
Fix Gemini OAuth terminal handling

### DIFF
--- a/src/auth/gemini.rs
+++ b/src/auth/gemini.rs
@@ -401,7 +401,6 @@ fn run_oauth_flow(
     crate::output::print_info("Steps:");
     crate::output::print_info("  1. Complete Gemini sign-in in your browser");
     crate::output::print_info("  2. Stay in this terminal; aisw will detect completion");
-    let spinner = crate::output::start_spinner("Waiting for Gemini OAuth...");
 
     let result = (|| {
         let terminal = TerminalGuard::capture();
@@ -439,19 +438,6 @@ fn run_oauth_flow(
         }
     })();
 
-    match &result {
-        Ok(_) => {
-            if let Some(ref sp) = spinner {
-                sp.finish_with_message("\u{2713} Credentials captured");
-            }
-        }
-        Err(_) => {
-            if let Some(ref sp) = spinner {
-                sp.finish_and_clear();
-            }
-        }
-    }
-
     // Always clean up the scratch HOME regardless of outcome. On success the
     // credential files have already been copied into the profile directory.
     let _ = std::fs::remove_dir_all(&scratch);
@@ -465,17 +451,12 @@ fn spawn_oauth_child(
 ) -> Result<std::process::Child> {
     #[cfg(target_os = "macos")]
     {
-        use std::os::unix::process::CommandExt;
-
         let child = Command::new("/usr/bin/script")
             .arg("-q")
             .arg("/dev/null")
             .arg(gemini_bin)
             .env("GEMINI_CLI_HOME", scratch)
             .current_dir(scratch_workdir)
-            // Create a dedicated process group so we can terminate the entire
-            // OAuth process tree (script + gemini child) reliably.
-            .process_group(0)
             .spawn()
             .with_context(|| format!("could not spawn {}", gemini_bin.display()))?;
         Ok(child)
@@ -483,14 +464,9 @@ fn spawn_oauth_child(
 
     #[cfg(not(target_os = "macos"))]
     {
-        #[cfg(unix)]
-        use std::os::unix::process::CommandExt;
-
         let mut cmd = Command::new(gemini_bin);
         cmd.env("GEMINI_CLI_HOME", scratch)
             .current_dir(scratch_workdir);
-        #[cfg(unix)]
-        cmd.process_group(0);
         let child = cmd
             .spawn()
             .with_context(|| format!("could not spawn {}", gemini_bin.display()))?;
@@ -502,7 +478,7 @@ fn stop_interactive_child(child: &mut std::process::Child) {
     #[cfg(unix)]
     {
         let pid = child.id() as i32;
-        send_signal_to_oauth_tree(pid, libc::SIGINT);
+        let _ = unsafe { libc::kill(pid, libc::SIGINT) };
         for _ in 0..10 {
             if child.try_wait().ok().flatten().is_some() {
                 return;
@@ -514,7 +490,7 @@ fn stop_interactive_child(child: &mut std::process::Child) {
         #[cfg(target_os = "linux")]
         kill_child_descendants(pid, libc::SIGTERM);
 
-        send_signal_to_oauth_tree(pid, libc::SIGTERM);
+        let _ = unsafe { libc::kill(pid, libc::SIGTERM) };
         for _ in 0..10 {
             if child.try_wait().ok().flatten().is_some() {
                 return;
@@ -528,13 +504,6 @@ fn stop_interactive_child(child: &mut std::process::Child) {
 
     let _ = child.kill();
     let _ = child.wait();
-}
-
-#[cfg(unix)]
-fn send_signal_to_oauth_tree(pid: i32, signal: i32) {
-    // Try process-group signaling first (negative PID), then direct PID.
-    let _ = unsafe { libc::kill(-pid, signal) };
-    let _ = unsafe { libc::kill(pid, signal) };
 }
 
 #[cfg(target_os = "linux")]
@@ -1005,6 +974,36 @@ mod tests {
             .profile_dir(Tool::Gemini, "default")
             .join("oauth_creds.json")
             .exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn oauth_child_stays_in_foreground_process_group() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let scratch = dir.path().join("scratch");
+        let workspace = scratch.join("workspace");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::create_dir_all(&bin_dir).unwrap();
+        prepare_scratch_home(&scratch, &workspace).unwrap();
+
+        let bin = bin_dir.join("gemini");
+        fs::write(&bin, "#!/bin/sh\nsleep 5\n").unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut child = spawn_oauth_child(&bin, &scratch, &workspace).unwrap();
+        let child_pgid = unsafe { libc::getpgid(child.id() as i32) };
+        let parent_pgid = unsafe { libc::getpgrp() };
+        stop_interactive_child(&mut child);
+
+        assert_eq!(
+            child_pgid, parent_pgid,
+            "Gemini OAuth must stay in the foreground process group so its TUI can read stdin"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep the Gemini OAuth child in the foreground terminal process group so the Gemini TUI can read stdin
- remove the aisw spinner while Gemini owns the terminal
- add a regression test that fails if the OAuth child is detached from the foreground process group

## Root cause
Gemini CLI runs a full interactive TUI before opening the browser. The previous `process_group(0)` spawn detached Gemini from aisw's foreground terminal process group while still expecting Gemini to read from the same terminal. That made the TUI unreliable and prevented the flow from advancing to the browser-open confirmation.

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- pre-commit hook passed
- pre-push hook passed
- CI passed: lint, coverage, ubuntu, macOS, Windows
- end-to-end repro with isolated AISW_HOME and xdg-open shim: `target/debug/aisw add gemini fixedrepro` reaches Google OAuth and invokes xdg-open with an accounts.google.com URL
- end-to-end repro with isolated HOME + isolated AISW_HOME and xdg-open shim, bypassing the local mise shim via real Gemini binary path: `target/debug/aisw add gemini isolatedhome` reaches Google OAuth and invokes xdg-open with an accounts.google.com URL