### PR TITLE
Fix Claude hex-wrapped credential compatibility

### DIFF
--- a/src/auth/claude/api_key.rs
+++ b/src/auth/claude/api_key.rs
@@ -121,23 +121,8 @@ pub fn read_api_key_with_backend(
     name: &str,
     backend: CredentialBackend,
 ) -> Result<String> {
-    let bytes = match backend {
-        CredentialBackend::File => {
-            profile_store.read_file(Tool::Claude, name, super::CREDENTIALS_FILE)?
-        }
-        CredentialBackend::SystemKeyring => {
-            super::super::secure_store::read_profile_secret(Tool::Claude, name)?.ok_or_else(
-                || {
-                    anyhow::anyhow!(
-                        "secure credentials for Claude Code profile '{}' are missing from the system keyring",
-                        name
-                    )
-                },
-            )?
-        }
-    };
-    let normalized = super::normalize_credentials_bytes(&bytes).unwrap_or(bytes);
-    let json: serde_json::Value = serde_json::from_slice(&normalized).map_err(|e| {
+    let bytes = super::read_stored_credentials(profile_store, name, backend)?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| {
         anyhow::anyhow!(
             "could not parse credentials file for profile '{}'.\n  \
              The profile may be corrupted. Run 'aisw remove claude {}' \

--- a/src/auth/claude/api_key.rs
+++ b/src/auth/claude/api_key.rs
@@ -136,7 +136,8 @@ pub fn read_api_key_with_backend(
             )?
         }
     };
-    let json: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| {
+    let normalized = super::normalize_credentials_bytes(&bytes).unwrap_or(bytes);
+    let json: serde_json::Value = serde_json::from_slice(&normalized).map_err(|e| {
         anyhow::anyhow!(
             "could not parse credentials file for profile '{}'.\n  \
              The profile may be corrupted. Run 'aisw remove claude {}' \

--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -157,6 +157,23 @@ pub(super) fn read_stored_credentials(
     .map(|bytes| normalize_credentials_bytes(&bytes).unwrap_or(bytes))
 }
 
+pub(crate) fn persist_stored_credentials(
+    profile_store: &ProfileStore,
+    name: &str,
+    backend: CredentialBackend,
+    bytes: &[u8],
+) -> Result<()> {
+    let normalized = normalize_credentials_bytes(bytes).unwrap_or_else(|| bytes.to_vec());
+    match backend {
+        CredentialBackend::File => {
+            profile_store.write_file(Tool::Claude, name, CREDENTIALS_FILE, &normalized)
+        }
+        CredentialBackend::SystemKeyring => {
+            secure_store::write_profile_secret(Tool::Claude, name, &normalized)
+        }
+    }
+}
+
 pub(crate) fn normalize_credentials_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
     if has_object_json_shape(bytes) {
         return Some(bytes.to_vec());

--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -118,10 +118,10 @@ pub fn live_credentials_match(
             }
             let live = std::fs::read(&live_path)
                 .with_context(|| format!("could not read {}", live_path.display()))?;
-            let live_value = serde_json::from_slice::<serde_json::Value>(&live)
-                .context("could not parse live credentials file")?;
-            let stored_value = serde_json::from_slice::<serde_json::Value>(&stored)
-                .context("could not parse stored credentials")?;
+            let live_value =
+                credentials_json_value(&live).context("could not parse live credentials file")?;
+            let stored_value =
+                credentials_json_value(&stored).context("could not parse stored credentials")?;
             Ok(live_value == stored_value)
         }
         ClaudeAuthStorage::Keychain => {
@@ -130,9 +130,9 @@ pub fn live_credentials_match(
             };
             // Compare as parsed JSON values to handle the trailing newline
             // added by the security CLI and any key-ordering differences.
-            let live_value = serde_json::from_slice::<serde_json::Value>(&live)
+            let live_value = credentials_json_value(&live)
                 .context("could not parse live Keychain credentials")?;
-            let stored_value = serde_json::from_slice::<serde_json::Value>(&stored)
+            let stored_value = credentials_json_value(&stored)
                 .context("could not parse stored credential payload")?;
             Ok(live_value == stored_value)
         }
@@ -153,6 +153,64 @@ pub(super) fn read_stored_credentials(
                     name
                 )
             }),
+    }
+    .map(|bytes| normalize_credentials_bytes(&bytes).unwrap_or(bytes))
+}
+
+pub(crate) fn normalize_credentials_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
+    if has_object_json_shape(bytes) {
+        return Some(bytes.to_vec());
+    }
+
+    let mut candidate = bytes.to_vec();
+    for _ in 0..3 {
+        let text = std::str::from_utf8(&candidate).ok()?.trim();
+        if text.len() % 2 != 0 || !text.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return None;
+        }
+
+        let decoded = decode_hex_bytes(text)?;
+        if has_object_json_shape(&decoded) {
+            return Some(decoded);
+        }
+        candidate = decoded;
+    }
+
+    None
+}
+
+fn credentials_json_value(bytes: &[u8]) -> Result<serde_json::Value> {
+    let normalized = normalize_credentials_bytes(bytes).unwrap_or_else(|| bytes.to_vec());
+    serde_json::from_slice(&normalized).context("credential payload is not valid JSON")
+}
+
+fn has_object_json_shape(bytes: &[u8]) -> bool {
+    matches!(
+        serde_json::from_slice::<serde_json::Value>(bytes),
+        Ok(serde_json::Value::Object(_))
+    )
+}
+
+fn decode_hex_bytes(text: &str) -> Option<Vec<u8>> {
+    let mut decoded = Vec::with_capacity(text.len() / 2);
+    let mut chunks = text.as_bytes().chunks_exact(2);
+    for pair in &mut chunks {
+        let hi = decode_hex_nibble(pair[0])?;
+        let lo = decode_hex_nibble(pair[1])?;
+        decoded.push((hi << 4) | lo);
+    }
+    if !chunks.remainder().is_empty() {
+        return None;
+    }
+    Some(decoded)
+}
+
+fn decode_hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
     }
 }
 
@@ -1264,6 +1322,44 @@ mod tests {
         let live_json: serde_json::Value = serde_json::from_str(&live).unwrap();
         assert_eq!(live_json["oauthToken"], "tok");
         assert_eq!(live_json["account"]["email"], "work@example.com");
+    }
+
+    #[test]
+    fn normalize_credentials_bytes_decodes_nested_hex_wrapped_json() {
+        let once = b"7b226f61757468546f6b656e223a22746f6b227d";
+        let twice =
+            b"37623232366636313735373436383534366636623635366532323361323237343666366232323764";
+
+        let normalized_once = normalize_credentials_bytes(once).unwrap();
+        let normalized_twice = normalize_credentials_bytes(twice).unwrap();
+
+        assert_eq!(normalized_once, br#"{"oauthToken":"tok"}"#);
+        assert_eq!(normalized_twice, br#"{"oauthToken":"tok"}"#);
+    }
+
+    #[test]
+    fn keychain_live_credentials_match_decodes_hex_wrapped_live_payload() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("home");
+        fs::create_dir_all(&user_home).unwrap();
+
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "keychain");
+        let _keyring = EnvVarGuard::set("AISW_KEYRING_TEST_DIR", dir.path().join("keyring"));
+
+        let (ps, _cs) = stores(dir.path());
+        ps.create(Tool::Claude, "work").unwrap();
+        ps.write_file(
+            Tool::Claude,
+            "work",
+            CREDENTIALS_FILE,
+            br#"{"oauthToken":"tok"}"#,
+        )
+        .unwrap();
+
+        keychain::write_keychain_credentials(b"7b226f61757468546f6b656e223a22746f6b227d").unwrap();
+
+        assert!(live_credentials_match(&ps, "work", CredentialBackend::File, &user_home).unwrap());
     }
 
     #[test]

--- a/src/auth/claude/oauth.rs
+++ b/src/auth/claude/oauth.rs
@@ -37,12 +37,14 @@ fn persist_oauth_storage(
     stored_backend: CredentialBackend,
     auth_bytes: &[u8],
 ) -> Result<()> {
+    let normalized =
+        super::normalize_credentials_bytes(auth_bytes).unwrap_or_else(|| auth_bytes.to_vec());
     match stored_backend {
         CredentialBackend::File => {
-            profile_store.write_file(Tool::Claude, name, super::CREDENTIALS_FILE, auth_bytes)
+            profile_store.write_file(Tool::Claude, name, super::CREDENTIALS_FILE, &normalized)
         }
         CredentialBackend::SystemKeyring => {
-            secure_store::write_profile_secret(Tool::Claude, name, auth_bytes)
+            secure_store::write_profile_secret(Tool::Claude, name, &normalized)
         }
     }
 }

--- a/src/auth/claude/oauth.rs
+++ b/src/auth/claude/oauth.rs
@@ -37,16 +37,7 @@ fn persist_oauth_storage(
     stored_backend: CredentialBackend,
     auth_bytes: &[u8],
 ) -> Result<()> {
-    let normalized =
-        super::normalize_credentials_bytes(auth_bytes).unwrap_or_else(|| auth_bytes.to_vec());
-    match stored_backend {
-        CredentialBackend::File => {
-            profile_store.write_file(Tool::Claude, name, super::CREDENTIALS_FILE, &normalized)
-        }
-        CredentialBackend::SystemKeyring => {
-            secure_store::write_profile_secret(Tool::Claude, name, &normalized)
-        }
-    }
+    super::persist_stored_credentials(profile_store, name, stored_backend, auth_bytes)
 }
 
 // ---- Live credential snapshot (for import) ----

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -374,17 +374,25 @@ fn from_live_claude(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
     };
 
     let write_result = match stored_backend {
-        CredentialBackend::File => profile_store.write_file(
-            Tool::Claude,
-            &args.profile_name,
-            ".credentials.json",
-            &snapshot.bytes,
-        ),
-        CredentialBackend::SystemKeyring => crate::auth::secure_store::write_profile_secret(
-            Tool::Claude,
-            &args.profile_name,
-            &snapshot.bytes,
-        ),
+        CredentialBackend::File => {
+            let normalized = auth::claude::normalize_credentials_bytes(&snapshot.bytes)
+                .unwrap_or_else(|| snapshot.bytes.clone());
+            profile_store.write_file(
+                Tool::Claude,
+                &args.profile_name,
+                ".credentials.json",
+                &normalized,
+            )
+        }
+        CredentialBackend::SystemKeyring => {
+            let normalized = auth::claude::normalize_credentials_bytes(&snapshot.bytes)
+                .unwrap_or_else(|| snapshot.bytes.clone());
+            crate::auth::secure_store::write_profile_secret(
+                Tool::Claude,
+                &args.profile_name,
+                &normalized,
+            )
+        }
     };
 
     if let Err(e) = write_result {
@@ -1588,6 +1596,37 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&stored).unwrap();
         assert_eq!(json["oauthToken"], "tok-abc");
+    }
+
+    #[test]
+    fn from_live_claude_decodes_hex_wrapped_live_credentials() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("user");
+        fs::create_dir_all(aisw_home.join("profiles")).unwrap();
+        fs::create_dir_all(user_home.join(".claude")).unwrap();
+        fs::write(
+            user_home.join(".claude").join(".credentials.json"),
+            b"7b226f61757468546f6b656e223a22746f6b2d686578227d",
+        )
+        .unwrap();
+        let _home = EnvVarGuard::set("HOME", user_home.to_str().unwrap());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        run_in(
+            from_live_args(Tool::Claude, "work"),
+            &aisw_home,
+            OsString::new(),
+        )
+        .unwrap();
+
+        let ps = ProfileStore::new(&aisw_home);
+        let stored = ps
+            .read_file(Tool::Claude, "work", ".credentials.json")
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&stored).unwrap();
+        assert_eq!(json["oauthToken"], "tok-hex");
     }
 
     #[test]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -373,27 +373,12 @@ fn from_live_claude(args: AddArgs, home: &Path, user_home: &Path) -> Result<()> 
         None
     };
 
-    let write_result = match stored_backend {
-        CredentialBackend::File => {
-            let normalized = auth::claude::normalize_credentials_bytes(&snapshot.bytes)
-                .unwrap_or_else(|| snapshot.bytes.clone());
-            profile_store.write_file(
-                Tool::Claude,
-                &args.profile_name,
-                ".credentials.json",
-                &normalized,
-            )
-        }
-        CredentialBackend::SystemKeyring => {
-            let normalized = auth::claude::normalize_credentials_bytes(&snapshot.bytes)
-                .unwrap_or_else(|| snapshot.bytes.clone());
-            crate::auth::secure_store::write_profile_secret(
-                Tool::Claude,
-                &args.profile_name,
-                &normalized,
-            )
-        }
-    };
+    let write_result = auth::claude::persist_stored_credentials(
+        &profile_store,
+        &args.profile_name,
+        stored_backend,
+        &snapshot.bytes,
+    );
 
     if let Err(e) = write_result {
         if let Some(snapshot) = overwrite_snapshot.as_ref() {

--- a/tests/use_cmd.rs
+++ b/tests/use_cmd.rs
@@ -649,6 +649,48 @@ fn use_claude_writes_keychain_when_keychain_backend_selected() {
 }
 
 #[test]
+fn use_claude_decodes_hex_wrapped_credentials_before_writing_live_state() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+
+    let profile_dir = env.aisw_home.join("profiles").join("claude").join("work");
+    std::fs::create_dir_all(&profile_dir).unwrap();
+    std::fs::write(
+        profile_dir.join(".credentials.json"),
+        b"7b226f61757468546f6b656e223a22746f6b227d",
+    )
+    .unwrap();
+
+    write_config_json(
+        &env,
+        serde_json::json!({
+            "version": 1,
+            "active": {"claude": null, "codex": null, "gemini": null},
+            "profiles": {
+                "claude": {
+                    "work": {
+                        "added_at": "2026-03-25T00:00:00Z",
+                        "auth_method": "o_auth",
+                        "credential_backend": "file",
+                        "label": null
+                    }
+                },
+                "codex": {},
+                "gemini": {}
+            },
+            "settings": {"backup_on_switch": true, "max_backups": 10}
+        }),
+    );
+
+    env.cmd().args(["use", "claude", "work"]).assert().success();
+
+    let live =
+        std::fs::read_to_string(env.fake_home.join(".claude").join(".credentials.json")).unwrap();
+    let live_json: serde_json::Value = serde_json::from_str(&live).unwrap();
+    assert_eq!(live_json["oauthToken"], "tok");
+}
+
+#[test]
 fn failing_claude_use_does_not_leak_api_key() {
     let env = TestEnv::new();
     add_claude_profile(&env, "work");


### PR DESCRIPTION
## Summary

- Fix Claude credential handling when live or stored payloads are hex-wrapped instead of direct JSON.
- Normalize only invalid non-JSON Claude payloads that cleanly decode into a valid JSON object, preserving existing valid JSON behavior.
- Centralize Claude credential normalization/persistence to avoid drift across `--from-live`, apply, and read paths.
- Add regression coverage for Claude `--from-live`, `use`, and keychain/live-state matching.

## User Impact

This fixes a real Claude profile import/switch failure where `aisw` could error with `trailing characters at line 1 column 2` when encountering hex-wrapped Claude credential payloads. Affected users are primarily Claude users importing live credentials or switching profiles on setups where that payload shape appears.

## CLI / UX Changes

  - New flags/options:
    - None.
  - Changed defaults:
    - None.
  - New/updated output:
    - None.
  - Error message changes:
    - No intended surface change beyond avoiding the previous parse failure.

## Backward Compatibility

  - [x] No breaking changes
  - [ ] Breaking change (describe below)

## Implementation Notes

Claude credential normalization is intentionally narrow:
- valid JSON objects are left untouched
- only non-JSON payloads that decode from hex into valid JSON objects are normalized

The normalization logic is centralized so all Claude storage/read paths follow the same compatibility rule.

## Tests & Validation

  ```bash
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
```
## Manual Verification
```
# Seed a Claude profile with a hex-wrapped credential payload, then verify use/import works.
cargo test --lib claude -- --nocapture
cargo test --test use_cmd -- --nocapture
cargo test --test secure_backend_cmd -- --nocapture
```
## Documentation

  - [x] No docs needed
  - [ ] Docs updated (README / CONTRIBUTING / command help)

## Security & Privacy Checklist

  - [x] No secrets/tokens/credentials committed
  - [x] Logs and screenshots are redacted
  - [x] Sensitive output paths are reviewed

## Release Notes

Fix Claude profile import/switch failures when credentials are stored in hex-wrapped JSON form.

## Linked Issues

Closes #27
