### PR TITLE
Add GUI-safe machine contract for core CLI flows

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,8 +50,33 @@ pub fn preparse_no_color(args: &[OsString]) -> bool {
     args.iter().any(|arg| arg == OsStr::new("--no-color"))
 }
 
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreparsedOutputMode {
+    Human,
+    Json,
+    ProgressJson,
+}
+
+#[allow(dead_code)]
+pub fn preparse_output_mode(args: &[OsString]) -> PreparsedOutputMode {
+    if args.iter().any(|arg| arg == OsStr::new("--progress-json")) {
+        PreparsedOutputMode::ProgressJson
+    } else if args.iter().any(|arg| arg == OsStr::new("--json")) {
+        PreparsedOutputMode::Json
+    } else {
+        PreparsedOutputMode::Human
+    }
+}
+
 #[derive(Subcommand, Debug)]
 pub enum Command {
+    /// Show CLI version details
+    Version(VersionArgs),
+
+    /// Show supported machine-readable capabilities
+    Capabilities(CapabilitiesArgs),
+
     /// Add a new account profile for a tool
     Add(AddArgs),
 
@@ -191,6 +216,10 @@ pub struct AddArgs {
     #[arg(long, value_name = "KEY")]
     pub api_key: Option<String>,
 
+    /// API key read from stdin until EOF
+    #[arg(long, conflicts_with_all = ["api_key", "from_env", "from_live"])]
+    pub api_key_stdin: bool,
+
     /// Human-readable label for this profile
     #[arg(long, value_name = "TEXT")]
     pub label: Option<String>,
@@ -214,6 +243,28 @@ pub struct AddArgs {
     /// Overwrite an existing profile without prompting (only meaningful with --from-live)
     #[arg(long)]
     pub yes: bool,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
+
+    /// Stream progress as newline-delimited JSON
+    #[arg(long)]
+    pub progress_json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct VersionArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct CapabilitiesArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -248,6 +299,10 @@ pub struct UseArgs {
     /// Profile name when using --all
     #[arg(long = "profile", value_name = "PROFILE")]
     pub all_profile: Option<String>,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -420,6 +475,10 @@ pub struct RemoveArgs {
     /// Allow removing the currently active profile
     #[arg(long)]
     pub force: bool,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -432,6 +491,10 @@ pub struct RenameArgs {
 
     /// New profile name. When old name is omitted, pass only this value.
     pub new_name: Option<String>,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -538,14 +601,21 @@ pub enum BackupCommand {
     List(BackupListArgs),
 
     /// Restore a backup by id
-    Restore {
-        /// Backup id to restore (from 'aisw backup list'; omit to choose interactively in TTY mode)
-        backup_id: Option<String>,
+    Restore(BackupRestoreArgs),
+}
 
-        /// Skip the confirmation prompt
-        #[arg(long)]
-        yes: bool,
-    },
+#[derive(Args, Debug)]
+pub struct BackupRestoreArgs {
+    /// Backup id to restore (from 'aisw backup list'; omit to choose interactively in TTY mode)
+    pub backup_id: Option<String>,
+
+    /// Skip the confirmation prompt
+    #[arg(long)]
+    pub yes: bool,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[cfg(test)]
@@ -919,10 +989,13 @@ mod tests {
         let Command::Backup(args) = cli.command else {
             panic!("wrong command")
         };
-        let BackupCommand::Restore { backup_id, .. } = args.command else {
+        let BackupCommand::Restore(restore_args) = args.command else {
             panic!("wrong subcommand")
         };
-        assert_eq!(backup_id.as_deref(), Some("2026-03-25T10-00-00.123Z-0001"));
+        assert_eq!(
+            restore_args.backup_id.as_deref(),
+            Some("2026-03-25T10-00-00.123Z-0001")
+        );
     }
 
     #[test]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 use std::fs;
+use std::io::Read;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
@@ -9,6 +10,7 @@ use crate::auth;
 use crate::auth::identity;
 use crate::cli::{AddArgs, AddCredentialBackend};
 use crate::config::{AuthMethod, Config, ConfigStore, CredentialBackend, ProfileMeta};
+use crate::machine;
 use crate::output;
 use crate::profile::ProfileStore;
 use crate::runtime;
@@ -63,6 +65,13 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
     // Guard: tool binary must be on PATH before we create any profile state.
     let detected = tool_detection::require_in(args.tool, tool_path)?;
 
+    let stdin_api_key = if args.api_key_stdin {
+        Some(read_api_key_from_stdin()?)
+    } else {
+        None
+    };
+    let api_key_arg = args.api_key.clone().or(stdin_api_key);
+
     let (backend, auth_method, source) = if args.from_env {
         let backend = resolved_api_key_backend(&args);
         let env_var = match args.tool {
@@ -103,9 +112,9 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
         if args.set_active {
             config_store.set_active(args.tool, &args.profile_name)?;
         }
-        print_add_summary(&args, backend, Some(env_var), AuthMethod::ApiKey);
+        emit_add_result(&args, backend, Some(env_var), AuthMethod::ApiKey)?;
         return Ok(());
-    } else if let Some(ref api_key) = args.api_key {
+    } else if let Some(api_key) = api_key_arg.as_deref() {
         let backend = resolved_api_key_backend(&args);
         match args.tool {
             Tool::Claude => auth::claude::add_api_key_with_backend(
@@ -215,7 +224,7 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
         config_store.set_active(args.tool, &args.profile_name)?;
     }
 
-    print_add_summary(&args, backend, source, auth_method);
+    emit_add_result(&args, backend, source, auth_method)?;
 
     Ok(())
 }
@@ -937,16 +946,25 @@ fn finalize_from_live(
     backend: CredentialBackend,
     auth_method: AuthMethod,
 ) -> Result<()> {
+    if args.json {
+        machine::print_success(
+            "add",
+            serde_json::json!({
+                "tool": tool.binary_name(),
+                "profile": args.profile_name,
+                "auth_method": auth_label(auth_method),
+                "credential_backend": backend.display_name(),
+                "active": true,
+                "source": "from_live",
+                "warnings": Vec::<String>::new(),
+            }),
+        )?;
+        return Ok(());
+    }
     output::print_title("Added profile");
     output::print_kv("Tool", tool.display_name());
     output::print_kv("Profile", &args.profile_name);
-    output::print_kv(
-        "Auth",
-        match auth_method {
-            AuthMethod::OAuth => "oauth",
-            AuthMethod::ApiKey => "api_key",
-        },
-    );
+    output::print_kv("Auth", auth_label(auth_method));
     output::print_kv("Backend", backend.display_name());
     output::print_kv("Activation", "active");
     output::print_blank_line();
@@ -1016,6 +1034,59 @@ fn print_add_summary(
         &args.profile_name,
         args.set_active,
     ));
+}
+
+fn emit_add_result(
+    args: &AddArgs,
+    backend: CredentialBackend,
+    source: Option<&str>,
+    auth_method: AuthMethod,
+) -> Result<()> {
+    if args.json {
+        machine::print_success(
+            "add",
+            serde_json::json!({
+                "tool": args.tool.binary_name(),
+                "profile": args.profile_name,
+                "auth_method": auth_label(auth_method),
+                "credential_backend": backend.display_name(),
+                "active": args.set_active || args.from_live,
+                "source": source,
+                "warnings": Vec::<String>::new(),
+            }),
+        )?;
+        return Ok(());
+    }
+
+    print_add_summary(args, backend, source, auth_method);
+    Ok(())
+}
+
+fn auth_label(auth_method: AuthMethod) -> &'static str {
+    match auth_method {
+        AuthMethod::OAuth => "oauth",
+        AuthMethod::ApiKey => "api_key",
+    }
+}
+
+fn read_api_key_from_stdin() -> Result<String> {
+    let mut secret = String::new();
+    std::io::stdin()
+        .read_to_string(&mut secret)
+        .context("could not read API key from stdin")?;
+
+    if secret.ends_with("\r\n") {
+        let new_len = secret.len() - 2;
+        secret.truncate(new_len);
+    } else if secret.ends_with('\n') {
+        secret.pop();
+    }
+
+    if secret.is_empty() {
+        bail!("API key stdin input was empty after trimming trailing newline.");
+    }
+
+    Ok(secret)
 }
 
 fn requested_backend(args: &AddArgs) -> Option<CredentialBackend> {
@@ -1106,14 +1177,18 @@ mod tests {
                 non_interactive: crate::runtime::is_non_interactive(),
                 quiet: crate::runtime::is_quiet(),
             };
-            crate::runtime::configure(non_interactive, quiet);
+            crate::runtime::configure(non_interactive, quiet, crate::runtime::OutputMode::Human);
             previous
         }
     }
 
     impl Drop for RuntimeGuard {
         fn drop(&mut self) {
-            crate::runtime::configure(self.non_interactive, self.quiet);
+            crate::runtime::configure(
+                self.non_interactive,
+                self.quiet,
+                crate::runtime::OutputMode::Human,
+            );
         }
     }
 
@@ -1156,12 +1231,15 @@ mod tests {
             tool,
             profile_name: name.to_owned(),
             api_key: Some(api_key.to_owned()),
+            api_key_stdin: false,
             label: None,
             credential_backend: None,
             set_active: false,
             from_env: false,
             from_live: false,
             yes: false,
+            json: false,
+            progress_json: false,
         }
     }
 
@@ -1170,12 +1248,15 @@ mod tests {
             tool,
             profile_name: name.to_owned(),
             api_key: None,
+            api_key_stdin: false,
             label: None,
             credential_backend: None,
             set_active: false,
             from_env: false,
             from_live: true,
             yes: true,
+            json: false,
+            progress_json: false,
         }
     }
 
@@ -1306,12 +1387,15 @@ mod tests {
             tool,
             profile_name: name.to_owned(),
             api_key: None,
+            api_key_stdin: false,
             label: None,
             credential_backend: None,
             set_active: false,
             from_env: true,
             from_live: false,
             yes: false,
+            json: false,
+            progress_json: false,
         }
     }
 
@@ -1446,12 +1530,15 @@ mod tests {
                 tool: Tool::Claude,
                 profile_name: "work".to_owned(),
                 api_key: None,
+                api_key_stdin: false,
                 label: None,
                 credential_backend: None,
                 set_active: false,
                 from_env: false,
                 from_live: false,
                 yes: false,
+                json: false,
+                progress_json: false,
             };
             run_in(args, &aisw_home, path_of(&bin_dir)).unwrap();
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -5,8 +5,9 @@ use dialoguer::{theme::ColorfulTheme, Select};
 use std::io::IsTerminal;
 
 use crate::backup::BackupManager;
-use crate::cli::{BackupCommand, BackupListArgs};
+use crate::cli::{BackupCommand, BackupListArgs, BackupRestoreArgs};
 use crate::config::ConfigStore;
+use crate::machine;
 use crate::output;
 use crate::profile::ProfileStore;
 use crate::runtime;
@@ -14,7 +15,7 @@ use crate::runtime;
 pub fn run(command: BackupCommand, home: &Path) -> Result<()> {
     match command {
         BackupCommand::List(args) => run_list(args, home),
-        BackupCommand::Restore { backup_id, yes } => run_restore(backup_id, yes, home),
+        BackupCommand::Restore(args) => run_restore(args, home),
     }
 }
 
@@ -107,8 +108,8 @@ fn print_json(entries: &[crate::backup::BackupEntry]) -> Result<()> {
     Ok(())
 }
 
-fn run_restore(backup_id: Option<String>, yes: bool, home: &Path) -> Result<()> {
-    let backup_id = resolve_backup_id(backup_id, home)?;
+fn run_restore(args: BackupRestoreArgs, home: &Path) -> Result<()> {
+    let backup_id = resolve_backup_id(args.backup_id.clone(), home)?;
     let manager = BackupManager::new(home);
     let entries = manager.list()?;
     let matching: Vec<_> = entries
@@ -123,7 +124,7 @@ fn run_restore(backup_id: Option<String>, yes: bool, home: &Path) -> Result<()> 
         );
     }
 
-    if !yes {
+    if !args.yes {
         if runtime::is_non_interactive() {
             bail!(
                 "backup restore requires confirmation.\n  \
@@ -148,7 +149,24 @@ fn run_restore(backup_id: Option<String>, yes: bool, home: &Path) -> Result<()> 
         }
     }
 
-    run_restore_inner(&backup_id, home)
+    let restored = run_restore_inner(&backup_id, home)?;
+    if args.json {
+        machine::print_success(
+            "backup_restore",
+            serde_json::json!({
+                "backup_id": backup_id,
+                "restored": restored.iter().map(|entry| {
+                    serde_json::json!({
+                        "tool": entry.tool.binary_name(),
+                        "profile": entry.profile,
+                    })
+                }).collect::<Vec<_>>(),
+                "activated": false,
+                "next_action": restored.first().map(|entry| format!("aisw use {} {}", entry.tool, entry.profile)),
+            }),
+        )?;
+    }
+    Ok(())
 }
 
 fn resolve_backup_id(backup_id: Option<String>, home: &Path) -> Result<String> {
@@ -199,7 +217,10 @@ fn resolve_backup_id(backup_id: Option<String>, home: &Path) -> Result<String> {
     Ok(unique_ids[selection].clone())
 }
 
-pub(crate) fn run_restore_inner(backup_id: &str, home: &Path) -> Result<()> {
+pub(crate) fn run_restore_inner(
+    backup_id: &str,
+    home: &Path,
+) -> Result<Vec<crate::backup::BackupEntry>> {
     let manager = BackupManager::new(home);
     let profile_store = ProfileStore::new(home);
     let config_store = ConfigStore::new(home);
@@ -219,6 +240,9 @@ pub(crate) fn run_restore_inner(backup_id: &str, home: &Path) -> Result<()> {
 
     manager.restore(backup_id, &profile_store, &config_store)?;
     for e in &matching {
+        if crate::runtime::is_json() {
+            continue;
+        }
         output::print_title("Restored backup");
         output::print_kv("Tool", e.tool.display_name());
         output::print_kv("Profile", &e.profile);
@@ -230,7 +254,7 @@ pub(crate) fn run_restore_inner(backup_id: &str, home: &Path) -> Result<()> {
         output::print_blank_line();
         output::print_next_step(output::next_step_after_restore(e.tool, &e.profile));
     }
-    Ok(())
+    Ok(matching.into_iter().cloned().collect())
 }
 
 #[cfg(test)]

--- a/src/commands/capabilities.rs
+++ b/src/commands/capabilities.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::cli::CapabilitiesArgs;
+use crate::types::Tool;
+
+#[derive(Serialize)]
+struct CapabilitiesPayload {
+    version: &'static str,
+    cli_api_version: u32,
+    json_schema_version: u32,
+    progress_schema_version: u32,
+    features: FeatureFlags,
+    tools: ToolCapabilitiesSet,
+}
+
+#[derive(Serialize)]
+struct FeatureFlags {
+    api_key_stdin: bool,
+    mutation_json: bool,
+    progress_json: bool,
+    verify: bool,
+    repair: bool,
+    contexts: bool,
+    workspace_bindings: bool,
+    project_bindings_alias: bool,
+}
+
+#[derive(Serialize)]
+struct ToolCapabilitiesSet {
+    claude: ToolCapabilities,
+    codex: ToolCapabilities,
+    gemini: ToolCapabilities,
+}
+
+#[derive(Serialize)]
+struct ToolCapabilities {
+    auth_methods: Vec<&'static str>,
+    state_modes: Vec<&'static str>,
+    credential_backends: Vec<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fail_closed_keyring_identity: Option<bool>,
+}
+
+pub fn run(args: CapabilitiesArgs) -> Result<()> {
+    let payload = CapabilitiesPayload {
+        version: env!("CARGO_PKG_VERSION"),
+        cli_api_version: 1,
+        json_schema_version: 1,
+        progress_schema_version: 1,
+        features: FeatureFlags {
+            api_key_stdin: true,
+            mutation_json: true,
+            progress_json: false,
+            verify: false,
+            repair: false,
+            contexts: true,
+            workspace_bindings: true,
+            project_bindings_alias: false,
+        },
+        tools: ToolCapabilitiesSet {
+            claude: tool_capabilities(Tool::Claude),
+            codex: tool_capabilities(Tool::Codex),
+            gemini: tool_capabilities(Tool::Gemini),
+        },
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        println!("machine features");
+        println!("  api_key_stdin: true");
+        println!("  mutation_json: true");
+        println!("  progress_json: false");
+    }
+
+    Ok(())
+}
+
+fn tool_capabilities(tool: Tool) -> ToolCapabilities {
+    match tool {
+        Tool::Claude => ToolCapabilities {
+            auth_methods: vec!["oauth", "api_key", "from_env", "from_live"],
+            state_modes: vec!["isolated", "shared"],
+            credential_backends: vec!["file", "system_keyring"],
+            fail_closed_keyring_identity: None,
+        },
+        Tool::Codex => ToolCapabilities {
+            auth_methods: vec!["oauth", "api_key", "from_env", "from_live"],
+            state_modes: vec!["isolated", "shared"],
+            credential_backends: vec!["file", "system_keyring"],
+            fail_closed_keyring_identity: Some(true),
+        },
+        Tool::Gemini => ToolCapabilities {
+            auth_methods: vec!["oauth", "api_key", "from_env", "from_live"],
+            state_modes: vec!["isolated"],
+            credential_backends: vec!["file"],
+            fail_closed_keyring_identity: None,
+        },
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ use crate::config::ConfigStore;
 
 pub mod add;
 pub mod backup;
+pub mod capabilities;
 pub mod context;
 pub mod doctor;
 pub mod init;
@@ -15,11 +16,14 @@ pub mod shell_hook;
 pub mod status;
 pub mod uninstall;
 pub mod use_;
+pub mod version;
 pub mod workspace;
 
 pub fn dispatch(cli: Cli) -> Result<()> {
     let home = ConfigStore::aisw_home()?;
     match cli.command {
+        Command::Version(args) => version::run(args)?,
+        Command::Capabilities(args) => capabilities::run(args)?,
         Command::Add(args) => add::run(args, &home)?,
         Command::Context(args) => context::run(args, &home)?,
         Command::Use(args) => use_::run(args, &home)?,

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -8,6 +8,7 @@ use crate::auth;
 use crate::backup::BackupManager;
 use crate::cli::RemoveArgs;
 use crate::config::{Config, ConfigStore};
+use crate::machine;
 use crate::output;
 use crate::profile::ProfileStore;
 use crate::runtime;
@@ -112,7 +113,14 @@ pub(crate) fn run_inner(args: RemoveArgs, home: &Path, confirmed: bool) -> Resul
     profile_meta
         .credential_backend
         .validate_for_tool(args.tool)?;
-    BackupManager::new(home).snapshot(args.tool, profile_name, &profile_dir, profile_meta)?;
+    let backup_path =
+        BackupManager::new(home).snapshot(args.tool, profile_name, &profile_dir, profile_meta)?;
+    let backup_id = backup_path
+        .ancestors()
+        .nth(2)
+        .and_then(|path| path.file_name())
+        .and_then(|name| name.to_str())
+        .map(str::to_owned);
 
     if profile_meta.credential_backend == crate::config::CredentialBackend::SystemKeyring {
         auth::secure_store::delete_profile_secret(args.tool, profile_name)?;
@@ -122,6 +130,20 @@ pub(crate) fn run_inner(args: RemoveArgs, home: &Path, confirmed: bool) -> Resul
 
     if is_active {
         config_store.clear_active(args.tool)?;
+    }
+
+    if args.json {
+        machine::print_success(
+            "remove",
+            serde_json::json!({
+                "tool": args.tool.binary_name(),
+                "removed_profile": profile_name,
+                "was_active": is_active,
+                "backup_ids": backup_id.into_iter().collect::<Vec<_>>(),
+                "remaining_profiles": remaining_profiles(home, args.tool)?,
+            }),
+        )?;
+        return Ok(());
     }
 
     output::print_title("Removed profile");
@@ -138,6 +160,17 @@ pub(crate) fn run_inner(args: RemoveArgs, home: &Path, confirmed: bool) -> Resul
     output::print_blank_line();
     output::print_next_step("Run 'aisw list' to review remaining profiles.");
     Ok(())
+}
+
+fn remaining_profiles(home: &Path, tool: Tool) -> Result<Vec<String>> {
+    let config = ConfigStore::new(home).load()?;
+    let mut names = config
+        .profiles_for(tool)
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    names.sort();
+    Ok(names)
 }
 
 fn precheck(args: &RemoveArgs, home: &Path) -> Result<()> {
@@ -342,6 +375,7 @@ mod tests {
             profile_name: Some(name.to_owned()),
             yes,
             force,
+            json: false,
         }
     }
 

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -7,6 +7,7 @@ use std::io::IsTerminal;
 use crate::auth;
 use crate::cli::RenameArgs;
 use crate::config::ConfigStore;
+use crate::machine;
 use crate::output;
 use crate::profile::{validate_profile_name, ProfileStore};
 
@@ -84,6 +85,21 @@ pub(crate) fn run_inner(args: RenameArgs, home: &Path) -> Result<()> {
             "rolled back profile directory rename after config update failed for {}",
             args.tool
         ));
+    }
+
+    if args.json {
+        let config = config_store.load()?;
+        machine::print_success(
+            "rename",
+            serde_json::json!({
+                "tool": args.tool.binary_name(),
+                "old_name": old_name,
+                "new_name": new_name,
+                "was_active": config.active_for(args.tool) == Some(new_name),
+                "backup_ids": Vec::<String>::new(),
+            }),
+        )?;
+        return Ok(());
     }
 
     output::print_title("Renamed profile");
@@ -272,6 +288,7 @@ mod tests {
             tool,
             old_name: Some(old_name.to_owned()),
             new_name: Some(new_name.to_owned()),
+            json: false,
         }
     }
 

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -9,6 +9,7 @@ use crate::backup::BackupManager;
 use crate::cli::UseArgs;
 use crate::config::{AuthMethod, ConfigStore, ProfileMeta};
 use crate::error::AiswError;
+use crate::machine;
 use crate::output;
 use crate::profile::ProfileStore;
 use crate::types::{StateMode, Tool};
@@ -29,7 +30,7 @@ pub fn run(args: UseArgs, home: &Path) -> Result<()> {
         if profile_name.is_empty() {
             anyhow::bail!("--all requires --profile <name>");
         }
-        run_all_in(profile_name, home, &user_home)
+        run_all_in(profile_name, args.json, home, &user_home)
     } else {
         let tool = args
             .tool
@@ -39,17 +40,25 @@ pub fn run(args: UseArgs, home: &Path) -> Result<()> {
             args.profile_name.as_deref(),
             args.state_mode,
             args.emit_env,
+            args.json,
             home,
             &user_home,
         )
     }
 }
 
-pub(crate) fn run_all_in(profile_name: &str, home: &Path, user_home: &Path) -> Result<()> {
+pub(crate) fn run_all_in(
+    profile_name: &str,
+    json: bool,
+    home: &Path,
+    user_home: &Path,
+) -> Result<()> {
     let config_store = ConfigStore::new(home);
     let config = config_store.load()?;
     let mut switched = 0usize;
     let mut errors = Vec::new();
+    let before_backup_ids = backup_ids_for(home, None)?;
+    let mut affected_tools = Vec::new();
 
     for tool in Tool::ALL {
         let profiles = config.profiles_for(tool);
@@ -60,8 +69,19 @@ pub(crate) fn run_all_in(profile_name: &str, home: &Path, user_home: &Path) -> R
             ));
             continue;
         }
-        match run_for_tool(tool, Some(profile_name), None, false, home, user_home) {
-            Ok(()) => switched += 1,
+        match run_for_tool(
+            tool,
+            Some(profile_name),
+            None,
+            false,
+            false,
+            home,
+            user_home,
+        ) {
+            Ok(()) => {
+                switched += 1;
+                affected_tools.push(tool);
+            }
             Err(e) => errors.push(format!("{}: {}", tool, e)),
         }
     }
@@ -69,8 +89,23 @@ pub(crate) fn run_all_in(profile_name: &str, home: &Path, user_home: &Path) -> R
     if switched == 0 && errors.is_empty() {
         anyhow::bail!("no tool has a profile named '{}'", profile_name);
     }
-    for e in &errors {
-        output::print_warning(e);
+    if json {
+        let after_backup_ids = backup_ids_for(home, None)?;
+        machine::print_success(
+            "use",
+            serde_json::json!({
+                "affected_tools": affected_tools.iter().map(|tool| tool.binary_name()).collect::<Vec<_>>(),
+                "active": active_map(home, &affected_tools)?,
+                "state_mode": state_mode_map(home, &affected_tools)?,
+                "live_match": live_match_map(home, user_home, &affected_tools)?,
+                "backup_ids": diff_backup_ids(&before_backup_ids, &after_backup_ids),
+                "warnings": errors,
+            }),
+        )?;
+    } else {
+        for e in &errors {
+            output::print_warning(e);
+        }
     }
     Ok(())
 }
@@ -85,6 +120,7 @@ pub(crate) fn run_in(args: UseArgs, home: &Path, user_home: &Path) -> Result<()>
         args.profile_name.as_deref(),
         args.state_mode,
         args.emit_env,
+        false,
         home,
         user_home,
     )
@@ -95,9 +131,11 @@ fn run_for_tool(
     requested_profile_name: Option<&str>,
     state_mode_override: Option<StateMode>,
     emit_env: bool,
+    json: bool,
     home: &Path,
     user_home: &Path,
 ) -> Result<()> {
+    let before_backup_ids = backup_ids_for(home, Some(tool))?;
     let resolved = resolve_profile_switch_request(
         tool,
         requested_profile_name,
@@ -113,7 +151,20 @@ fn run_for_tool(
         tool.supports_state_mode().then_some(resolved.state_mode),
     )?;
 
-    if !emit_env {
+    if json {
+        let after_backup_ids = backup_ids_for(home, Some(tool))?;
+        machine::print_success(
+            "use",
+            serde_json::json!({
+                "affected_tools": [tool.binary_name()],
+                "active": active_map(home, &[tool])?,
+                "state_mode": state_mode_map(home, &[tool])?,
+                "live_match": live_match_map(home, user_home, &[tool])?,
+                "backup_ids": diff_backup_ids(&before_backup_ids, &after_backup_ids),
+                "warnings": Vec::<String>::new(),
+            }),
+        )?;
+    } else if !emit_env {
         print_switch_summary(&resolved, home);
     }
 
@@ -585,6 +636,79 @@ fn auth_label(method: AuthMethod) -> &'static str {
     }
 }
 
+fn backup_ids_for(home: &Path, tool: Option<Tool>) -> Result<Vec<String>> {
+    let mut ids = BackupManager::new(home)
+        .list()?
+        .into_iter()
+        .filter(|entry| match tool {
+            Some(selected) => entry.tool == selected,
+            None => true,
+        })
+        .map(|entry| entry.backup_id)
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids.dedup();
+    Ok(ids)
+}
+
+fn diff_backup_ids(before: &[String], after: &[String]) -> Vec<String> {
+    after
+        .iter()
+        .filter(|id| !before.iter().any(|existing| existing == *id))
+        .cloned()
+        .collect()
+}
+
+fn active_map(home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
+    let config = ConfigStore::new(home).load()?;
+    let mut map = serde_json::Map::new();
+    for tool in tools {
+        map.insert(
+            tool.binary_name().to_owned(),
+            config
+                .active_for(*tool)
+                .map(|value| serde_json::Value::String(value.to_owned()))
+                .unwrap_or(serde_json::Value::Null),
+        );
+    }
+    Ok(serde_json::Value::Object(map))
+}
+
+fn state_mode_map(home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
+    let config = ConfigStore::new(home).load()?;
+    let mut map = serde_json::Map::new();
+    for tool in tools {
+        map.insert(
+            tool.binary_name().to_owned(),
+            if tool.supports_state_mode() {
+                serde_json::Value::String(config.state_mode_for(*tool).display_name().to_owned())
+            } else {
+                serde_json::Value::String(StateMode::Isolated.display_name().to_owned())
+            },
+        );
+    }
+    Ok(serde_json::Value::Object(map))
+}
+
+fn live_match_map(home: &Path, user_home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
+    let statuses = crate::commands::status::collect_status(
+        home,
+        user_home,
+        &std::env::var_os("PATH").unwrap_or_default(),
+    )?;
+    let mut map = serde_json::Map::new();
+    for tool in tools {
+        let value = statuses
+            .iter()
+            .find(|status| status.tool == *tool)
+            .and_then(|status| status.active_profile_applied)
+            .map(serde_json::Value::Bool)
+            .unwrap_or(serde_json::Value::Null);
+        map.insert(tool.binary_name().to_owned(), value);
+    }
+    Ok(serde_json::Value::Object(map))
+}
+
 /// Best-effort: extract a human-readable account identity from stored credentials.
 /// Returns `None` silently when no identity is parseable — never fails the switch.
 fn extract_switch_identity(profile_store: &ProfileStore, tool: Tool, name: &str) -> Option<String> {
@@ -673,14 +797,18 @@ mod tests {
                 non_interactive: crate::runtime::is_non_interactive(),
                 quiet: crate::runtime::is_quiet(),
             };
-            crate::runtime::configure(non_interactive, quiet);
+            crate::runtime::configure(non_interactive, quiet, crate::runtime::OutputMode::Human);
             guard
         }
     }
 
     impl Drop for RuntimeModeGuard {
         fn drop(&mut self) {
-            crate::runtime::configure(self.non_interactive, self.quiet);
+            crate::runtime::configure(
+                self.non_interactive,
+                self.quiet,
+                crate::runtime::OutputMode::Human,
+            );
         }
     }
 
@@ -731,6 +859,7 @@ mod tests {
             emit_env,
             all: false,
             all_profile: None,
+            json: false,
         }
     }
 
@@ -742,6 +871,7 @@ mod tests {
             emit_env,
             all: false,
             all_profile: None,
+            json: false,
         }
     }
 
@@ -1099,7 +1229,7 @@ mod tests {
         setup_codex_api_key_profile(&home, "work");
         setup_gemini_api_key_profile(&home, "work");
 
-        run_all_in("work", &home, &user_home).unwrap();
+        run_all_in("work", false, &home, &user_home).unwrap();
 
         let config = ConfigStore::new(&home).load().unwrap();
         assert_eq!(config.active_for(Tool::Claude), Some("work"));
@@ -1118,7 +1248,7 @@ mod tests {
         setup_claude_api_key_profile(&home, "work");
         // Only Claude has "work"
 
-        run_all_in("work", &home, &user_home).unwrap();
+        run_all_in("work", false, &home, &user_home).unwrap();
 
         let config = ConfigStore::new(&home).load().unwrap();
         assert_eq!(config.active_for(Tool::Claude), Some("work"));
@@ -1133,7 +1263,7 @@ mod tests {
         let user_home = tmp.path().join("uhome");
         std::fs::create_dir_all(&home).unwrap();
 
-        let err = run_all_in("work", &home, &user_home).unwrap_err();
+        let err = run_all_in("work", false, &home, &user_home).unwrap_err();
         assert!(
             err.to_string().contains("no tool has a profile"),
             "unexpected: {}",

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -1270,4 +1270,92 @@ mod tests {
             err
         );
     }
+
+    #[test]
+    fn diff_backup_ids_returns_only_new_ids() {
+        let before = vec!["b".to_owned(), "a".to_owned()];
+        let after = vec!["a".to_owned(), "b".to_owned(), "c".to_owned()];
+        assert_eq!(diff_backup_ids(&before, &after), vec!["c".to_owned()]);
+    }
+
+    #[test]
+    fn active_and_state_mode_maps_reflect_current_config() {
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(&home).unwrap();
+
+        setup_claude_api_key_profile(&home, "work");
+        setup_gemini_api_key_profile(&home, "personal");
+        let config_store = ConfigStore::new(&home);
+        config_store
+            .activate_profile(Tool::Claude, "work", Some(StateMode::Shared))
+            .unwrap();
+
+        let active = active_map(&home, &[Tool::Claude, Tool::Gemini]).unwrap();
+        assert_eq!(active["claude"], "work");
+        assert_eq!(active["gemini"], serde_json::Value::Null);
+
+        let state_modes = state_mode_map(&home, &[Tool::Claude, Tool::Gemini]).unwrap();
+        assert_eq!(state_modes["claude"], "shared");
+        assert_eq!(state_modes["gemini"], "isolated");
+    }
+
+    #[test]
+    fn backup_ids_for_returns_sorted_unique_ids() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(
+            home.join("backups")
+                .join("2026-01-01T00-00-00.000Z-0")
+                .join("claude")
+                .join("work"),
+        )
+        .unwrap();
+        std::fs::create_dir_all(
+            home.join("backups")
+                .join("2026-01-02T00-00-00.000Z-0")
+                .join("claude")
+                .join("work"),
+        )
+        .unwrap();
+        std::fs::create_dir_all(
+            home.join("backups")
+                .join("2026-01-02T00-00-00.000Z-0")
+                .join("codex")
+                .join("work"),
+        )
+        .unwrap();
+
+        let claude_ids = backup_ids_for(&home, Some(Tool::Claude)).unwrap();
+        assert_eq!(
+            claude_ids,
+            vec![
+                "2026-01-01T00-00-00.000Z-0".to_owned(),
+                "2026-01-02T00-00-00.000Z-0".to_owned()
+            ]
+        );
+
+        let all_ids = backup_ids_for(&home, None).unwrap();
+        assert_eq!(
+            all_ids,
+            vec![
+                "2026-01-01T00-00-00.000Z-0".to_owned(),
+                "2026-01-02T00-00-00.000Z-0".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn live_match_map_returns_null_for_inactive_tools() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let user_home = tmp.path().join("uhome");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&user_home).unwrap();
+
+        let live = live_match_map(&home, &user_home, &[Tool::Claude, Tool::Gemini]).unwrap();
+        assert_eq!(live["claude"], serde_json::Value::Null);
+        assert_eq!(live["gemini"], serde_json::Value::Null);
+    }
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::cli::VersionArgs;
+
+#[derive(Serialize)]
+struct VersionPayload {
+    version: &'static str,
+    cli_api_version: u32,
+    json_schema_version: u32,
+    progress_schema_version: u32,
+}
+
+pub fn run(args: VersionArgs) -> Result<()> {
+    let payload = VersionPayload {
+        version: env!("CARGO_PKG_VERSION"),
+        cli_api_version: 1,
+        json_schema_version: 1,
+        progress_schema_version: 1,
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        println!("{}", payload.version);
+    }
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use crate::machine::MachineRemediation;
 use crate::types::Tool;
 
 /// Exit code for all errors not mapped to a specific `AiswError` variant.
@@ -73,6 +74,32 @@ impl AiswError {
             AiswError::ProfileNotFound { .. } => 2,
             // All other structured errors use the standard error exit code.
             _ => EXIT_GENERAL_ERROR,
+        }
+    }
+
+    pub fn remediation(&self) -> Option<MachineRemediation> {
+        match self {
+            AiswError::ProfileNotFound { tool, .. } => Some(MachineRemediation {
+                kind: "run_command",
+                command: format!("aisw list {tool}"),
+                safe: true,
+            }),
+            AiswError::ProfileAlreadyExists { tool, .. } => Some(MachineRemediation {
+                kind: "run_command",
+                command: format!("aisw list {tool}"),
+                safe: true,
+            }),
+            AiswError::ToolNotInstalled { tool: _ } => Some(MachineRemediation {
+                kind: "run_command",
+                command: "aisw doctor --json".to_owned(),
+                safe: true,
+            }),
+            AiswError::BackupNotFound { .. } => Some(MachineRemediation {
+                kind: "run_command",
+                command: "aisw backup list --json".to_owned(),
+                safe: true,
+            }),
+            _ => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod commands;
 pub mod config;
 pub mod error;
 pub mod live_apply;
+pub mod machine;
 pub mod output;
 pub mod profile;
 pub mod runtime;
@@ -33,9 +34,28 @@ use anyhow::Result;
 pub fn run() -> Result<()> {
     let argv: Vec<std::ffi::OsString> = std::env::args_os().collect();
     let clap_no_color = cli::preparse_no_color(&argv);
-    let cli = cli::parse_from(argv, clap_no_color).unwrap_or_else(|err| err.exit());
+    let output_mode = match cli::preparse_output_mode(&argv) {
+        cli::PreparsedOutputMode::Human => runtime::OutputMode::Human,
+        cli::PreparsedOutputMode::Json => runtime::OutputMode::Json,
+        cli::PreparsedOutputMode::ProgressJson => runtime::OutputMode::ProgressJson,
+    };
+    let cli = match cli::parse_from(argv, clap_no_color) {
+        Ok(cli) => cli,
+        Err(err) => {
+            if !matches!(output_mode, runtime::OutputMode::Human) {
+                let failure = machine::parse_error(None, &err);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&failure)
+                        .unwrap_or_else(|_| "{\"ok\":false}".to_owned())
+                );
+                std::process::exit(err.exit_code());
+            }
+            err.exit()
+        }
+    };
     let _terminal_guard = terminal::TerminalGuard::capture();
-    runtime::configure(cli.non_interactive, cli.quiet);
+    runtime::configure(cli.non_interactive, cli.quiet, output_mode);
     output::configure(cli.no_color, cli.quiet);
     commands::dispatch(cli)
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,0 +1,101 @@
+use anyhow::Error;
+use serde::Serialize;
+
+use crate::error::AiswError;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MachineRemediation {
+    pub kind: &'static str,
+    pub command: String,
+    pub safe: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MachineError {
+    pub kind: String,
+    pub message: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remediation: Option<MachineRemediation>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MachineEnvelope<T: Serialize> {
+    pub ok: bool,
+    pub command: &'static str,
+    pub result: T,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MachineFailureEnvelope {
+    pub ok: bool,
+    pub command: String,
+    pub error: MachineError,
+}
+
+pub fn print_success<T: Serialize>(command: &'static str, result: T) -> anyhow::Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&MachineEnvelope {
+            ok: true,
+            command,
+            result,
+        })?
+    );
+    Ok(())
+}
+
+pub fn print_failure(command: Option<&str>, err: &Error, exit_code: i32) {
+    let failure = MachineFailureEnvelope {
+        ok: false,
+        command: command.unwrap_or("unknown").to_owned(),
+        error: machine_error(err, exit_code),
+    };
+
+    if let Ok(json) = serde_json::to_string_pretty(&failure) {
+        println!("{json}");
+    } else {
+        println!(
+            "{{\"ok\":false,\"command\":\"{}\",\"error\":{{\"kind\":\"internal_error\",\"message\":\"failed to serialize machine error\",\"exit_code\":{}}}}}",
+            command.unwrap_or("unknown"),
+            exit_code
+        );
+    }
+}
+
+pub fn parse_error(command: Option<&str>, err: &clap::Error) -> MachineFailureEnvelope {
+    let kind = match err.kind() {
+        clap::error::ErrorKind::UnknownArgument => "unsupported_flag",
+        clap::error::ErrorKind::InvalidSubcommand => "unsupported_command",
+        _ => "validation_error",
+    };
+
+    MachineFailureEnvelope {
+        ok: false,
+        command: command.unwrap_or("unknown").to_owned(),
+        error: MachineError {
+            kind: kind.to_owned(),
+            message: err.to_string().trim().to_owned(),
+            exit_code: err.exit_code(),
+            remediation: None,
+        },
+    }
+}
+
+fn machine_error(err: &Error, exit_code: i32) -> MachineError {
+    if let Some(typed) = err.downcast_ref::<AiswError>() {
+        return MachineError {
+            kind: typed.code().to_owned(),
+            message: typed.to_string(),
+            exit_code,
+            remediation: typed.remediation(),
+        };
+    }
+
+    MachineError {
+        kind: "validation_error".to_owned(),
+        message: err.to_string(),
+        exit_code,
+        remediation: None,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,11 @@ fn main() {
             .downcast_ref::<aisw::error::AiswError>()
             .map(|ae| ae.exit_code())
             .unwrap_or(aisw::error::EXIT_GENERAL_ERROR);
-        aisw::output::print_error_chain(&e);
+        if aisw::runtime::is_machine_mode() {
+            aisw::machine::print_failure(None, &e, exit_code);
+        } else {
+            aisw::output::print_error_chain(&e);
+        }
         std::process::exit(exit_code);
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -13,7 +13,7 @@ const KV_LABEL_WIDTH: usize = 14;
 /// Creates a spinner if stdout is a TTY and not quiet/non-interactive.
 /// Returns `None` when suppressed (tests, quiet mode, non-TTY).
 pub fn start_spinner(msg: &str) -> Option<ProgressBar> {
-    if runtime::is_quiet() || !console::Term::stdout().is_term() {
+    if runtime::is_quiet() || runtime::is_machine_mode() || !console::Term::stdout().is_term() {
         return None;
     }
     let pb = ProgressBar::new_spinner();
@@ -39,7 +39,7 @@ pub fn configure(no_color_flag: bool, quiet: bool) {
 }
 
 pub fn print_title(title: &str) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("{}", style(title).bold().cyan());
@@ -48,7 +48,7 @@ pub fn print_title(title: &str) {
 }
 
 pub fn print_section(title: &str) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("{}", style(title).bold());
@@ -59,7 +59,7 @@ pub fn print_tool_section(tool: Tool) {
 }
 
 pub fn print_profile_section(name: &str, active: bool) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     if active {
@@ -74,7 +74,7 @@ pub fn print_profile_section(name: &str, active: bool) {
 }
 
 pub fn print_kv(label: &str, value: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!(
@@ -85,14 +85,14 @@ pub fn print_kv(label: &str, value: impl AsRef<str>) {
 }
 
 pub fn print_blank_line() {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!();
 }
 
 pub fn print_next_step(message: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("{}", style("Next").bold().cyan());
@@ -120,7 +120,7 @@ pub fn next_step_after_restore(tool: Tool, profile_name: &str) -> String {
 }
 
 pub fn print_fix(message: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("{}", style("Fix").bold().yellow());
@@ -128,49 +128,49 @@ pub fn print_fix(message: impl AsRef<str>) {
 }
 
 pub fn print_info(message: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("  {}", style(message.as_ref()).dim());
 }
 
 pub fn print_effects_header() {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("{}", style("Effects").bold().green());
 }
 
 pub fn print_effect(message: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("  {}", style(message.as_ref()).green());
 }
 
 pub fn print_success(message: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("{}", style(message.as_ref()).green().bold());
 }
 
 pub fn print_warning(message: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("{}", style(message.as_ref()).yellow().bold());
 }
 
 pub fn print_empty_state(message: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     println!("{}", style(message.as_ref()).dim());
 }
 
 pub fn print_table_header(columns: &[(&str, usize)]) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
 
@@ -191,7 +191,7 @@ pub fn print_table_header(columns: &[(&str, usize)]) {
 }
 
 pub fn print_table_row(cells: &[(&str, usize)]) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
 
@@ -228,14 +228,14 @@ pub fn ellipsize(value: &str, max_chars: usize) -> String {
 }
 
 pub fn print_warning_stderr(message: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     eprintln!("{}", style(message.as_ref()).yellow().bold());
 }
 
 pub fn print_info_stderr(message: impl AsRef<str>) {
-    if runtime::is_quiet() {
+    if runtime::is_quiet() || runtime::is_machine_mode() {
         return;
     }
     eprintln!("  {}", style(message.as_ref()).dim());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,23 +8,35 @@ use std::cell::Cell;
 static NON_INTERACTIVE: AtomicBool = AtomicBool::new(false);
 #[cfg(not(test))]
 static QUIET: AtomicBool = AtomicBool::new(false);
+#[cfg(not(test))]
+static OUTPUT_MODE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
 
 #[cfg(test)]
 thread_local! {
     static NON_INTERACTIVE: Cell<bool> = const { Cell::new(false) };
     static QUIET: Cell<bool> = const { Cell::new(false) };
+    static OUTPUT_MODE: Cell<OutputMode> = const { Cell::new(OutputMode::Human) };
 }
 
-pub fn configure(non_interactive: bool, quiet: bool) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputMode {
+    Human = 0,
+    Json = 1,
+    ProgressJson = 2,
+}
+
+pub fn configure(non_interactive: bool, quiet: bool, output_mode: OutputMode) {
     #[cfg(test)]
     {
         NON_INTERACTIVE.with(|flag| flag.set(non_interactive));
         QUIET.with(|flag| flag.set(quiet));
+        OUTPUT_MODE.with(|flag| flag.set(output_mode));
     }
     #[cfg(not(test))]
     {
         NON_INTERACTIVE.store(non_interactive, Ordering::Relaxed);
         QUIET.store(quiet, Ordering::Relaxed);
+        OUTPUT_MODE.store(output_mode as u8, Ordering::Relaxed);
     }
 }
 
@@ -48,4 +60,31 @@ pub fn is_quiet() -> bool {
     {
         QUIET.load(Ordering::Relaxed)
     }
+}
+
+pub fn output_mode() -> OutputMode {
+    #[cfg(test)]
+    {
+        OUTPUT_MODE.with(Cell::get)
+    }
+    #[cfg(not(test))]
+    {
+        match OUTPUT_MODE.load(Ordering::Relaxed) {
+            1 => OutputMode::Json,
+            2 => OutputMode::ProgressJson,
+            _ => OutputMode::Human,
+        }
+    }
+}
+
+pub fn is_json() -> bool {
+    output_mode() == OutputMode::Json
+}
+
+pub fn is_progress_json() -> bool {
+    output_mode() == OutputMode::ProgressJson
+}
+
+pub fn is_machine_mode() -> bool {
+    !matches!(output_mode(), OutputMode::Human)
 }

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -1,0 +1,185 @@
+mod common;
+
+use common::TestEnv;
+
+fn json_output(env: &TestEnv, args: &[&str]) -> serde_json::Value {
+    let output = env.output(args);
+    assert!(
+        output.status.success(),
+        "command failed: aisw {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "stderr should be empty for machine success: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn version_json_reports_contract_versions() {
+    let env = TestEnv::new();
+    let json = json_output(&env, &["version", "--json"]);
+    assert!(json["version"].as_str().is_some());
+    assert_eq!(json["cli_api_version"], 1);
+    assert_eq!(json["json_schema_version"], 1);
+    assert_eq!(json["progress_schema_version"], 1);
+}
+
+#[test]
+fn capabilities_json_reports_tool_capabilities() {
+    let env = TestEnv::new();
+    let json = json_output(&env, &["capabilities", "--json"]);
+    assert_eq!(json["features"]["api_key_stdin"], true);
+    assert_eq!(json["features"]["mutation_json"], true);
+    assert_eq!(json["tools"]["gemini"]["state_modes"][0], "isolated");
+    assert_eq!(json["tools"]["codex"]["fail_closed_keyring_identity"], true);
+}
+
+#[test]
+fn parse_errors_are_structured_in_machine_mode() {
+    let env = TestEnv::new();
+    let output = env.output(&["--json", "switch"]);
+    assert!(!output.status.success());
+    assert!(output.stderr.is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["kind"], "unsupported_flag");
+}
+
+#[test]
+fn add_api_key_stdin_json_succeeds_without_stderr() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+
+    let output = env
+        .cmd()
+        .args(["add", "claude", "work", "--api-key-stdin", "--json"])
+        .write_stdin("sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "add");
+    assert_eq!(json["result"]["profile"], "work");
+    assert_eq!(json["result"]["credential_backend"], "file");
+}
+
+#[test]
+fn add_api_key_stdin_empty_is_structured_failure() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+
+    let output = env
+        .cmd()
+        .args(["add", "claude", "work", "--api-key-stdin", "--json"])
+        .write_stdin("\n")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(output.stderr.is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["command"], "unknown");
+    assert_eq!(json["error"]["kind"], "validation_error");
+}
+
+#[test]
+fn use_json_returns_active_state_and_backup() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work",
+            "--api-key",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ])
+        .assert()
+        .success();
+
+    let json = json_output(&env, &["use", "claude", "work", "--json"]);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["result"]["active"]["claude"], "work");
+    assert!(json["result"]["backup_ids"].as_array().is_some());
+}
+
+#[test]
+fn remove_json_returns_remaining_profiles() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work",
+            "--api-key",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ])
+        .assert()
+        .success();
+
+    let json = json_output(&env, &["remove", "claude", "work", "--yes", "--json"]);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["result"]["removed_profile"], "work");
+    assert_eq!(json["result"]["remaining_profiles"], serde_json::json!([]));
+}
+
+#[test]
+fn rename_json_returns_new_name() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work",
+            "--api-key",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ])
+        .assert()
+        .success();
+
+    let json = json_output(&env, &["rename", "claude", "work", "personal", "--json"]);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["result"]["new_name"], "personal");
+}
+
+#[test]
+fn backup_restore_json_reports_non_activation() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work",
+            "--api-key",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ])
+        .assert()
+        .success();
+    env.cmd().args(["use", "claude", "work"]).assert().success();
+
+    let backups = json_output(&env, &["backup", "list", "--json"]);
+    let backup_id = backups[0]["backup_id"].as_str().unwrap().to_owned();
+
+    let json = json_output(&env, &["backup", "restore", &backup_id, "--yes", "--json"]);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["result"]["backup_id"], backup_id);
+    assert_eq!(json["result"]["activated"], false);
+}


### PR DESCRIPTION
## Summary
This hardens `aisw`'s subprocess contract so a desktop GUI can integrate with the existing CLI safely without changing the default human CLI UX.

## What changed
- add machine-readable discovery via `aisw version --json` and `aisw capabilities --json`
- add explicit machine-mode error envelopes for `--json` command flows
- add `aisw add <tool> <profile> --api-key-stdin` to avoid passing secrets in argv
- add `--json` result envelopes for the core mutation path:
  - `add`
  - `use`
  - `remove`
  - `rename`
  - `backup restore`
- suppress human-oriented stdout/stderr output while machine mode is active so JSON stays clean
- add GUI contract coverage in `tests/gui_contract.rs`

## Why
The GUI should treat `aisw` as the local credential authority and use it as a subprocess, not reimplement credential handling. These changes provide the minimum contract needed to safely onboard API keys, discover supported features, and drive core profile mutations with structured results.

## Notes
- default human CLI behavior is preserved
- existing read-command JSON shapes remain unchanged
- `backup restore --json` stays explicit about restoring without activation
- progress streaming, verify/repair, and GUI bootstrap detection are intentionally left for follow-up PRs

## Verification
- `cargo test`
- `cargo test --test gui_contract --test cli_basic --test add_cmd --test use_cmd --test backup_cmd --test json_output_contract`
