### PR TITLE
Add workspace-aware context bindings and cross-shell guardrails

### DIFF
--- a/src/auth/files.rs
+++ b/src/auth/files.rs
@@ -109,21 +109,28 @@ pub(crate) fn shell_single_quote(value: &str) -> String {
 /// We detect Fish by checking for `FISH_VERSION`, which Fish always exports into
 /// child-process environments.
 pub(crate) fn emit_export(key: &str, value: &str) {
-    if std::env::var_os("FISH_VERSION").is_some() {
-        println!("set -gx {} {}", key, shell_single_quote(value));
-    } else {
-        println!("export {}={}", key, shell_single_quote(value));
+    match std::env::var("AISW_SHELL").ok().as_deref() {
+        Some("pwsh") => println!("$env:{} = {}", key, powershell_single_quote(value)),
+        _ if std::env::var_os("FISH_VERSION").is_some() => {
+            println!("set -gx {} {}", key, shell_single_quote(value));
+        }
+        _ => println!("export {}={}", key, shell_single_quote(value)),
     }
 }
 
 /// Emit a shell unset statement for `key`, choosing the correct syntax for the
 /// active shell.
 pub(crate) fn emit_unset(key: &str) {
-    if std::env::var_os("FISH_VERSION").is_some() {
-        println!("set -e {}", key);
-    } else {
-        println!("unset {}", key);
+    match std::env::var("AISW_SHELL").ok().as_deref() {
+        Some("pwsh") => println!("Remove-Item Env:{} -ErrorAction SilentlyContinue", key),
+        _ if std::env::var_os("FISH_VERSION").is_some() => println!("set -e {}", key),
+        _ => println!("unset {}", key),
     }
+}
+
+fn powershell_single_quote(value: &str) -> String {
+    let escaped = value.replace('\'', "''");
+    format!("'{}'", escaped)
 }
 
 #[cfg(test)]
@@ -233,5 +240,10 @@ mod tests {
             shell_single_quote("/home/user/my profiles/codex"),
             "'/home/user/my profiles/codex'"
         );
+    }
+
+    #[test]
+    fn powershell_single_quote_escapes_embedded_single_quote() {
+        assert_eq!(powershell_single_quote("it's"), "'it''s'");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -494,6 +494,7 @@ pub enum Shell {
     Bash,
     Zsh,
     Fish,
+    Pwsh,
 }
 
 #[derive(Args, Debug)]
@@ -848,6 +849,7 @@ mod tests {
             ("bash", Shell::Bash),
             ("zsh", Shell::Zsh),
             ("fish", Shell::Fish),
+            ("pwsh", Shell::Pwsh),
         ] {
             let cli = parse(&["shell-hook", input]).unwrap();
             let Command::ShellHook(args) = cli.command else {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,6 +89,9 @@ pub enum Command {
 
     /// Run a health check on the aisw installation and tool environment
     Doctor(DoctorArgs),
+
+    /// Bind workspaces to expected contexts and enforce guardrails
+    Workspace(WorkspaceArgs),
 }
 
 #[derive(Args, Debug)]
@@ -96,6 +99,84 @@ pub struct DoctorArgs {
     /// Output results as JSON
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct WorkspaceArgs {
+    #[command(subcommand)]
+    pub command: WorkspaceCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum WorkspaceCommand {
+    /// Bind a path, repo, remote, or default rule to a context
+    Bind(WorkspaceBindArgs),
+
+    /// Show workspace-to-context resolution for the current directory
+    Status(WorkspaceStatusArgs),
+
+    /// Validate workspace rules and current workspace configuration
+    Doctor(WorkspaceDoctorArgs),
+
+    /// Set the default workspace guard mode
+    Guard(WorkspaceGuardArgs),
+
+    #[command(hide = true)]
+    Check(WorkspaceCheckArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct WorkspaceBindArgs {
+    /// Path to bind. In a git repo this writes .git/info/aisw.json by default.
+    pub path: Option<String>,
+
+    /// Context to bind the workspace to
+    #[arg(long, value_name = "CONTEXT")]
+    pub context: String,
+
+    /// Bind a git remote pattern like github.com/acme/*
+    #[arg(long, value_name = "PATTERN", conflicts_with_all = ["path", "default"])]
+    pub git_remote: Option<String>,
+
+    /// Set the default context when no workspace-specific rule matches
+    #[arg(long, conflicts_with_all = ["path", "git_remote"])]
+    pub default: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct WorkspaceStatusArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct WorkspaceDoctorArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct WorkspaceGuardArgs {
+    /// Default workspace guard mode
+    #[arg(long, value_enum)]
+    pub mode: WorkspaceGuardMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum WorkspaceGuardMode {
+    Warn,
+    Strict,
+}
+
+#[derive(Args, Debug)]
+pub struct WorkspaceCheckArgs {
+    #[arg(long)]
+    pub tool: Option<Tool>,
+
+    #[arg(long, hide = true)]
+    pub prompt: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -262,14 +262,12 @@ fn credentials_filename(tool: Tool) -> &'static str {
 // ---- rc file path helper ----
 
 pub fn rc_path_for_shell(shell_exe: &str, user_home: &Path) -> Option<PathBuf> {
-    let basename = Path::new(shell_exe)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or(shell_exe);
-    match basename {
+    let basename = crate::commands::init::normalized_shell_name(Some(shell_exe))?;
+    match basename.as_str() {
         "bash" => Some(user_home.join(".bashrc")),
         "zsh" => Some(user_home.join(".zshrc")),
         "fish" => Some(user_home.join(".config").join("fish").join("config.fish")),
+        "pwsh" => Some(crate::commands::init::rc_file(user_home, "pwsh")),
         _ => None,
     }
 }
@@ -304,7 +302,11 @@ pub fn collect(home: &Path, user_home: &Path, path_var: &std::ffi::OsStr) -> Doc
     checks.push(check_keyring());
 
     // 4. Shell hook
-    let shell_exe = std::env::var("SHELL").ok();
+    let shell_exe = std::env::var("SHELL").ok().or_else(|| {
+        std::env::var("PSModulePath")
+            .ok()
+            .map(|_| "pwsh".to_owned())
+    });
     let rc_path = shell_exe
         .as_deref()
         .and_then(|s| rc_path_for_shell(s, user_home));
@@ -533,6 +535,19 @@ mod tests {
             rc_path_for_shell("fish", home),
             Some(Path::new("/home/user/.config/fish/config.fish").to_path_buf())
         );
+    }
+
+    #[test]
+    fn rc_path_pwsh() {
+        let home = Path::new("/home/user");
+        let expected = if cfg!(windows) {
+            Path::new("/home/user/Documents/PowerShell/Microsoft.PowerShell_profile.ps1")
+                .to_path_buf()
+        } else {
+            Path::new("/home/user/.config/powershell/Microsoft.PowerShell_profile.ps1")
+                .to_path_buf()
+        };
+        assert_eq!(rc_path_for_shell("pwsh", home), Some(expected));
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -37,26 +37,24 @@ pub(crate) fn run_inner(
     let detected_tools = detect_supported_tools();
 
     // Shell hook installation.
-    let shell_name = shell_env
-        .and_then(|s| Path::new(s).file_name())
-        .and_then(|n| n.to_str());
+    let shell_name = normalized_shell_name(shell_env);
     output::print_section("Shell integration");
-    output::print_kv("Shell", shell_name.unwrap_or("unknown"));
-    match shell_name {
-        Some(s @ ("bash" | "zsh" | "fish")) => {
+    output::print_kv("Shell", shell_name.as_deref().unwrap_or("unknown"));
+    match shell_name.as_deref() {
+        Some(s @ ("bash" | "zsh" | "fish" | "pwsh")) => {
             install_shell_hook(user_home, s, confirmed)?;
         }
         Some(name) => {
             output::print_warning(format!(
                 "Shell not recognized ({}). Install the hook manually: \
-                 aisw shell-hook bash >> ~/.bashrc",
+                 aisw shell-hook pwsh >> <your-profile.ps1>",
                 name
             ));
         }
         None => {
             output::print_warning(
                 "Could not detect shell. Install the hook manually: \
-                 aisw shell-hook bash >> ~/.bashrc",
+                 aisw shell-hook pwsh >> <your-profile.ps1>",
             );
         }
     }
@@ -91,6 +89,22 @@ fn print_detected_tools(detected: &HashMap<Tool, Option<DetectedTool>>) {
     }
 }
 
+pub(crate) fn normalized_shell_name(shell_env: Option<&str>) -> Option<String> {
+    let basename = shell_env
+        .and_then(|s| Path::new(s).file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+        .trim_end_matches(".exe")
+        .to_ascii_lowercase();
+
+    match basename.as_str() {
+        "bash" | "zsh" | "fish" | "pwsh" => Some(basename),
+        "powershell" => Some("pwsh".to_owned()),
+        _ if basename.is_empty() => None,
+        _ => Some(basename),
+    }
+}
+
 pub(crate) fn rc_file(user_home: &Path, shell: &str) -> PathBuf {
     match shell {
         "bash" => {
@@ -102,6 +116,19 @@ pub(crate) fn rc_file(user_home: &Path, shell: &str) -> PathBuf {
         }
         "zsh" => user_home.join(".zshrc"),
         "fish" => user_home.join(".config").join("fish").join("config.fish"),
+        "pwsh" => {
+            if cfg!(windows) {
+                user_home
+                    .join("Documents")
+                    .join("PowerShell")
+                    .join("Microsoft.PowerShell_profile.ps1")
+            } else {
+                user_home
+                    .join(".config")
+                    .join("powershell")
+                    .join("Microsoft.PowerShell_profile.ps1")
+            }
+        }
         _ => unreachable!(),
     }
 }
@@ -138,6 +165,10 @@ fn install_shell_hook(user_home: &Path, shell: &str, confirmed: bool) -> Result<
     let hook_line = match shell {
         "bash" | "zsh" => format!("\n{}\neval \"$(aisw shell-hook {})\"\n", HOOK_MARKER, shell),
         "fish" => format!("\n{}\naisw shell-hook fish | source\n", HOOK_MARKER),
+        "pwsh" => format!(
+            "\n{}\naisw shell-hook pwsh | Out-String | Invoke-Expression\n",
+            HOOK_MARKER
+        ),
         _ => unreachable!(),
     };
 
@@ -986,6 +1017,20 @@ mod tests {
         let rc = user_home.join(".config").join("fish").join("config.fish");
         let contents = fs::read_to_string(&rc).unwrap();
         assert!(contents.contains("shell-hook fish | source"));
+    }
+
+    #[test]
+    fn normalized_shell_name_maps_powershell_variants() {
+        assert_eq!(
+            normalized_shell_name(Some("/usr/bin/pwsh")),
+            Some("pwsh".to_owned())
+        );
+        assert_eq!(
+            normalized_shell_name(Some(
+                "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+            )),
+            Some("pwsh".to_owned())
+        );
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod shell_hook;
 pub mod status;
 pub mod uninstall;
 pub mod use_;
+pub mod workspace;
 
 pub fn dispatch(cli: Cli) -> Result<()> {
     let home = ConfigStore::aisw_home()?;
@@ -49,6 +50,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
                 std::process::exit(1);
             }
         }
+        Command::Workspace(args) => workspace::run(args, &home)?,
     }
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -29,7 +29,11 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Command::Status(args) => status::run(args, &home)?,
         Command::Init(args) => {
             let user_home = dirs::home_dir().context("could not determine home directory")?;
-            let shell_env = std::env::var("SHELL").ok();
+            let shell_env = std::env::var("SHELL").ok().or_else(|| {
+                std::env::var("PSModulePath")
+                    .ok()
+                    .map(|_| "pwsh".to_owned())
+            });
             if crate::runtime::is_non_interactive() && !args.yes {
                 anyhow::bail!(
                     "init requires confirmation and prompt input.\n  \

--- a/src/commands/shell_hook.rs
+++ b/src/commands/shell_hook.rs
@@ -2,40 +2,174 @@ use anyhow::Result;
 
 use crate::cli::{Shell, ShellHookArgs};
 
-// Bash and zsh share POSIX-compatible function syntax.
 const BASH_ZSH_HOOK: &str = "\
-# Added by aisw \u{2014} do not edit manually
+# Added by aisw - do not edit manually
 export AISW_SHELL_HOOK=1
+__aisw_prompt_check() {
+  if [ \"${PWD-}\" != \"${AISW_LAST_PWD-}\" ]; then
+    AISW_LAST_PWD=\"$PWD\"
+    command aisw workspace check --prompt
+  fi
+}
+__aisw_install_prompt_hook() {
+  if [ -n \"${ZSH_VERSION-}\" ]; then
+    typeset -ga precmd_functions chpwd_functions
+    case \" ${precmd_functions[*]} \" in
+      *\" __aisw_prompt_check \"*) ;;
+      *) precmd_functions+=(__aisw_prompt_check) ;;
+    esac
+    case \" ${chpwd_functions[*]} \" in
+      *\" __aisw_prompt_check \"*) ;;
+      *) chpwd_functions+=(__aisw_prompt_check) ;;
+    esac
+  else
+    case \";${PROMPT_COMMAND-};\" in
+      *\";__aisw_prompt_check;\"*) ;;
+      *) PROMPT_COMMAND=\"__aisw_prompt_check${PROMPT_COMMAND:+;$PROMPT_COMMAND}\" ;;
+    esac
+  fi
+}
 aisw() {
   if [ \"$1\" = \"use\" ] || { [ \"$1\" = \"context\" ] && [ \"$2\" = \"use\" ]; }; then
     eval \"$(command aisw \"$@\" --emit-env 2>/dev/null)\"
     command aisw \"$@\"
+    __aisw_prompt_check
   else
     command aisw \"$@\"
   fi
 }
+claude() {
+  command aisw workspace check --tool claude || return $?
+  command claude \"$@\"
+}
+codex() {
+  command aisw workspace check --tool codex || return $?
+  command codex \"$@\"
+}
+gemini() {
+  command aisw workspace check --tool gemini || return $?
+  command gemini \"$@\"
+}
+__aisw_install_prompt_hook
 ";
 
 // Fish cannot eval POSIX `export KEY=VALUE`. aisw detects Fish via FISH_VERSION
 // and emits native `set -gx` / `set -e` lines, so the hook just evals them directly.
 const FISH_HOOK: &str = "\
-# Added by aisw \u{2014} do not edit manually
+# Added by aisw - do not edit manually
 set -gx AISW_SHELL_HOOK 1
+set -gx AISW_SHELL fish
+set -g AISW_LAST_PWD ''
+
+function __aisw_prompt_check --on-variable PWD
+  if test \"$PWD\" != \"$AISW_LAST_PWD\"
+    set -g AISW_LAST_PWD \"$PWD\"
+    command aisw workspace check --prompt
+  end
+end
 
 function aisw
   if test \"$argv[1]\" = \"use\"; or begin; test \"$argv[1]\" = \"context\"; and test \"$argv[2]\" = \"use\"; end
     eval (command aisw $argv --emit-env 2>/dev/null)
     command aisw $argv
+    __aisw_prompt_check
   else
     command aisw $argv
   end
 end
+
+function claude
+  command aisw workspace check --tool claude
+  or return $status
+  command claude $argv
+end
+
+function codex
+  command aisw workspace check --tool codex
+  or return $status
+  command codex $argv
+end
+
+function gemini
+  command aisw workspace check --tool gemini
+  or return $status
+  command gemini $argv
+end
 ";
+
+const POWERSHELL_HOOK: &str = r#"
+# Added by aisw - do not edit manually
+$env:AISW_SHELL_HOOK = '1'
+$env:AISW_SHELL = 'pwsh'
+function global:__aisw_get_command_path([string]$Name) {
+  $cmd = Get-Command $Name -All | Where-Object { $_.CommandType -eq 'Application' } | Select-Object -First 1
+  if ($null -eq $cmd) {
+    throw "Could not find application '$Name' on PATH."
+  }
+  $cmd.Source
+}
+function global:__aisw_bin {
+  __aisw_get_command_path 'aisw'
+}
+function global:__aisw_prompt_check {
+  $cwd = $PWD.Path
+  if ($global:AISW_LAST_PWD -ne $cwd) {
+    $global:AISW_LAST_PWD = $cwd
+    & (__aisw_bin) workspace check --prompt
+  }
+}
+if (-not (Test-Path Function:\global:__aisw_original_prompt)) {
+  if (Test-Path Function:\prompt) {
+    Copy-Item Function:\prompt Function:\global:__aisw_original_prompt
+  }
+}
+function global:prompt {
+  __aisw_prompt_check
+  if (Test-Path Function:\global:__aisw_original_prompt) {
+    & $function:__aisw_original_prompt
+  } else {
+    "PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "
+  }
+}
+function global:aisw {
+  param([Parameter(ValueFromRemainingArguments = $true)][string[]]$ArgsRest)
+  $aiswBin = __aisw_bin
+  if ($ArgsRest.Length -gt 0 -and ($ArgsRest[0] -eq 'use' -or ($ArgsRest.Length -gt 1 -and $ArgsRest[0] -eq 'context' -and $ArgsRest[1] -eq 'use'))) {
+    $envScript = & $aiswBin @ArgsRest --emit-env 2>$null | Out-String
+    if (-not [string]::IsNullOrWhiteSpace($envScript)) {
+      Invoke-Expression $envScript
+    }
+    & $aiswBin @ArgsRest
+    __aisw_prompt_check
+  } else {
+    & $aiswBin @ArgsRest
+  }
+}
+function global:claude {
+  param([Parameter(ValueFromRemainingArguments = $true)][string[]]$ArgsRest)
+  & (__aisw_bin) workspace check --tool claude
+  if ($LASTEXITCODE -ne 0) { return }
+  & (__aisw_get_command_path 'claude') @ArgsRest
+}
+function global:codex {
+  param([Parameter(ValueFromRemainingArguments = $true)][string[]]$ArgsRest)
+  & (__aisw_bin) workspace check --tool codex
+  if ($LASTEXITCODE -ne 0) { return }
+  & (__aisw_get_command_path 'codex') @ArgsRest
+}
+function global:gemini {
+  param([Parameter(ValueFromRemainingArguments = $true)][string[]]$ArgsRest)
+  & (__aisw_bin) workspace check --tool gemini
+  if ($LASTEXITCODE -ne 0) { return }
+  & (__aisw_get_command_path 'gemini') @ArgsRest
+}
+"#;
 
 pub fn run(args: ShellHookArgs) -> Result<()> {
     match args.shell {
         Shell::Bash | Shell::Zsh => print!("{}", BASH_ZSH_HOOK),
         Shell::Fish => print!("{}", FISH_HOOK),
+        Shell::Pwsh => print!("{}", POWERSHELL_HOOK),
     }
     Ok(())
 }
@@ -65,6 +199,7 @@ mod tests {
         assert!(BASH_ZSH_HOOK.contains("aisw()"));
         assert!(BASH_ZSH_HOOK.contains("--emit-env"));
         assert!(BASH_ZSH_HOOK.contains("export AISW_SHELL_HOOK=1"));
+        assert!(BASH_ZSH_HOOK.contains("workspace check --tool claude"));
     }
 
     #[test]
@@ -80,12 +215,18 @@ mod tests {
     }
 
     #[test]
+    fn pwsh_hook_returns_ok() {
+        assert!(run(hook_args(Shell::Pwsh)).is_ok());
+    }
+
+    #[test]
     fn fish_hook_contains_required_strings() {
         assert!(FISH_HOOK.contains("AISW_SHELL_HOOK"));
         assert!(FISH_HOOK.contains("set -gx AISW_SHELL_HOOK 1"));
         assert!(FISH_HOOK.contains("function aisw"));
         assert!(FISH_HOOK.contains("--emit-env"));
         assert!(FISH_HOOK.contains("set -gx"));
+        assert!(FISH_HOOK.contains("workspace check --tool claude"));
     }
 
     #[test]
@@ -103,5 +244,13 @@ mod tests {
         assert!(!FISH_HOOK.contains("string replace"));
         assert!(!FISH_HOOK.contains("string split"));
         assert!(!FISH_HOOK.contains("string unescape"));
+    }
+
+    #[test]
+    fn pwsh_hook_contains_required_strings() {
+        assert!(POWERSHELL_HOOK.contains("$env:AISW_SHELL = 'pwsh'"));
+        assert!(POWERSHELL_HOOK.contains("function global:aisw"));
+        assert!(POWERSHELL_HOOK.contains("--emit-env"));
+        assert!(POWERSHELL_HOOK.contains("workspace check --tool claude"));
     }
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -32,13 +32,13 @@ pub(crate) struct ToolStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct DerivedContextStatus {
-    status: &'static str,
-    active: Option<String>,
-    matches: Vec<String>,
-    drift_candidates: Vec<String>,
-    mapped_profiles: Option<std::collections::HashMap<Tool, String>>,
-    unmanaged_tools: Vec<(Tool, Option<String>)>,
+pub(crate) struct DerivedContextStatus {
+    pub(crate) status: &'static str,
+    pub(crate) active: Option<String>,
+    pub(crate) matches: Vec<String>,
+    pub(crate) drift_candidates: Vec<String>,
+    pub(crate) mapped_profiles: Option<std::collections::HashMap<Tool, String>>,
+    pub(crate) unmanaged_tools: Vec<(Tool, Option<String>)>,
 }
 
 pub fn run(args: StatusArgs, home: &Path) -> Result<()> {
@@ -496,7 +496,10 @@ fn print_json(
     Ok(())
 }
 
-fn derive_context_status(config: &Config, statuses: &[ToolStatus]) -> DerivedContextStatus {
+pub(crate) fn derive_context_status(
+    config: &Config,
+    statuses: &[ToolStatus],
+) -> DerivedContextStatus {
     let active_profiles = Tool::ALL
         .iter()
         .map(|tool| {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -41,6 +41,12 @@ pub(crate) struct DerivedContextStatus {
     pub(crate) unmanaged_tools: Vec<(Tool, Option<String>)>,
 }
 
+impl DerivedContextStatus {
+    pub(crate) fn is_ambiguous(&self) -> bool {
+        self.status == "ambiguous"
+    }
+}
+
 pub fn run(args: StatusArgs, home: &Path) -> Result<()> {
     let user_home = dirs::home_dir().unwrap_or_else(|| Path::new(".").to_path_buf());
     run_in(

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -8,7 +8,7 @@ use crate::commands::init::{rc_file, HOOK_MARKER};
 use crate::output;
 use crate::runtime;
 
-const SHELLS: [&str; 3] = ["bash", "zsh", "fish"];
+const SHELLS: [&str; 4] = ["bash", "zsh", "fish", "pwsh"];
 
 pub fn run(args: UninstallArgs, home: &Path, user_home: &Path) -> Result<()> {
     if runtime::is_non_interactive() && !args.yes && !args.dry_run {

--- a/src/commands/workspace.rs
+++ b/src/commands/workspace.rs
@@ -1,0 +1,403 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde_json::json;
+
+use crate::cli::{
+    WorkspaceArgs, WorkspaceBindArgs, WorkspaceCheckArgs, WorkspaceCommand, WorkspaceDoctorArgs,
+    WorkspaceGuardArgs, WorkspaceGuardMode, WorkspaceStatusArgs,
+};
+use crate::config::ConfigStore;
+use crate::output;
+use crate::types::Tool;
+use crate::workspace::{
+    collect_workspace_status, detect_repo, guard_mode, load_repo_local_config,
+    normalize_remote_pattern, repo_local_config_path, save_repo_local_config,
+    validate_context_exists, GitRemoteRule, GuardMode, PathRule, WorkspaceConfig, WorkspaceState,
+    WorkspaceStore,
+};
+
+pub fn run(args: WorkspaceArgs, home: &Path) -> Result<()> {
+    match args.command {
+        WorkspaceCommand::Bind(args) => bind(args, home),
+        WorkspaceCommand::Status(args) => status(args, home),
+        WorkspaceCommand::Doctor(args) => doctor(args, home),
+        WorkspaceCommand::Guard(args) => guard(args, home),
+        WorkspaceCommand::Check(args) => check(args, home),
+    }
+}
+
+fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
+    let config = ConfigStore::new(home).load()?;
+    validate_context_exists(&config, &args.context)?;
+
+    if args.default {
+        let store = WorkspaceStore::new(home);
+        let mut workspace_config = store.load()?;
+        workspace_config.default_context = Some(args.context.clone());
+        store.save(&workspace_config)?;
+
+        output::print_title("Updated workspace default");
+        output::print_kv("Context", &args.context);
+        output::print_effects_header();
+        output::print_effect("Default workspace context saved.");
+        return Ok(());
+    }
+
+    if let Some(pattern) = args.git_remote.as_deref() {
+        let store = WorkspaceStore::new(home);
+        let mut workspace_config = store.load()?;
+        let normalized = normalize_remote_pattern(pattern);
+        upsert_git_remote_rule(&mut workspace_config, &normalized, &args.context);
+        store.save(&workspace_config)?;
+
+        output::print_title("Bound workspace remote");
+        output::print_kv("Pattern", &normalized);
+        output::print_kv("Context", &args.context);
+        output::print_effects_header();
+        output::print_effect("Remote workspace rule saved.");
+        return Ok(());
+    }
+
+    let target = args.path.as_deref().unwrap_or(".");
+    let path = resolve_target_path(target)?;
+    if let Some(repo) = detect_repo(&path)? {
+        save_repo_local_config(&repo, &args.context)?;
+        output::print_title("Bound workspace repo");
+        output::print_kv("Repo", repo.root.display().to_string());
+        output::print_kv(
+            "Config",
+            repo_local_config_path(&repo).display().to_string(),
+        );
+        output::print_kv("Context", &args.context);
+        output::print_effects_header();
+        output::print_effect("Repo-local workspace binding saved.");
+        return Ok(());
+    }
+
+    let store = WorkspaceStore::new(home);
+    let mut workspace_config = store.load()?;
+    upsert_path_rule(
+        &mut workspace_config,
+        &path.display().to_string(),
+        &args.context,
+    );
+    store.save(&workspace_config)?;
+
+    output::print_title("Bound workspace path");
+    output::print_kv("Path", path.display().to_string());
+    output::print_kv("Context", &args.context);
+    output::print_effects_header();
+    output::print_effect("User workspace path rule saved.");
+    Ok(())
+}
+
+fn status(args: WorkspaceStatusArgs, home: &Path) -> Result<()> {
+    let cwd = std::env::current_dir().context("could not determine current directory")?;
+    let status = collect_workspace_status(home, &cwd)?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "workspace": status.workspace,
+                "repo_root": status.repo_root,
+                "matched_rule": status.matched_rule,
+                "expected_context": status.expected_context,
+                "active_context": status.active_context,
+                "active_profiles": {
+                    "claude": status.active_profiles.get(&Tool::Claude).cloned().flatten(),
+                    "codex": status.active_profiles.get(&Tool::Codex).cloned().flatten(),
+                    "gemini": status.active_profiles.get(&Tool::Gemini).cloned().flatten(),
+                },
+                "status": status.status.as_str(),
+                "recommended_command": status.recommended_command,
+            }))?
+        );
+        return Ok(());
+    }
+
+    output::print_title("Workspace");
+    output::print_kv("Workspace", status.workspace.display().to_string());
+    if let Some(repo_root) = status.repo_root.as_ref() {
+        output::print_kv("Repo root", repo_root.display().to_string());
+    }
+    output::print_kv(
+        "Expected",
+        status.expected_context.as_deref().unwrap_or("none"),
+    );
+    output::print_kv("Active", active_profiles_summary(&status.active_profiles));
+    if let Some(active_context) = status.active_context.as_deref() {
+        output::print_kv("Active context", active_context);
+    }
+    output::print_kv("Status", status.status.as_str());
+    if let Some(rule) = status.matched_rule.as_deref() {
+        output::print_kv("Matched rule", rule);
+    }
+    if let Some(command) = status.recommended_command.as_deref() {
+        output::print_kv("Action", command);
+    }
+    Ok(())
+}
+
+fn doctor(args: WorkspaceDoctorArgs, home: &Path) -> Result<()> {
+    let cwd = std::env::current_dir().context("could not determine current directory")?;
+    let store = WorkspaceStore::new(home);
+    let config = store.load()?;
+    let main_config = ConfigStore::new(home).load()?;
+    let repo = detect_repo(&cwd)?;
+    let mut checks = Vec::new();
+
+    checks.push(doctor_check(
+        "workspace config",
+        if store.path().exists() {
+            "pass"
+        } else {
+            "warn"
+        },
+        if store.path().exists() {
+            format!("Loaded {}", store.path().display())
+        } else {
+            format!("{} not found; using defaults", store.path().display())
+        },
+    ));
+
+    for rule in &config.path_rules {
+        let status = if main_config.context(&rule.context).is_some() {
+            "pass"
+        } else {
+            "fail"
+        };
+        checks.push(doctor_check(
+            &format!("path rule {}", rule.path),
+            status,
+            format!("context={}", rule.context),
+        ));
+    }
+
+    for rule in &config.git_remote_rules {
+        let status = if main_config.context(&rule.context).is_some() {
+            "pass"
+        } else {
+            "fail"
+        };
+        checks.push(doctor_check(
+            &format!("remote rule {}", rule.pattern),
+            status,
+            format!("context={}", rule.context),
+        ));
+    }
+
+    if let Some(default_context) = config.default_context.as_deref() {
+        checks.push(doctor_check(
+            "default context",
+            if main_config.context(default_context).is_some() {
+                "pass"
+            } else {
+                "fail"
+            },
+            default_context.to_owned(),
+        ));
+    }
+
+    if let Some(repo) = repo.as_ref() {
+        match load_repo_local_config(repo)? {
+            Some(local) => checks.push(doctor_check(
+                "repo-local config",
+                if main_config.context(&local.context).is_some() {
+                    "pass"
+                } else {
+                    "fail"
+                },
+                format!(
+                    "{} -> {}",
+                    repo_local_config_path(repo).display(),
+                    local.context
+                ),
+            )),
+            None => checks.push(doctor_check(
+                "repo-local config",
+                "warn",
+                "not set for current repo".to_owned(),
+            )),
+        }
+    }
+
+    let workspace_status = collect_workspace_status(home, &cwd)?;
+    let status_level = match workspace_status.status {
+        WorkspaceState::Match => "pass",
+        WorkspaceState::NoExpectedContext => "warn",
+        WorkspaceState::InvalidContext => "fail",
+        WorkspaceState::Mismatch | WorkspaceState::AmbiguousActive | WorkspaceState::Unmanaged => {
+            "warn"
+        }
+    };
+    checks.push(doctor_check(
+        "current workspace",
+        status_level,
+        format!(
+            "status={}, expected={}, active={}",
+            workspace_status.status.as_str(),
+            workspace_status
+                .expected_context
+                .as_deref()
+                .unwrap_or("none"),
+            workspace_status.active_context.as_deref().unwrap_or("none")
+        ),
+    ));
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "checks": checks }))?
+        );
+        return Ok(());
+    }
+
+    output::print_title("Workspace doctor");
+    for check in checks {
+        output::print_kv(&format!("{} [{}]", check.name, check.status), check.message);
+    }
+    Ok(())
+}
+
+fn guard(args: WorkspaceGuardArgs, home: &Path) -> Result<()> {
+    let store = WorkspaceStore::new(home);
+    let mut config = store.load()?;
+    config.guard_mode = match args.mode {
+        WorkspaceGuardMode::Warn => GuardMode::Warn,
+        WorkspaceGuardMode::Strict => GuardMode::Strict,
+    };
+    store.save(&config)?;
+
+    output::print_title("Updated workspace guard");
+    output::print_kv("Mode", config.guard_mode.display_name());
+    output::print_effects_header();
+    output::print_effect("Default workspace guard mode saved.");
+    Ok(())
+}
+
+fn check(args: WorkspaceCheckArgs, home: &Path) -> Result<()> {
+    let mode = guard_mode(home)?;
+    let cwd = std::env::current_dir().context("could not determine current directory")?;
+    let status = collect_workspace_status(home, &cwd)?;
+
+    if matches!(
+        status.status,
+        WorkspaceState::Match | WorkspaceState::NoExpectedContext
+    ) {
+        return Ok(());
+    }
+
+    let expected = status.expected_context.as_deref().unwrap_or("none");
+    let action = status
+        .recommended_command
+        .as_deref()
+        .unwrap_or("aisw workspace status");
+    let active = status
+        .active_context
+        .clone()
+        .unwrap_or_else(|| active_profiles_summary(&status.active_profiles));
+
+    let tool_label = args
+        .tool
+        .map(|tool| tool.display_name().to_owned())
+        .unwrap_or_else(|| "agent".to_owned());
+
+    if args.prompt {
+        output::print_warning_stderr(format!(
+            "Workspace guard: expected context '{expected}', current state '{active}' ({status}). Run '{action}'.",
+            status = status.status.as_str()
+        ));
+        return Ok(());
+    }
+
+    match mode {
+        GuardMode::Warn => {
+            output::print_warning_stderr(format!(
+                "Workspace guard warning: expected context '{expected}', current state '{active}' ({status}). Run '{action}' before launching {tool_label}.",
+                status = status.status.as_str()
+            ));
+            Ok(())
+        }
+        GuardMode::Strict => {
+            bail!(
+                "workspace guard refused to launch {}.\n  Expected context: '{}'\n  Current state: '{}'\n  Status: {}\n  Run '{}'.",
+                tool_label,
+                expected,
+                active,
+                status.status.as_str(),
+                action
+            )
+        }
+    }
+}
+
+fn resolve_target_path(raw: &str) -> Result<PathBuf> {
+    let path = Path::new(raw);
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(std::env::current_dir()
+        .context("could not determine current directory")?
+        .join(path))
+}
+
+fn upsert_path_rule(config: &mut WorkspaceConfig, path: &str, context: &str) {
+    if let Some(existing) = config.path_rules.iter_mut().find(|rule| rule.path == path) {
+        existing.context = context.to_owned();
+    } else {
+        config.path_rules.push(PathRule {
+            path: path.to_owned(),
+            context: context.to_owned(),
+        });
+    }
+}
+
+fn upsert_git_remote_rule(config: &mut WorkspaceConfig, pattern: &str, context: &str) {
+    if let Some(existing) = config
+        .git_remote_rules
+        .iter_mut()
+        .find(|rule| rule.pattern == pattern)
+    {
+        existing.context = context.to_owned();
+    } else {
+        config.git_remote_rules.push(GitRemoteRule {
+            pattern: pattern.to_owned(),
+            context: context.to_owned(),
+        });
+    }
+}
+
+fn active_profiles_summary(
+    active_profiles: &std::collections::HashMap<Tool, Option<String>>,
+) -> String {
+    Tool::ALL
+        .iter()
+        .map(|tool| {
+            format!(
+                "{} {}",
+                tool.binary_name(),
+                active_profiles
+                    .get(tool)
+                    .and_then(|value| value.as_deref())
+                    .unwrap_or("none")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[derive(serde::Serialize)]
+struct DoctorCheck {
+    name: String,
+    status: &'static str,
+    message: String,
+}
+
+fn doctor_check(name: &str, status: &'static str, message: String) -> DoctorCheck {
+    DoctorCheck {
+        name: name.to_owned(),
+        status,
+        message,
+    }
+}

--- a/src/commands/workspace.rs
+++ b/src/commands/workspace.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 
 use crate::cli::{
     WorkspaceArgs, WorkspaceBindArgs, WorkspaceCheckArgs, WorkspaceCommand, WorkspaceDoctorArgs,
-    WorkspaceGuardArgs, WorkspaceGuardMode, WorkspaceStatusArgs,
+    WorkspaceGuardArgs, WorkspaceStatusArgs,
 };
 use crate::config::ConfigStore;
 use crate::output;
@@ -263,10 +263,7 @@ fn doctor(args: WorkspaceDoctorArgs, home: &Path) -> Result<()> {
 fn guard(args: WorkspaceGuardArgs, home: &Path) -> Result<()> {
     let store = WorkspaceStore::new(home);
     let mut config = store.load()?;
-    config.guard_mode = match args.mode {
-        WorkspaceGuardMode::Warn => GuardMode::Warn,
-        WorkspaceGuardMode::Strict => GuardMode::Strict,
-    };
+    config.guard_mode = GuardMode::from(args.mode);
     store.save(&config)?;
 
     output::print_title("Updated workspace guard");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod terminal;
 pub mod tool_detection;
 pub mod types;
 pub mod util;
+pub mod workspace;
 
 /// Serializes child-process spawning across all unit tests.
 ///

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,629 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::commands::status::{collect_status, derive_context_status, DerivedContextStatus};
+use crate::config::{Config, ConfigStore};
+use crate::types::Tool;
+
+const WORKSPACES_VERSION: u32 = 1;
+const WORKSPACES_FILE: &str = "workspaces.json";
+const REPO_LOCAL_FILE: &str = "aisw.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct WorkspaceConfig {
+    #[serde(default = "workspace_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub guard_mode: GuardMode,
+    pub default_context: Option<String>,
+    #[serde(default)]
+    pub path_rules: Vec<PathRule>,
+    #[serde(default)]
+    pub git_remote_rules: Vec<GitRemoteRule>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct RepoLocalWorkspaceConfig {
+    #[serde(default = "workspace_version")]
+    pub version: u32,
+    pub context: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathRule {
+    pub path: String,
+    pub context: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GitRemoteRule {
+    pub pattern: String,
+    pub context: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, clap::ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardMode {
+    #[default]
+    Warn,
+    Strict,
+}
+
+impl GuardMode {
+    pub fn display_name(self) -> &'static str {
+        match self {
+            GuardMode::Warn => "warn",
+            GuardMode::Strict => "strict",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoInfo {
+    pub root: PathBuf,
+    pub git_dir: PathBuf,
+    pub remotes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceBinding {
+    pub workspace: PathBuf,
+    pub repo_root: Option<PathBuf>,
+    pub expected_context: Option<String>,
+    pub matched_rule: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceStatus {
+    pub workspace: PathBuf,
+    pub repo_root: Option<PathBuf>,
+    pub matched_rule: Option<String>,
+    pub expected_context: Option<String>,
+    pub active_context: Option<String>,
+    pub active_profiles: HashMap<Tool, Option<String>>,
+    pub status: WorkspaceState,
+    pub recommended_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceState {
+    Match,
+    Mismatch,
+    Unmanaged,
+    InvalidContext,
+    AmbiguousActive,
+    NoExpectedContext,
+}
+
+impl WorkspaceState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            WorkspaceState::Match => "match",
+            WorkspaceState::Mismatch => "mismatch",
+            WorkspaceState::Unmanaged => "unmanaged",
+            WorkspaceState::InvalidContext => "invalid_context",
+            WorkspaceState::AmbiguousActive => "ambiguous_active",
+            WorkspaceState::NoExpectedContext => "no_expected_context",
+        }
+    }
+}
+
+fn workspace_version() -> u32 {
+    WORKSPACES_VERSION
+}
+
+pub struct WorkspaceStore {
+    path: PathBuf,
+}
+
+impl WorkspaceStore {
+    pub fn new(home: &Path) -> Self {
+        Self {
+            path: home.join(WORKSPACES_FILE),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn load(&self) -> Result<WorkspaceConfig> {
+        if !self.path.exists() {
+            return Ok(WorkspaceConfig::default());
+        }
+        let contents = fs::read_to_string(&self.path)
+            .with_context(|| format!("could not read {}", self.path.display()))?;
+        let mut config: WorkspaceConfig = serde_json::from_str(&contents)
+            .with_context(|| format!("could not parse {}", self.path.display()))?;
+        if config.version == 0 {
+            config.version = WORKSPACES_VERSION;
+        }
+        Ok(config)
+    }
+
+    pub fn save(&self, config: &WorkspaceConfig) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("could not create directory {}", parent.display()))?;
+        }
+        let json = serde_json::to_string_pretty(config)?;
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, json).with_context(|| format!("could not write {}", tmp.display()))?;
+        set_file_permissions_600(&tmp)?;
+        fs::rename(&tmp, &self.path)
+            .with_context(|| format!("could not move {}", self.path.display()))?;
+        Ok(())
+    }
+}
+
+pub fn repo_local_config_path(repo: &RepoInfo) -> PathBuf {
+    repo.git_dir.join("info").join(REPO_LOCAL_FILE)
+}
+
+pub fn load_repo_local_config(repo: &RepoInfo) -> Result<Option<RepoLocalWorkspaceConfig>> {
+    let path = repo_local_config_path(repo);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let contents =
+        fs::read_to_string(&path).with_context(|| format!("could not read {}", path.display()))?;
+    let mut config: RepoLocalWorkspaceConfig = serde_json::from_str(&contents)
+        .with_context(|| format!("could not parse {}", path.display()))?;
+    if config.version == 0 {
+        config.version = WORKSPACES_VERSION;
+    }
+    Ok(Some(config))
+}
+
+pub fn save_repo_local_config(repo: &RepoInfo, context: &str) -> Result<()> {
+    let path = repo_local_config_path(repo);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("could not create directory {}", parent.display()))?;
+    }
+    let config = RepoLocalWorkspaceConfig {
+        version: WORKSPACES_VERSION,
+        context: context.to_owned(),
+    };
+    let json = serde_json::to_string_pretty(&config)?;
+    fs::write(&path, json).with_context(|| format!("could not write {}", path.display()))?;
+    set_file_permissions_600(&path)?;
+    Ok(())
+}
+
+pub fn detect_repo(start: &Path) -> Result<Option<RepoInfo>> {
+    let mut current = absolutize(start)?;
+    loop {
+        let dot_git = current.join(".git");
+        if dot_git.is_dir() {
+            return Ok(Some(RepoInfo {
+                root: current.clone(),
+                git_dir: dot_git.clone(),
+                remotes: load_git_remotes(&dot_git)?,
+            }));
+        }
+        if dot_git.is_file() {
+            let git_dir = resolve_gitdir_pointer(&dot_git)?;
+            return Ok(Some(RepoInfo {
+                root: current.clone(),
+                remotes: load_git_remotes(&git_dir)?,
+                git_dir,
+            }));
+        }
+        if !current.pop() {
+            return Ok(None);
+        }
+    }
+}
+
+pub fn resolve_binding(home: &Path, cwd: &Path) -> Result<WorkspaceBinding> {
+    let workspace = absolutize(cwd)?;
+    let repo = detect_repo(&workspace)?;
+    let store = WorkspaceStore::new(home);
+    let config = store.load()?;
+
+    if let Some(repo) = repo.as_ref() {
+        if let Some(local) = load_repo_local_config(repo)? {
+            return Ok(WorkspaceBinding {
+                workspace,
+                repo_root: Some(repo.root.clone()),
+                expected_context: Some(local.context),
+                matched_rule: Some(format!(
+                    "repo_local:{}",
+                    repo_local_config_path(repo).display()
+                )),
+            });
+        }
+    }
+
+    let canonical_workspace = fs::canonicalize(&workspace).unwrap_or_else(|_| workspace.clone());
+    if let Some(rule) = find_matching_path_rule(&config.path_rules, &canonical_workspace)? {
+        return Ok(WorkspaceBinding {
+            workspace,
+            repo_root: repo.as_ref().map(|r| r.root.clone()),
+            expected_context: Some(rule.context.clone()),
+            matched_rule: Some(format!("path:{}", rule.path)),
+        });
+    }
+
+    if let Some(repo) = repo.as_ref() {
+        if let Some(rule) = find_matching_remote_rule(&config.git_remote_rules, &repo.remotes) {
+            return Ok(WorkspaceBinding {
+                workspace,
+                repo_root: Some(repo.root.clone()),
+                expected_context: Some(rule.context.clone()),
+                matched_rule: Some(format!("git_remote:{}", rule.pattern)),
+            });
+        }
+    }
+
+    if let Some(default_context) = config.default_context.clone() {
+        return Ok(WorkspaceBinding {
+            workspace,
+            repo_root: repo.as_ref().map(|r| r.root.clone()),
+            expected_context: Some(default_context),
+            matched_rule: Some("default".to_owned()),
+        });
+    }
+
+    Ok(WorkspaceBinding {
+        workspace,
+        repo_root: repo.as_ref().map(|r| r.root.clone()),
+        expected_context: None,
+        matched_rule: None,
+    })
+}
+
+pub fn collect_workspace_status(home: &Path, cwd: &Path) -> Result<WorkspaceStatus> {
+    let binding = resolve_binding(home, cwd)?;
+    let config_store = ConfigStore::new(home);
+    let config = config_store.load()?;
+    let user_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let statuses = collect_status(
+        home,
+        &user_home,
+        &std::env::var_os("PATH").unwrap_or_default(),
+    )?;
+    let context_status = derive_context_status(&config, &statuses);
+    let active_profiles = Tool::ALL
+        .iter()
+        .map(|tool| {
+            (
+                *tool,
+                statuses
+                    .iter()
+                    .find(|status| status.tool == *tool)
+                    .and_then(|status| status.active_profile.clone()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    let status = classify_workspace_state(&config, &binding, &active_profiles, &context_status);
+    let recommended_command = match status {
+        WorkspaceState::Mismatch | WorkspaceState::AmbiguousActive | WorkspaceState::Unmanaged => {
+            binding
+                .expected_context
+                .as_ref()
+                .map(|expected| format!("aisw context use {expected}"))
+        }
+        _ => None,
+    };
+
+    Ok(WorkspaceStatus {
+        workspace: binding.workspace,
+        repo_root: binding.repo_root,
+        matched_rule: binding.matched_rule,
+        expected_context: binding.expected_context,
+        active_context: context_status.active.clone(),
+        active_profiles,
+        status,
+        recommended_command,
+    })
+}
+
+pub fn context_matches_active(
+    config: &Config,
+    context_name: &str,
+    active_profiles: &HashMap<Tool, Option<String>>,
+) -> bool {
+    let Some(context) = config.context(context_name) else {
+        return false;
+    };
+    let total = context.profiles.iter().count();
+    total > 0
+        && context.profiles.iter().all(|(tool, profile)| {
+            active_profiles
+                .get(&tool)
+                .and_then(|value| value.as_deref())
+                == Some(profile)
+        })
+}
+
+pub fn guard_mode(home: &Path) -> Result<GuardMode> {
+    Ok(WorkspaceStore::new(home).load()?.guard_mode)
+}
+
+fn classify_workspace_state(
+    config: &Config,
+    binding: &WorkspaceBinding,
+    active_profiles: &HashMap<Tool, Option<String>>,
+    context_status: &DerivedContextStatus,
+) -> WorkspaceState {
+    let Some(expected_context) = binding.expected_context.as_deref() else {
+        return WorkspaceState::NoExpectedContext;
+    };
+    if config.context(expected_context).is_none() {
+        return WorkspaceState::InvalidContext;
+    }
+    if context_matches_active(config, expected_context, active_profiles) {
+        return WorkspaceState::Match;
+    }
+    if context_status.status == "ambiguous" {
+        return WorkspaceState::AmbiguousActive;
+    }
+    if active_profiles.values().all(|profile| profile.is_none()) {
+        return WorkspaceState::Unmanaged;
+    }
+    WorkspaceState::Mismatch
+}
+
+fn find_matching_path_rule<'a>(
+    rules: &'a [PathRule],
+    workspace: &Path,
+) -> Result<Option<&'a PathRule>> {
+    let mut best: Option<(&PathRule, usize)> = None;
+    for rule in rules {
+        let path = expand_tilde(Path::new(&rule.path))?;
+        let abs = absolutize(&path)?;
+        let candidate = fs::canonicalize(&abs).unwrap_or(abs);
+        if is_path_prefix(&candidate, workspace) {
+            let score = candidate.components().count();
+            match best {
+                Some((_, best_score)) if best_score >= score => {}
+                _ => best = Some((rule, score)),
+            }
+        }
+    }
+    Ok(best.map(|(rule, _)| rule))
+}
+
+fn find_matching_remote_rule<'a>(
+    rules: &'a [GitRemoteRule],
+    remotes: &[String],
+) -> Option<&'a GitRemoteRule> {
+    let mut best: Option<(&GitRemoteRule, usize, usize)> = None;
+    for (rule_index, rule) in rules.iter().enumerate() {
+        let pattern = normalize_remote_pattern(&rule.pattern);
+        if remotes
+            .iter()
+            .any(|remote| wildcard_match(&pattern, remote))
+        {
+            let specificity = pattern.chars().filter(|ch| *ch != '*').count();
+            match best {
+                Some((_, best_specificity, best_index))
+                    if best_specificity > specificity
+                        || (best_specificity == specificity && best_index < rule_index) => {}
+                _ => best = Some((rule, specificity, rule_index)),
+            }
+        }
+    }
+    best.map(|(rule, _, _)| rule)
+}
+
+pub fn normalize_remote_pattern(pattern: &str) -> String {
+    normalize_remote_like(pattern)
+}
+
+pub fn normalize_remote(url: &str) -> String {
+    normalize_remote_like(url)
+}
+
+fn normalize_remote_like(input: &str) -> String {
+    let trimmed = input.trim();
+    let without_scheme = if let Some(rest) = trimmed.strip_prefix("ssh://") {
+        rest
+    } else if let Some(rest) = trimmed.strip_prefix("https://") {
+        rest
+    } else if let Some(rest) = trimmed.strip_prefix("http://") {
+        rest
+    } else if let Some(rest) = trimmed.strip_prefix("git://") {
+        rest
+    } else {
+        trimmed
+    };
+
+    let without_user = without_scheme
+        .strip_prefix("git@")
+        .or_else(|| without_scheme.strip_prefix("ssh@"))
+        .unwrap_or(without_scheme);
+
+    let normalized = if let Some((host, path)) = without_user.split_once(':') {
+        format!("{host}/{path}")
+    } else {
+        without_user.to_owned()
+    };
+
+    normalized
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .to_ascii_lowercase()
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+    let p = pattern.as_bytes();
+    let v = value.as_bytes();
+    let (mut pi, mut vi) = (0usize, 0usize);
+    let (mut star, mut match_i) = (None, 0usize);
+    while vi < v.len() {
+        if pi < p.len() && p[pi] == v[vi] {
+            pi += 1;
+            vi += 1;
+        } else if pi < p.len() && p[pi] == b'*' {
+            star = Some(pi);
+            pi += 1;
+            match_i = vi;
+        } else if let Some(star_idx) = star {
+            pi = star_idx + 1;
+            match_i += 1;
+            vi = match_i;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() && p[pi] == b'*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
+fn load_git_remotes(git_dir: &Path) -> Result<Vec<String>> {
+    let config_path = git_dir.join("config");
+    if !config_path.exists() {
+        return Ok(Vec::new());
+    }
+    let contents = fs::read_to_string(&config_path)
+        .with_context(|| format!("could not read {}", config_path.display()))?;
+    let mut current_remote: Option<String> = None;
+    let mut remotes = Vec::new();
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("[remote \"") && trimmed.ends_with("\"]") {
+            current_remote = Some(trimmed.to_owned());
+            continue;
+        }
+        if !trimmed.starts_with("url") {
+            continue;
+        }
+        if current_remote.is_none() {
+            continue;
+        }
+        let Some((_, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        remotes.push(normalize_remote(value.trim()));
+    }
+    Ok(remotes)
+}
+
+fn resolve_gitdir_pointer(dot_git_file: &Path) -> Result<PathBuf> {
+    let contents = fs::read_to_string(dot_git_file)
+        .with_context(|| format!("could not read {}", dot_git_file.display()))?;
+    let raw = contents
+        .trim()
+        .strip_prefix("gitdir:")
+        .map(str::trim)
+        .ok_or_else(|| anyhow!("invalid gitdir pointer in {}", dot_git_file.display()))?;
+    let git_dir = PathBuf::from(raw);
+    if git_dir.is_absolute() {
+        Ok(git_dir)
+    } else {
+        Ok(dot_git_file
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(git_dir))
+    }
+}
+
+pub fn expand_tilde(path: &Path) -> Result<PathBuf> {
+    let mut components = path.components();
+    match components.next() {
+        Some(Component::Normal(first)) if first == "~" => {
+            let home = dirs::home_dir().context("could not determine home directory")?;
+            let mut expanded = home;
+            for component in components {
+                expanded.push(component.as_os_str());
+            }
+            Ok(expanded)
+        }
+        _ => Ok(path.to_path_buf()),
+    }
+}
+
+fn absolutize(path: &Path) -> Result<PathBuf> {
+    let expanded = expand_tilde(path)?;
+    if expanded.is_absolute() {
+        return Ok(expanded);
+    }
+    Ok(std::env::current_dir()
+        .context("could not determine current directory")?
+        .join(expanded))
+}
+
+fn is_path_prefix(prefix: &Path, value: &Path) -> bool {
+    let prefix_components = prefix.components().collect::<Vec<_>>();
+    let value_components = value.components().collect::<Vec<_>>();
+    prefix_components.len() <= value_components.len()
+        && prefix_components
+            .iter()
+            .zip(value_components.iter())
+            .all(|(a, b)| a == b)
+}
+
+fn set_file_permissions_600(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(path, perms)
+            .with_context(|| format!("could not set permissions on {}", path.display()))?;
+    }
+    #[cfg(windows)]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+pub fn validate_context_exists(config: &Config, name: &str) -> Result<()> {
+    if config.context(name).is_none() {
+        bail!(
+            "context '{}' not found.\n  Create it first with: aisw context create {} --claude <profile>",
+            name,
+            name
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_remote_variants() {
+        assert_eq!(
+            normalize_remote("git@github.com:acme/api.git"),
+            "github.com/acme/api"
+        );
+        assert_eq!(
+            normalize_remote("https://github.com/acme/api.git"),
+            "github.com/acme/api"
+        );
+        assert_eq!(
+            normalize_remote("ssh://git@github.com/acme/api.git"),
+            "github.com/acme/api"
+        );
+    }
+
+    #[test]
+    fn wildcard_matching_handles_single_star() {
+        assert!(wildcard_match("github.com/acme/*", "github.com/acme/api"));
+        assert!(!wildcard_match("github.com/acme/*", "github.com/other/api"));
+    }
+
+    #[test]
+    fn path_prefix_matching_is_component_aware() {
+        assert!(is_path_prefix(
+            Path::new("/tmp/work"),
+            Path::new("/tmp/work/api")
+        ));
+        assert!(!is_path_prefix(
+            Path::new("/tmp/work"),
+            Path::new("/tmp/workbench")
+        ));
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -62,6 +62,15 @@ impl GuardMode {
     }
 }
 
+impl From<crate::cli::WorkspaceGuardMode> for GuardMode {
+    fn from(mode: crate::cli::WorkspaceGuardMode) -> Self {
+        match mode {
+            crate::cli::WorkspaceGuardMode::Warn => GuardMode::Warn,
+            crate::cli::WorkspaceGuardMode::Strict => GuardMode::Strict,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepoInfo {
     pub root: PathBuf,
@@ -362,7 +371,7 @@ fn classify_workspace_state(
     if context_matches_active(config, expected_context, active_profiles) {
         return WorkspaceState::Match;
     }
-    if context_status.status == "ambiguous" {
+    if context_status.is_ambiguous() {
         return WorkspaceState::AmbiguousActive;
     }
     if active_profiles.values().all(|profile| profile.is_none()) {
@@ -487,18 +496,15 @@ fn load_git_remotes(git_dir: &Path) -> Result<Vec<String>> {
     }
     let contents = fs::read_to_string(&config_path)
         .with_context(|| format!("could not read {}", config_path.display()))?;
-    let mut current_remote: Option<String> = None;
+    let mut in_remote_section = false;
     let mut remotes = Vec::new();
     for line in contents.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with("[remote \"") && trimmed.ends_with("\"]") {
-            current_remote = Some(trimmed.to_owned());
+        if trimmed.starts_with('[') {
+            in_remote_section = trimmed.starts_with("[remote \"") && trimmed.ends_with("\"]");
             continue;
         }
-        if !trimmed.starts_with("url") {
-            continue;
-        }
-        if current_remote.is_none() {
+        if !in_remote_section || !trimmed.starts_with("url") {
             continue;
         }
         let Some((_, value)) = trimmed.split_once('=') else {
@@ -661,6 +667,28 @@ mod tests {
         fs::write(
             git_dir.join("config"),
             "[core]\n\trepositoryformatversion = 0\nurl = https://example.com/ignored.git\n[remote \"origin\"]\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n\turl = git@github.com:acme/api.git\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            load_git_remotes(&git_dir).unwrap(),
+            vec![String::from("github.com/acme/api")]
+        );
+    }
+
+    #[test]
+    fn load_git_remotes_does_not_leak_url_from_non_remote_section_after_remote() {
+        let temp = TempDir::new().unwrap();
+        let git_dir = temp.path().join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            concat!(
+                "[remote \"origin\"]\n",
+                "\turl = git@github.com:acme/api.git\n",
+                "[branch \"main\"]\n",
+                "\turl = https://should-be-ignored.example.com/repo.git\n",
+            ),
         )
         .unwrap();
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -592,6 +592,9 @@ pub fn validate_context_exists(config: &Config, name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{ContextEntry, ContextProfiles};
+    use std::env;
+    use tempfile::TempDir;
 
     #[test]
     fn normalize_remote_variants() {
@@ -625,5 +628,142 @@ mod tests {
             Path::new("/tmp/work"),
             Path::new("/tmp/workbench")
         ));
+    }
+
+    #[test]
+    fn remote_rule_prefers_more_specific_pattern_then_first_defined() {
+        let rules = vec![
+            GitRemoteRule {
+                pattern: "github.com/acme/*".to_owned(),
+                context: "broad".to_owned(),
+            },
+            GitRemoteRule {
+                pattern: "github.com/acme/api".to_owned(),
+                context: "specific".to_owned(),
+            },
+            GitRemoteRule {
+                pattern: "github.com/acme/api".to_owned(),
+                context: "same-specificity-later".to_owned(),
+            },
+        ];
+
+        let matched = find_matching_remote_rule(&rules, &[String::from("github.com/acme/api")])
+            .expect("rule should match");
+        assert_eq!(matched.context, "specific");
+    }
+
+    #[test]
+    fn load_git_remotes_ignores_non_remote_urls_and_missing_config() {
+        let temp = TempDir::new().unwrap();
+        let git_dir = temp.path().join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        assert!(load_git_remotes(&git_dir).unwrap().is_empty());
+
+        fs::write(
+            git_dir.join("config"),
+            "[core]\n\trepositoryformatversion = 0\nurl = https://example.com/ignored.git\n[remote \"origin\"]\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n\turl = git@github.com:acme/api.git\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            load_git_remotes(&git_dir).unwrap(),
+            vec![String::from("github.com/acme/api")]
+        );
+    }
+
+    #[test]
+    fn resolve_gitdir_pointer_supports_relative_and_absolute_paths() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path().join("repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        let dot_git = repo_root.join(".git");
+        fs::write(&dot_git, "gitdir: ../actual.git\n").unwrap();
+        assert_eq!(
+            resolve_gitdir_pointer(&dot_git).unwrap(),
+            repo_root.join("../actual.git")
+        );
+
+        let absolute = temp.path().join("absolute.git");
+        fs::write(&dot_git, format!("gitdir: {}\n", absolute.display())).unwrap();
+        assert_eq!(resolve_gitdir_pointer(&dot_git).unwrap(), absolute);
+    }
+
+    #[test]
+    fn expand_tilde_expands_home_and_leaves_plain_paths_unchanged() {
+        let temp = TempDir::new().unwrap();
+        let original_home = env::var_os("HOME");
+        env::set_var("HOME", temp.path());
+
+        let expanded = expand_tilde(Path::new("~/clients/acme")).unwrap();
+        assert_eq!(expanded, temp.path().join("clients").join("acme"));
+        assert_eq!(
+            expand_tilde(Path::new("relative/path")).unwrap(),
+            PathBuf::from("relative/path")
+        );
+
+        match original_home {
+            Some(value) => env::set_var("HOME", value),
+            None => env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    fn classify_workspace_state_covers_invalid_ambiguous_and_unmanaged() {
+        let mut config = Config::default();
+        let mut profiles = ContextProfiles::default();
+        profiles.insert(Tool::Claude, "work");
+        config.contexts.entries_mut().insert(
+            "client-acme".to_owned(),
+            ContextEntry::new(profiles, chrono::Utc::now()),
+        );
+
+        let invalid_binding = WorkspaceBinding {
+            workspace: PathBuf::from("/tmp/project"),
+            repo_root: None,
+            expected_context: Some("missing".to_owned()),
+            matched_rule: None,
+        };
+        let empty_profiles = HashMap::from([
+            (Tool::Claude, None),
+            (Tool::Codex, None),
+            (Tool::Gemini, None),
+        ]);
+        let ambiguous = DerivedContextStatus {
+            status: "ambiguous",
+            active: Some("other".to_owned()),
+            matches: vec!["client-acme".to_owned()],
+            drift_candidates: vec![],
+            mapped_profiles: None,
+            unmanaged_tools: vec![],
+        };
+        assert_eq!(
+            classify_workspace_state(&config, &invalid_binding, &empty_profiles, &ambiguous),
+            WorkspaceState::InvalidContext
+        );
+
+        let valid_binding = WorkspaceBinding {
+            workspace: PathBuf::from("/tmp/project"),
+            repo_root: None,
+            expected_context: Some("client-acme".to_owned()),
+            matched_rule: None,
+        };
+        assert_eq!(
+            classify_workspace_state(&config, &valid_binding, &empty_profiles, &ambiguous),
+            WorkspaceState::AmbiguousActive
+        );
+
+        let unmanaged = DerivedContextStatus {
+            status: "unmanaged",
+            active: None,
+            matches: vec![],
+            drift_candidates: vec![],
+            mapped_profiles: None,
+            unmanaged_tools: vec![],
+        };
+        assert_eq!(
+            classify_workspace_state(&config, &valid_binding, &empty_profiles, &unmanaged),
+            WorkspaceState::Unmanaged
+        );
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -593,7 +593,6 @@ pub fn validate_context_exists(config: &Config, name: &str) -> Result<()> {
 mod tests {
     use super::*;
     use crate::config::{ContextEntry, ContextProfiles};
-    use std::env;
     use tempfile::TempDir;
 
     #[test]
@@ -691,21 +690,14 @@ mod tests {
 
     #[test]
     fn expand_tilde_expands_home_and_leaves_plain_paths_unchanged() {
-        let temp = TempDir::new().unwrap();
-        let original_home = env::var_os("HOME");
-        env::set_var("HOME", temp.path());
-
+        let _temp = TempDir::new().unwrap();
+        let home = dirs::home_dir().expect("home directory should be available");
         let expanded = expand_tilde(Path::new("~/clients/acme")).unwrap();
-        assert_eq!(expanded, temp.path().join("clients").join("acme"));
+        assert_eq!(expanded, home.join("clients").join("acme"));
         assert_eq!(
             expand_tilde(Path::new("relative/path")).unwrap(),
             PathBuf::from("relative/path")
         );
-
-        match original_home {
-            Some(value) => env::set_var("HOME", value),
-            None => env::remove_var("HOME"),
-        }
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -230,6 +230,7 @@ impl TestEnv {
                 cmd.arg("--no-config");
                 cmd
             }
+            "pwsh" => StdCommand::new("pwsh"),
             _ => panic!("unsupported shell: {shell}"),
         };
 
@@ -251,7 +252,13 @@ impl TestEnv {
 
     pub fn run_shell_script(&self, shell: &str, script: &str) -> Option<Output> {
         let mut cmd = self.shell_cmd(shell)?;
-        cmd.args(["-c", script]).output().ok()
+        match shell {
+            "pwsh" => cmd
+                .args(["-NoProfile", "-NonInteractive", "-Command", script])
+                .output()
+                .ok(),
+            _ => cmd.args(["-c", script]).output().ok(),
+        }
     }
 
     /// Convenience: path to a file inside AISW_HOME.

--- a/tests/shell_hook_cmd.rs
+++ b/tests/shell_hook_cmd.rs
@@ -24,17 +24,36 @@ fn hook_output(shell: &str) -> Vec<u8> {
 }
 
 fn try_syntax_check(binary: &str, source: &[u8]) -> Option<bool> {
-    let mut child = Command::new(binary)
-        .arg(if binary == "fish" {
-            "--no-execute"
-        } else {
-            "-n"
-        })
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
+    let mut child = if binary == "fish" {
+        Command::new(binary)
+            .arg("--no-execute")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?
+    } else if binary == "pwsh" {
+        Command::new(binary)
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "$src = [Console]::In.ReadToEnd(); [scriptblock]::Create($src) | Out-Null",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?
+    } else {
+        Command::new(binary)
+            .arg("-n")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?
+    };
     child.stdin.take().unwrap().write_all(source).unwrap();
     Some(child.wait().unwrap().success())
 }
@@ -225,6 +244,83 @@ printf 'context_gemini=%s\n' "$GEMINI_API_KEY"
     );
 }
 
+fn assert_real_pwsh_shell_hook_behavior() {
+    let env = TestEnv::new();
+    add_codex_profile(&env, "work", VALID_CODEX_KEY);
+    add_codex_profile(&env, "oss", VALID_CODEX_KEY_ALT);
+    add_gemini_api_key_profile(&env, "api");
+    add_gemini_oauth_profile(&env, "oauth");
+
+    let script = r#"
+Invoke-Expression ((command aisw shell-hook pwsh | Out-String))
+Write-Output "sentinel=$env:AISW_SHELL_HOOK"
+aisw use codex work *> $null
+Write-Output "codex_isolated=$env:CODEX_HOME"
+aisw use codex oss --state-mode shared *> $null
+if ($null -eq $env:CODEX_HOME) {
+    Write-Output "codex_shared=__unset__"
+} else {
+    Write-Output "codex_shared=$env:CODEX_HOME"
+}
+aisw use gemini api *> $null
+Write-Output "gemini_api=$env:GEMINI_API_KEY"
+aisw use gemini oauth *> $null
+if ($null -eq $env:GEMINI_API_KEY) {
+    Write-Output "gemini_oauth=__unset__"
+} else {
+    Write-Output "gemini_oauth=$env:GEMINI_API_KEY"
+}
+aisw context create workspace --codex work --gemini api *> $null
+aisw context use workspace *> $null
+Write-Output "context_codex=$env:CODEX_HOME"
+Write-Output "context_gemini=$env:GEMINI_API_KEY"
+"#;
+
+    let Some(output) = env.run_shell_script("pwsh", script) else {
+        return;
+    };
+    assert!(
+        output.status.success(),
+        "pwsh sourced hook script failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected_codex_home = env
+        .aisw_home
+        .join("profiles")
+        .join("codex")
+        .join("work")
+        .display()
+        .to_string();
+    assert!(stdout.contains("sentinel=1"), "stdout:\n{stdout}");
+    assert!(
+        stdout.contains(&format!("codex_isolated={expected_codex_home}")),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("codex_shared=__unset__"),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("gemini_api={VALID_GEMINI_KEY}")),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("gemini_oauth=__unset__"),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("context_codex={expected_codex_home}")),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("context_gemini={VALID_GEMINI_KEY}")),
+        "stdout:\n{stdout}"
+    );
+}
+
 #[test]
 fn shell_hook_bash_exits_zero_with_expected_content() {
     TestEnv::new()
@@ -326,4 +422,29 @@ fn shell_hook_fish_is_valid_syntax() {
 #[test]
 fn shell_hook_fish_updates_environment_in_real_shell() {
     assert_real_fish_shell_hook_behavior();
+}
+
+#[test]
+fn shell_hook_pwsh_exits_zero_with_expected_content() {
+    TestEnv::new()
+        .cmd()
+        .args(["shell-hook", "pwsh"])
+        .assert()
+        .success()
+        .stdout(contains("AISW_SHELL_HOOK"))
+        .stdout(contains("function global:aisw"))
+        .stdout(contains("--emit-env"));
+}
+
+#[test]
+fn shell_hook_pwsh_is_valid_syntax() {
+    let output = hook_output("pwsh");
+    if let Some(ok) = try_syntax_check("pwsh", &output) {
+        assert!(ok, "pwsh reported syntax errors in the hook");
+    }
+}
+
+#[test]
+fn shell_hook_pwsh_updates_environment_in_real_shell() {
+    assert_real_pwsh_shell_hook_behavior();
 }

--- a/tests/shell_hook_cmd.rs
+++ b/tests/shell_hook_cmd.rs
@@ -252,7 +252,7 @@ fn assert_real_pwsh_shell_hook_behavior() {
     add_gemini_oauth_profile(&env, "oauth");
 
     let script = r#"
-Invoke-Expression ((command aisw shell-hook pwsh | Out-String))
+aisw shell-hook pwsh | Out-String | Invoke-Expression
 Write-Output "sentinel=$env:AISW_SHELL_HOOK"
 aisw use codex work *> $null
 Write-Output "codex_isolated=$env:CODEX_HOME"

--- a/tests/workspace_cmd.rs
+++ b/tests/workspace_cmd.rs
@@ -200,6 +200,126 @@ fn workspace_bind_path_outside_repo_updates_user_store() {
 }
 
 #[test]
+fn strict_workspace_guard_blocks_wrapped_claude_before_launch() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let repo = setup_repo(&env, "clients/acme", "git@github.com:acme/api.git");
+    env.add_script_tool(
+        "claude",
+        "#!/bin/sh\nprintf launched > \"$HOME/claude-launched\"\n",
+    );
+
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            repo.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["workspace", "guard", "--mode", "strict"])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["use", "claude", "personal-claude"])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["use", "codex", "personal-codex"])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["use", "gemini", "personal-gemini"])
+        .assert()
+        .success();
+
+    let script = format!(
+        "eval \"$(command aisw shell-hook bash)\"\ncd \"{}\"\nclaude hello\n",
+        repo.join("api").display()
+    );
+    let output = env.run_shell_script("bash", &script).unwrap();
+    assert!(!output.status.success(), "claude launch should be blocked");
+    assert!(
+        !env.fake_home.join("claude-launched").exists(),
+        "wrapped claude should not have executed"
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("workspace guard refused"));
+}
+
+#[test]
+fn strict_workspace_guard_blocks_wrapped_codex_and_gemini_before_launch() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let repo = setup_repo(&env, "clients/acme", "git@github.com:acme/api.git");
+    env.add_script_tool(
+        "codex",
+        "#!/bin/sh\nprintf launched > \"$HOME/codex-launched\"\n",
+    );
+    env.add_script_tool(
+        "gemini",
+        "#!/bin/sh\nprintf launched > \"$HOME/gemini-launched\"\n",
+    );
+
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            repo.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["workspace", "guard", "--mode", "strict"])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["use", "claude", "personal-claude"])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["use", "codex", "personal-codex"])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["use", "gemini", "personal-gemini"])
+        .assert()
+        .success();
+
+    let codex_script = format!(
+        "eval \"$(command aisw shell-hook bash)\"\ncd \"{}\"\ncodex hello\n",
+        repo.join("api").display()
+    );
+    let codex_output = env.run_shell_script("bash", &codex_script).unwrap();
+    assert!(
+        !codex_output.status.success(),
+        "codex launch should be blocked"
+    );
+    assert!(
+        !env.fake_home.join("codex-launched").exists(),
+        "wrapped codex should not have executed"
+    );
+
+    let gemini_script = format!(
+        "eval \"$(command aisw shell-hook bash)\"\ncd \"{}\"\ngemini hello\n",
+        repo.join("api").display()
+    );
+    let gemini_output = env.run_shell_script("bash", &gemini_script).unwrap();
+    assert!(
+        !gemini_output.status.success(),
+        "gemini launch should be blocked"
+    );
+    assert!(
+        !env.fake_home.join("gemini-launched").exists(),
+        "wrapped gemini should not have executed"
+    );
+}
+
+#[test]
 fn workspace_check_warn_mode_allows_launch() {
     let env = TestEnv::new();
     setup_profiles_and_contexts(&env);

--- a/tests/workspace_cmd.rs
+++ b/tests/workspace_cmd.rs
@@ -200,6 +200,33 @@ fn workspace_bind_path_outside_repo_updates_user_store() {
 }
 
 #[test]
+fn workspace_bind_default_and_git_remote_update_user_store() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+
+    env.cmd()
+        .args(["workspace", "bind", "--default", "--context", "client-acme"])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            "--git-remote",
+            "git@github.com:acme/*",
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&env.read_home_file("workspaces.json")).unwrap();
+    assert_eq!(json["default_context"], "client-acme");
+    assert_eq!(json["git_remote_rules"][0]["pattern"], "github.com/acme/*");
+}
+
+#[test]
 fn strict_workspace_guard_blocks_wrapped_claude_before_launch() {
     let env = TestEnv::new();
     setup_profiles_and_contexts(&env);
@@ -346,4 +373,102 @@ fn workspace_check_warn_mode_allows_launch() {
         .assert()
         .success()
         .stderr(contains("Workspace guard warning"));
+}
+
+#[test]
+fn workspace_check_prompt_warns_and_strict_without_tool_uses_agent_label() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let repo = setup_repo(&env, "clients/acme", "git@github.com:acme/api.git");
+
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            repo.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["workspace", "guard", "--mode", "strict"])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["use", "claude", "personal-claude"])
+        .assert()
+        .success();
+
+    env.cmd()
+        .current_dir(repo.join("api"))
+        .args(["workspace", "check", "--prompt"])
+        .assert()
+        .success()
+        .stderr(contains("Workspace guard: expected context"));
+
+    env.cmd()
+        .current_dir(repo.join("api"))
+        .args(["workspace", "check"])
+        .assert()
+        .failure()
+        .stderr(contains("workspace guard refused to launch agent"));
+}
+
+#[test]
+fn workspace_status_human_and_doctor_json_cover_match_and_fail_states() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let repo = setup_repo(&env, "clients/acme", "git@github.com:acme/api.git");
+
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            "--default",
+            "--context",
+            "missing-context",
+        ])
+        .assert()
+        .failure();
+
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            repo.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["context", "use", "client-acme"])
+        .assert()
+        .success();
+
+    env.cmd()
+        .current_dir(repo.join("api"))
+        .args(["workspace", "status"])
+        .assert()
+        .success()
+        .stdout(contains("Active context"))
+        .stdout(contains("Status"))
+        .stdout(contains("match"));
+
+    let doctor_json = env
+        .cmd()
+        .current_dir(repo.join("api"))
+        .args(["workspace", "doctor", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&doctor_json).unwrap();
+    assert!(json["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|check| { check["name"] == "current workspace" && check["status"] == "pass" }));
 }

--- a/tests/workspace_cmd.rs
+++ b/tests/workspace_cmd.rs
@@ -1,0 +1,229 @@
+mod common;
+
+use std::fs;
+
+use common::TestEnv;
+use predicates::str::contains;
+
+const VALID_CLAUDE_WORK: &str = "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const VALID_CLAUDE_PERSONAL: &str = "sk-ant-api03-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const VALID_CODEX_WORK: &str = "sk-codex-test-key-12345";
+const VALID_CODEX_PERSONAL: &str = "sk-codex-test-key-67890";
+const VALID_GEMINI_WORK: &str = "AIzawork1234567890ABCDEF";
+const VALID_GEMINI_PERSONAL: &str = "AIzauser1234567890ABCDEF";
+
+fn setup_profiles_and_contexts(env: &TestEnv) {
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.add_fake_tool("codex", "codex 1.0.0");
+    env.add_fake_tool("gemini", "gemini 0.9.0");
+
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work-claude",
+            "--api-key",
+            VALID_CLAUDE_WORK,
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "personal-claude",
+            "--api-key",
+            VALID_CLAUDE_PERSONAL,
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["add", "codex", "work-codex", "--api-key", VALID_CODEX_WORK])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "add",
+            "codex",
+            "personal-codex",
+            "--api-key",
+            VALID_CODEX_PERSONAL,
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "add",
+            "gemini",
+            "work-gemini",
+            "--api-key",
+            VALID_GEMINI_WORK,
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "add",
+            "gemini",
+            "personal-gemini",
+            "--api-key",
+            VALID_GEMINI_PERSONAL,
+        ])
+        .assert()
+        .success();
+
+    env.cmd()
+        .args([
+            "context",
+            "create",
+            "client-acme",
+            "--claude",
+            "work-claude",
+            "--codex",
+            "work-codex",
+            "--gemini",
+            "work-gemini",
+        ])
+        .assert()
+        .success();
+}
+
+fn setup_repo(env: &TestEnv, rel: &str, remote: &str) -> std::path::PathBuf {
+    let repo = env.fake_home.join(rel);
+    fs::create_dir_all(repo.join(".git").join("info")).unwrap();
+    fs::create_dir_all(repo.join("api")).unwrap();
+    fs::write(
+        repo.join(".git").join("config"),
+        format!("[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = {remote}\n"),
+    )
+    .unwrap();
+    repo
+}
+
+#[test]
+fn workspace_bind_in_repo_writes_repo_local_config() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let repo = setup_repo(&env, "clients/acme", "git@github.com:acme/api.git");
+
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            repo.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+
+    let local = repo.join(".git").join("info").join("aisw.json");
+    assert!(local.exists(), "repo-local workspace config should exist");
+    let json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(local).unwrap()).unwrap();
+    assert_eq!(json["context"], "client-acme");
+    assert!(
+        !env.home_file("workspaces.json").exists(),
+        "repo-local bind should not spill into the user workspace store"
+    );
+}
+
+#[test]
+fn workspace_status_json_reports_mismatch_for_expected_context() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let repo = setup_repo(&env, "clients/acme", "git@github.com:acme/api.git");
+
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            "--git-remote",
+            "github.com/acme/*",
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+
+    env.cmd()
+        .current_dir(repo.join("api"))
+        .args(["use", "claude", "personal-claude"])
+        .assert()
+        .success();
+    env.cmd()
+        .current_dir(repo.join("api"))
+        .args(["use", "codex", "personal-codex"])
+        .assert()
+        .success();
+
+    let output = env
+        .cmd()
+        .current_dir(repo.join("api"))
+        .args(["workspace", "status", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["matched_rule"], "git_remote:github.com/acme/*");
+    assert_eq!(json["expected_context"], "client-acme");
+    assert_eq!(json["status"], "mismatch");
+    assert_eq!(json["recommended_command"], "aisw context use client-acme");
+    assert_eq!(json["active_profiles"]["claude"], "personal-claude");
+    assert_eq!(json["active_profiles"]["codex"], "personal-codex");
+}
+
+#[test]
+fn workspace_bind_path_outside_repo_updates_user_store() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let path = env.fake_home.join("scratch").join("project");
+    fs::create_dir_all(&path).unwrap();
+
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            path.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&env.read_home_file("workspaces.json")).unwrap();
+    assert_eq!(json["path_rules"][0]["context"], "client-acme");
+}
+
+#[test]
+fn workspace_check_warn_mode_allows_launch() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let repo = setup_repo(&env, "clients/acme", "git@github.com:acme/api.git");
+
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            repo.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["use", "claude", "personal-claude"])
+        .assert()
+        .success();
+
+    env.cmd()
+        .current_dir(repo.join("api"))
+        .args(["workspace", "check", "--tool", "claude"])
+        .assert()
+        .success()
+        .stderr(contains("Workspace guard warning"));
+}


### PR DESCRIPTION
## Summary

  - Add a new workspace command family to bind repos, folders, and git remotes to expected aisw contexts.
  - Add workspace resolution, status, doctoring, and guard-mode persistence using repo-local .git/info/aisw.json and user-level ~/.aisw/workspaces.json.
  - Reuse existing context matching to detect workspace/context drift and recommend the correct aisw context use ... remediation.
  - Extend shell integration so workspace guardrails apply before launching claude, codex, and gemini, with support for bash, zsh, fish, and pwsh.
  - Add isolated test coverage for repo-local bindings, user-level path rules, strict guard blocking for all supported agents, and cross-shell env/hook behavior.

  ## User Impact

  This solves the “wrong account in the wrong repo” problem by letting users map a workspace to an expected aisw context and having aisw warn or block when the active state does not match. It primarily affects users who switch between work/personal/client repos
  across Claude Code, Codex CLI, and Gemini CLI.

  ## CLI / UX Changes

  - New flags/options:
      - New top-level workspace command family:
          - `aisw workspace bind [PATH] --context <name>`
          - `aisw workspace bind --git-remote <pattern> --context <name>`
          - `aisw workspace bind --default --context <name>`
          - `aisw workspace status [--json]`
          - `aisw workspace doctor [--json]`
          - `aisw workspace guard --mode warn|strict`

      - aisw shell-hook now also supports pwsh

  - Changed defaults:
      - Repo bindings default to local uncommitted .git/info/aisw.json when binding inside a git repo
      - Workspace guard mode defaults from ~/.aisw/workspaces.json

  - New/updated output:
      - workspace status shows resolved workspace, matched rule, expected context, active context/profile state, and recommended remediation
      - workspace doctor validates workspace rule files and context references

  - Error message changes:
      - Strict workspace guard now refuses agent launch with a targeted “workspace guard refused to launch …” error and remediation command

  ## Backward Compatibility

  - [x] No breaking changes

  ## Implementation Notes

  - The feature intentionally reuses existing context storage and matching logic instead of introducing a new “bundle” abstraction.
  - Resolution order is:
      - repo-local .git/info/aisw.json
      - user path rule
      - user git-remote rule
      - default context

  - Repo-local bindings are preferred for privacy and stay out of committed repo state by default.
  - Guard enforcement is implemented in shell hooks rather than a new run command, so existing agent entrypoints stay natural for users.
  - PowerShell support required extending --emit-env output generation in addition to hook generation; otherwise profile switching would not update the live shell session correctly.

  ## Tests & Validation

  Ran locally:
```
  cargo fmt
  cargo test --test workspace_cmd
  cargo test --test shell_hook_cmd
  cargo test --lib pwsh
  cargo test
```

  ## Manual Verification
```
  # create a context that represents a workspace
  aisw context create client-acme --claude work-claude --codex work-codex --gemini work-gemini

  # bind the current repo locally without committing config
  aisw workspace bind . --context client-acme

  # inspect current workspace resolution
  aisw workspace status
  aisw workspace status --json

  # bind by remote pattern
  aisw workspace bind --git-remote github.com/acme/* --context client-acme

  # set guard mode
  aisw workspace guard --mode warn
  aisw workspace guard --mode strict

  # install/update shell hook
  aisw shell-hook bash
  aisw shell-hook zsh
  aisw shell-hook fish
  aisw shell-hook pwsh

  # switch into a mismatched repo and verify warning/block behavior
  claude
  codex
  gemini
```
  ## Documentation

  - [x] Docs updated (README / CONTRIBUTING / command help)

  ## Security & Privacy Checklist

  - [x] No secrets/tokens/credentials committed
  - [x] Sensitive output paths are reviewed