### PR TITLE
Add GUI-safe init bootstrap and OAuth progress streams

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -25,6 +25,9 @@ aisw --non-interactive --quiet <command>
 # Add an API key profile without any prompts
 aisw --non-interactive add claude ci --api-key "$ANTHROPIC_API_KEY"
 
+# Or avoid passing the secret in argv
+printf '%s' "$ANTHROPIC_API_KEY" | aisw --non-interactive add claude ci --api-key-stdin --json
+
 # Add from an already-exported environment variable
 aisw --non-interactive add codex ci --from-env
 
@@ -39,9 +42,17 @@ Interactive OAuth flows (`aisw add claude personal` without flags) are not avail
 
 ## Machine-readable output
 
-All inventory and status commands support `--json`:
+Read commands support `--json`, and core mutation commands now expose machine envelopes as well:
 
 ```sh
+aisw version --json
+aisw capabilities --json
+aisw init --json --no-shell-hook --detect-live
+aisw add claude work --api-key-stdin --json
+aisw use claude work --json
+aisw remove claude work --yes --json
+aisw rename claude work personal --json
+aisw backup restore 20260325T114502Z-claude-ci --yes --json
 aisw status --json
 aisw status --context --json
 aisw list --json
@@ -51,7 +62,21 @@ aisw backup list --json
 aisw doctor --json
 ```
 
-JSON output goes to stdout. Errors always go to stderr with a non-zero exit code.
+With `--json`, success and expected command failures are emitted as structured JSON on stdout. Human-oriented stdout/stderr output is suppressed. The process still exits non-zero on failure.
+
+For OAuth-based `add`, use `--progress-json` to stream newline-delimited JSON progress events:
+
+```sh
+aisw add claude personal --progress-json
+```
+
+Example event stream:
+
+```json
+{"type":"started","seq":1,"command":"add","tool":"claude","profile":"personal"}
+{"type":"waiting_for_user","seq":3,"command":"add","tool":"claude","profile":"personal","phase":"waiting_for_user","safe_to_cancel":true,"message":"Complete login in the browser or terminal"}
+{"type":"result","seq":5,"command":"add","tool":"claude","profile":"personal","ok":true,"result":{"tool":"claude","profile":"personal","auth_method":"oauth","credential_backend":"file","active":false,"source":null,"warnings":[]}}
+```
 
 ### Useful JSON patterns
 
@@ -83,11 +108,13 @@ aisw backup list --json | jq '[.[] | select(.profile == "claude/work")] | sort_b
 | Output | Destination | Notes |
 |---|---|---|
 | Human-readable tables and status | stdout | Suppressed by `--quiet` |
-| Errors | stderr + non-zero exit | Always present, never suppressed |
+| Errors in human mode | stderr + non-zero exit | Always present, never suppressed |
+| Errors in machine mode (`--json`, `--progress-json`) | stdout + non-zero exit | Structured JSON envelope |
 | Prompts | stderr or tty | Only shown without `--non-interactive` and without `--yes` |
 | `aisw use --emit-env` / `aisw context use --emit-env` | stdout | Shell variable exports; not affected by `--quiet` |
 | `aisw shell-hook` | stdout | Shell hook code; not affected by `--quiet` |
 | JSON output (`--json`) | stdout | Not affected by `--quiet` |
+| Progress JSON (`--progress-json`) | stdout | One JSON object per line, intended for GUI/OAuth flows |
 
 Exit code `0` means success. Any non-zero exit code means failure; the error message is on stderr.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,8 +20,8 @@ aisw [--no-color] [--non-interactive] [--quiet] <command> ...
 ## At a glance
 
 ```text
-aisw init [--yes]
-aisw add <tool> <profile> [--api-key KEY] [--from-env] [--from-live] [--label TEXT] [--credential-backend file|system-keyring] [--set-active] [--yes]
+aisw init [--yes] [--json --no-shell-hook [--detect-live]]
+aisw add <tool> <profile> [--api-key KEY|--api-key-stdin] [--from-env] [--from-live] [--label TEXT] [--credential-backend file|system-keyring] [--set-active] [--yes] [--json|--progress-json]
 aisw context create <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>]
 aisw context list [--search TEXT] [--json]
 aisw context use <name> [--state-mode isolated|shared] [--emit-env]
@@ -56,6 +56,7 @@ aisw doctor [--json]
 
 ```text
 aisw init [--yes]
+aisw init --json --no-shell-hook [--detect-live]
 ```
 
 Bootstrap command. Run once after install.
@@ -68,9 +69,13 @@ Bootstrap command. Run once after install.
 | Flag | Effect |
 |---|---|
 | `--yes` | Accept all prompts without confirmation |
+| `--json` | Return a machine-readable bootstrap payload instead of interactive output |
+| `--no-shell-hook` | Skip shell hook installation or modification; required with `--json` |
+| `--detect-live` | Include live credential detection results in the machine payload |
 
 Notes:
 - `init` is safe to re-run. If `~/.aisw/` already exists, it skips creation and proceeds to detection.
+- `init --json` is non-prompting by design. It creates `~/.aisw/config.json`, never edits shell rc files, and can report live credentials without importing them.
 - For Gemini, when both `~/.gemini/.env` and OAuth cache files are present, import uses the `.env` file first.
 - For Claude Code on macOS, `init` checks the Keychain before checking the credentials file.
 - `init` will not import a duplicate if the OAuth identity matches an already-stored profile.
@@ -78,6 +83,7 @@ Notes:
 ```sh
 aisw init
 aisw init --yes
+aisw init --json --no-shell-hook --detect-live
 ```
 
 ---
@@ -85,7 +91,7 @@ aisw init --yes
 ## `aisw add`
 
 ```text
-aisw add <tool> <profile> [--api-key KEY] [--from-env] [--from-live] [--label TEXT] [--credential-backend file|system-keyring] [--set-active] [--yes]
+aisw add <tool> <profile> [--api-key KEY|--api-key-stdin] [--from-env] [--from-live] [--label TEXT] [--credential-backend file|system-keyring] [--set-active] [--yes] [--json|--progress-json]
 ```
 
 Create a named profile.
@@ -93,16 +99,20 @@ Create a named profile.
 | Flag | Effect |
 |---|---|
 | `--api-key KEY` | Store the given API key |
+| `--api-key-stdin` | Read the API key from stdin until EOF |
 | `--from-env` | Read the key from the tool's env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) |
 | `--from-live` | Capture the tool's current live credentials without launching login |
 | `--label TEXT` | Human-readable description, shown in `list` and `status` |
 | `--credential-backend file|system-keyring` | Override where `aisw` stores the managed profile secret |
 | `--set-active` | Activate the profile immediately after adding |
 | `--yes` | Overwrite an existing profile when used with `--from-live` |
+| `--json` | Return a single machine-readable result envelope |
+| `--progress-json` | Stream newline-delimited JSON progress events, then a final result event |
 
 Notes:
 - Without `--api-key`, `--from-env`, or `--from-live`, `add` runs the interactive OAuth flow for the tool.
 - In `--non-interactive` mode, interactive OAuth is not available and the command fails.
+- `--api-key-stdin` is intended for GUI and automation integrations that should not expose secrets in process arguments.
 - `--from-live` captures what the tool is currently using; it does not launch a browser or auth flow.
 - `--from-live` always activates the profile because those credentials are already live.
 - `--from-live --yes` overwrites an existing profile in place; the existing entry is not removed until capture succeeds.
@@ -117,7 +127,9 @@ Live credential locations by tool:
 
 ```sh
 aisw add claude work --api-key "$ANTHROPIC_API_KEY"
+printf '%s' "$ANTHROPIC_API_KEY" | aisw add claude work --api-key-stdin --json
 aisw add codex ci --from-env
+aisw add claude personal --progress-json
 aisw add gemini personal --label "Personal account" --set-active
 aisw add claude work --from-live
 aisw add codex work --from-live --yes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,6 +35,12 @@ aisw init
 
 This creates `~/.aisw/`, offers to install the optional shell hook (recommended), and detects any accounts you are already logged into. If you are already signed into Claude Code, Codex, or Gemini, `init` will offer to import those credentials as named profiles so you start without re-authenticating.
 
+For GUI or other machine-driven onboarding, use the non-prompting bootstrap path instead:
+
+```sh
+aisw init --json --no-shell-hook --detect-live
+```
+
 ## 3. Add profiles
 
 **API key:**
@@ -43,6 +49,12 @@ This creates `~/.aisw/`, offers to install the optional shell hook (recommended)
 aisw add claude work --api-key "$ANTHROPIC_API_KEY"
 aisw add codex work --api-key "$OPENAI_API_KEY"
 aisw add gemini work --api-key "$GEMINI_API_KEY"
+```
+
+**API key from stdin** (safer for GUIs and subprocess clients):
+
+```sh
+printf '%s' "$ANTHROPIC_API_KEY" | aisw add claude work --api-key-stdin --json
 ```
 
 **From the current environment variable** (useful in CI or when the key is already exported):
@@ -57,6 +69,12 @@ aisw add codex ci --from-env
 aisw add claude personal
 aisw add codex personal
 aisw add gemini personal
+```
+
+If you want machine-readable OAuth progress for a GUI:
+
+```sh
+aisw add claude personal --progress-json
 ```
 
 **Capture the currently logged-in account** (no re-login):

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -529,6 +529,18 @@ pub struct InitArgs {
     /// Answer yes to all confirmation prompts
     #[arg(long)]
     pub yes: bool,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
+
+    /// Do not install or modify shell hook files
+    #[arg(long)]
+    pub no_shell_hook: bool,
+
+    /// Detect existing live upstream credentials without importing them
+    #[arg(long)]
+    pub detect_live: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -26,6 +26,15 @@ pub fn run(args: AddArgs, home: &Path) -> Result<()> {
 }
 
 pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<()> {
+    let mut progress = machine::ProgressReporter::new(
+        "add",
+        Some(args.tool.binary_name()),
+        Some(args.profile_name.clone()),
+    );
+    if let Some(progress) = progress.as_mut() {
+        progress.started()?;
+    }
+
     let requested_backend = args.credential_backend.map(map_cli_backend);
     validate_requested_backend(args.tool, requested_backend)?;
 
@@ -112,7 +121,13 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
         if args.set_active {
             config_store.set_active(args.tool, &args.profile_name)?;
         }
-        emit_add_result(&args, backend, Some(env_var), AuthMethod::ApiKey)?;
+        emit_add_result(
+            &args,
+            backend,
+            Some(env_var),
+            AuthMethod::ApiKey,
+            progress.as_mut(),
+        )?;
         return Ok(());
     } else if let Some(api_key) = api_key_arg.as_deref() {
         let backend = resolved_api_key_backend(&args);
@@ -150,6 +165,14 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
                  Re-run without --non-interactive, or pass --api-key.",
                 args.tool.display_name()
             );
+        }
+        if let Some(progress) = progress.as_mut() {
+            progress.info("starting_upstream_auth", "Starting upstream OAuth flow")?;
+            progress.waiting_for_user(
+                "waiting_for_user",
+                "Complete login in the browser or terminal",
+                true,
+            )?;
         }
         match args.tool {
             Tool::Claude => {
@@ -220,11 +243,14 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
         }
     };
 
+    if let Some(progress) = progress.as_mut() {
+        progress.info("applying_changes", "Applying captured credentials")?;
+    }
     if args.set_active {
         config_store.set_active(args.tool, &args.profile_name)?;
     }
 
-    emit_add_result(&args, backend, source, auth_method)?;
+    emit_add_result(&args, backend, source, auth_method, progress.as_mut())?;
 
     Ok(())
 }
@@ -946,19 +972,28 @@ fn finalize_from_live(
     backend: CredentialBackend,
     auth_method: AuthMethod,
 ) -> Result<()> {
-    if args.json {
-        machine::print_success(
+    let result = serde_json::json!({
+        "tool": tool.binary_name(),
+        "profile": args.profile_name,
+        "auth_method": auth_label(auth_method),
+        "credential_backend": backend.display_name(),
+        "active": true,
+        "source": "from_live",
+        "warnings": Vec::<String>::new(),
+    });
+    if runtime::is_progress_json() {
+        if let Some(mut progress) = machine::ProgressReporter::new(
             "add",
-            serde_json::json!({
-                "tool": tool.binary_name(),
-                "profile": args.profile_name,
-                "auth_method": auth_label(auth_method),
-                "credential_backend": backend.display_name(),
-                "active": true,
-                "source": "from_live",
-                "warnings": Vec::<String>::new(),
-            }),
-        )?;
+            Some(tool.binary_name()),
+            Some(args.profile_name.clone()),
+        ) {
+            progress.started()?;
+            progress.info("applying_changes", "Applying captured credentials")?;
+            progress.result(true, result)?;
+            return Ok(());
+        }
+    } else if args.json {
+        machine::print_success("add", result)?;
         return Ok(());
     }
     output::print_title("Added profile");
@@ -1041,20 +1076,22 @@ fn emit_add_result(
     backend: CredentialBackend,
     source: Option<&str>,
     auth_method: AuthMethod,
+    progress: Option<&mut machine::ProgressReporter>,
 ) -> Result<()> {
-    if args.json {
-        machine::print_success(
-            "add",
-            serde_json::json!({
-                "tool": args.tool.binary_name(),
-                "profile": args.profile_name,
-                "auth_method": auth_label(auth_method),
-                "credential_backend": backend.display_name(),
-                "active": args.set_active || args.from_live,
-                "source": source,
-                "warnings": Vec::<String>::new(),
-            }),
-        )?;
+    let result = serde_json::json!({
+        "tool": args.tool.binary_name(),
+        "profile": args.profile_name,
+        "auth_method": auth_label(auth_method),
+        "credential_backend": backend.display_name(),
+        "active": args.set_active || args.from_live,
+        "source": source,
+        "warnings": Vec::<String>::new(),
+    });
+    if let Some(progress) = progress {
+        progress.result(true, result)?;
+        return Ok(());
+    } else if args.json {
+        machine::print_success("add", result)?;
         return Ok(());
     }
 

--- a/src/commands/capabilities.rs
+++ b/src/commands/capabilities.rs
@@ -19,6 +19,8 @@ struct FeatureFlags {
     api_key_stdin: bool,
     mutation_json: bool,
     progress_json: bool,
+    non_prompting_init: bool,
+    detect_live_init: bool,
     verify: bool,
     repair: bool,
     contexts: bool,
@@ -51,7 +53,9 @@ pub fn run(args: CapabilitiesArgs) -> Result<()> {
         features: FeatureFlags {
             api_key_stdin: true,
             mutation_json: true,
-            progress_json: false,
+            progress_json: true,
+            non_prompting_init: true,
+            detect_live_init: true,
             verify: false,
             repair: false,
             contexts: true,
@@ -71,7 +75,7 @@ pub fn run(args: CapabilitiesArgs) -> Result<()> {
         println!("machine features");
         println!("  api_key_stdin: true");
         println!("  mutation_json: true");
-        println!("  progress_json: false");
+        println!("  progress_json: true");
     }
 
     Ok(())

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -7,9 +7,12 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use chrono::Utc;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input};
+use serde::Serialize;
 
 use crate::auth;
+use crate::cli::InitArgs;
 use crate::config::{AuthMethod, ConfigStore, CredentialBackend, ProfileMeta};
+use crate::machine;
 use crate::output;
 use crate::profile::{validate_profile_name, ProfileStore};
 use crate::runtime;
@@ -18,6 +21,51 @@ use crate::types::Tool;
 
 // Marker written by shell_hook.rs — must match.
 pub(crate) const HOOK_MARKER: &str = "# Added by aisw";
+
+#[derive(Serialize)]
+struct InitMachinePayload {
+    aisw_home: String,
+    created_home: bool,
+    created_config: bool,
+    shell: InitShellStatus,
+    detected_tools: Vec<DetectedToolStatus>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    live_accounts: Vec<LiveAccountStatus>,
+}
+
+#[derive(Serialize)]
+struct InitShellStatus {
+    detected: Option<String>,
+    action: &'static str,
+    rc_file: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DetectedToolStatus {
+    tool: &'static str,
+    detected: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+}
+
+#[derive(Serialize)]
+struct LiveAccountStatus {
+    tool: &'static str,
+    detected: bool,
+    outcome: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auth_method: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    existing_profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+}
 
 pub(crate) fn run_inner(
     aisw_home: &Path,
@@ -70,11 +118,102 @@ pub(crate) fn run_inner(
     Ok(())
 }
 
+pub(crate) fn run_machine(
+    aisw_home: &Path,
+    user_home: &Path,
+    shell_env: Option<&str>,
+    args: &InitArgs,
+) -> Result<()> {
+    if !args.no_shell_hook {
+        anyhow::bail!(
+            "init --json requires --no-shell-hook to avoid shell file mutation.\n  \
+             Re-run with 'aisw init --json --no-shell-hook', or use interactive init."
+        );
+    }
+
+    let (created_home, created_config) = ensure_aisw_home(aisw_home)?;
+    let detected_tools = detect_supported_tools();
+    let shell_name = normalized_shell_name(shell_env);
+    let live_accounts = if args.detect_live {
+        detect_live_accounts(aisw_home, user_home, &detected_tools)?
+    } else {
+        Vec::new()
+    };
+
+    machine::print_success(
+        "init",
+        InitMachinePayload {
+            aisw_home: aisw_home.display().to_string(),
+            created_home,
+            created_config,
+            shell: InitShellStatus {
+                rc_file: shell_name
+                    .as_deref()
+                    .map(|shell| rc_file(user_home, shell).display().to_string()),
+                detected: shell_name,
+                action: "skipped",
+            },
+            detected_tools: Tool::ALL
+                .into_iter()
+                .map(|tool| {
+                    detected_tool_status(
+                        tool,
+                        detected_tools.get(&tool).and_then(|entry| entry.as_ref()),
+                    )
+                })
+                .collect(),
+            live_accounts,
+        },
+    )
+}
+
+fn ensure_aisw_home(aisw_home: &Path) -> Result<(bool, bool)> {
+    let created_home = !aisw_home.exists();
+    let created_config = !aisw_home.join("config.json").exists();
+    fs::create_dir_all(aisw_home)
+        .with_context(|| format!("could not create {}", aisw_home.display()))?;
+    ConfigStore::new(aisw_home).load()?;
+    Ok((created_home, created_config))
+}
+
 fn detect_supported_tools() -> HashMap<Tool, Option<DetectedTool>> {
     Tool::ALL
         .into_iter()
         .map(|tool| (tool, tool_detection::detect(tool)))
         .collect()
+}
+
+fn detected_tool_status(tool: Tool, detected: Option<&DetectedTool>) -> DetectedToolStatus {
+    DetectedToolStatus {
+        tool: tool.binary_name(),
+        detected: detected.is_some(),
+        version: detected.and_then(|entry| entry.version.clone()),
+        path: detected.map(|entry| entry.binary_path.display().to_string()),
+    }
+}
+
+fn detect_live_accounts(
+    aisw_home: &Path,
+    user_home: &Path,
+    detected: &HashMap<Tool, Option<DetectedTool>>,
+) -> Result<Vec<LiveAccountStatus>> {
+    Ok(vec![
+        detect_live_claude(
+            aisw_home,
+            user_home,
+            detected.get(&Tool::Claude).and_then(|entry| entry.as_ref()),
+        )?,
+        detect_live_codex(
+            aisw_home,
+            user_home,
+            detected.get(&Tool::Codex).and_then(|entry| entry.as_ref()),
+        )?,
+        detect_live_gemini(
+            aisw_home,
+            user_home,
+            detected.get(&Tool::Gemini).and_then(|entry| entry.as_ref()),
+        )?,
+    ])
 }
 
 fn print_detected_tools(detected: &HashMap<Tool, Option<DetectedTool>>) {
@@ -444,6 +583,252 @@ fn extract_gemini_api_key(bytes: &[u8]) -> Option<String> {
         .ok()?
         .lines()
         .find_map(|line| line.strip_prefix("GEMINI_API_KEY=").map(ToOwned::to_owned))
+}
+
+fn detect_live_claude(
+    aisw_home: &Path,
+    user_home: &Path,
+    detected: Option<&DetectedTool>,
+) -> Result<LiveAccountStatus> {
+    let profile_store = ProfileStore::new(aisw_home);
+    let config_store = ConfigStore::new(aisw_home);
+    let local_state =
+        auth::claude::live_local_state_dir(user_home).map(|path| path.display().to_string());
+    let maybe_snapshot = auth::claude::live_credentials_snapshot_for_import(user_home)?;
+
+    let Some(snapshot) = maybe_snapshot else {
+        let (outcome, note) = if auth::claude::keychain_import_supported() && local_state.is_some()
+        {
+            (
+                "local_state_without_importable_auth",
+                Some(
+                    "Claude local state exists, but aisw could not find importable auth in ~/.claude/.credentials.json or the system keyring."
+                        .to_owned(),
+                ),
+            )
+        } else {
+            ("no_live_auth", None)
+        };
+        return Ok(LiveAccountStatus {
+            tool: Tool::Claude.binary_name(),
+            detected: detected.is_some(),
+            outcome,
+            auth_method: None,
+            source_description: None,
+            existing_profile: None,
+            local_state,
+            note,
+        });
+    };
+
+    let (source_description, source_bytes) = match snapshot.source {
+        auth::claude::LiveCredentialSource::File(path) => {
+            (format!("found {}", path.display()), snapshot.bytes)
+        }
+        auth::claude::LiveCredentialSource::Keychain => (
+            format!("found {}", auth::system_keyring::display_name()),
+            snapshot.bytes,
+        ),
+    };
+    let auth_method = if extract_json_string_field(&source_bytes, "apiKey").is_some() {
+        "api_key"
+    } else {
+        "oauth"
+    };
+    let account_bytes = auth::claude::read_live_oauth_account_metadata_for_import(user_home)?;
+    let existing_profile = if auth_method == "oauth" {
+        existing_claude_profile_for_exact_credentials(
+            &profile_store,
+            &config_store,
+            &source_bytes,
+            account_bytes.as_deref(),
+        )?
+        .or_else(|| {
+            auth::identity::existing_claude_oauth_profile_for_live_state(
+                &profile_store,
+                &config_store,
+                &source_bytes,
+                account_bytes.as_deref(),
+            )
+            .ok()
+            .flatten()
+        })
+    } else if let Some(api_key) = extract_json_string_field(&source_bytes, "apiKey") {
+        auth::identity::existing_api_key_profile_for_secret(
+            &profile_store,
+            &config_store,
+            Tool::Claude,
+            &api_key,
+        )?
+    } else {
+        None
+    };
+
+    Ok(LiveAccountStatus {
+        tool: Tool::Claude.binary_name(),
+        detected: detected.is_some(),
+        outcome: if existing_profile.is_some() {
+            "already_managed"
+        } else {
+            "detected"
+        },
+        auth_method: Some(auth_method),
+        source_description: Some(source_description),
+        existing_profile,
+        local_state,
+        note: None,
+    })
+}
+
+fn detect_live_codex(
+    aisw_home: &Path,
+    user_home: &Path,
+    detected: Option<&DetectedTool>,
+) -> Result<LiveAccountStatus> {
+    let profile_store = ProfileStore::new(aisw_home);
+    let config_store = ConfigStore::new(aisw_home);
+    let local_state =
+        auth::codex::live_local_state_dir(user_home).map(|path| path.display().to_string());
+    let maybe_snapshot = auth::codex::live_credentials_snapshot_for_import(user_home)?;
+
+    let Some(snapshot) = maybe_snapshot else {
+        let note = if local_state.is_some() {
+            let storage = auth::codex::live_auth_storage(user_home)?
+                .unwrap_or(auth::codex::LiveAuthStorage::Auto);
+            Some(match storage {
+                auth::codex::LiveAuthStorage::Keyring => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json or the system keyring.".to_owned(),
+                auth::codex::LiveAuthStorage::Auto => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json. Codex may be using the system keyring instead of a file backend.".to_owned(),
+                auth::codex::LiveAuthStorage::File => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json even though the configured backend is file.".to_owned(),
+                auth::codex::LiveAuthStorage::Unknown => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json. The configured auth backend is not recognized.".to_owned(),
+            })
+        } else {
+            None
+        };
+        return Ok(LiveAccountStatus {
+            tool: Tool::Codex.binary_name(),
+            detected: detected.is_some(),
+            outcome: if local_state.is_some() {
+                "local_state_without_importable_auth"
+            } else {
+                "no_live_auth"
+            },
+            auth_method: None,
+            source_description: None,
+            existing_profile: None,
+            local_state,
+            note,
+        });
+    };
+
+    let source_description = format!("found {}", snapshot.source_path.display());
+    let source_bytes = snapshot.bytes;
+    let auth_method = if extract_json_string_field(&source_bytes, "token").is_some() {
+        "api_key"
+    } else {
+        "oauth"
+    };
+    let existing_profile = if auth_method == "api_key" {
+        let secret = extract_json_string_field(&source_bytes, "token")
+            .context("Codex auth.json is missing token field for API-key detection")?;
+        auth::identity::existing_api_key_profile_for_secret(
+            &profile_store,
+            &config_store,
+            Tool::Codex,
+            &secret,
+        )?
+    } else {
+        auth::identity::existing_oauth_profile_for_json_bytes(
+            &profile_store,
+            &config_store,
+            Tool::Codex,
+            &source_bytes,
+        )?
+    };
+
+    Ok(LiveAccountStatus {
+        tool: Tool::Codex.binary_name(),
+        detected: detected.is_some(),
+        outcome: if existing_profile.is_some() {
+            "already_managed"
+        } else {
+            "detected"
+        },
+        auth_method: Some(auth_method),
+        source_description: Some(source_description),
+        existing_profile,
+        local_state,
+        note: None,
+    })
+}
+
+fn detect_live_gemini(
+    aisw_home: &Path,
+    user_home: &Path,
+    detected: Option<&DetectedTool>,
+) -> Result<LiveAccountStatus> {
+    let profile_store = ProfileStore::new(aisw_home);
+    let config_store = ConfigStore::new(aisw_home);
+    let local_state = auth::gemini::live_dir(user_home)
+        .exists()
+        .then(|| auth::gemini::live_dir(user_home).display().to_string());
+    let Some(selection) = auth::gemini::detect_live_import_selection(user_home)? else {
+        return Ok(LiveAccountStatus {
+            tool: Tool::Gemini.binary_name(),
+            detected: detected.is_some(),
+            outcome: if local_state.is_some() {
+                "local_state_without_importable_auth"
+            } else {
+                "no_live_auth"
+            },
+            auth_method: None,
+            source_description: None,
+            existing_profile: None,
+            local_state,
+            note: None,
+        });
+    };
+
+    let auth_method = match selection.method {
+        AuthMethod::ApiKey => "api_key",
+        AuthMethod::OAuth => "oauth",
+    };
+    let existing_profile = match selection.method {
+        AuthMethod::ApiKey => {
+            let key_bytes = fs::read(&selection.env_file)
+                .with_context(|| format!("could not read {}", selection.env_file.display()))?;
+            let key = extract_gemini_api_key(&key_bytes)
+                .context("Gemini .env is missing GEMINI_API_KEY entry")?;
+            auth::identity::existing_api_key_profile_for_secret(
+                &profile_store,
+                &config_store,
+                Tool::Gemini,
+                &key,
+            )?
+        }
+        AuthMethod::OAuth => auth::gemini::existing_oauth_profile_for_live_files(
+            &profile_store,
+            &config_store,
+            &selection.oauth_files,
+        )?,
+    };
+
+    Ok(LiveAccountStatus {
+        tool: Tool::Gemini.binary_name(),
+        detected: detected.is_some(),
+        outcome: if existing_profile.is_some() {
+            "already_managed"
+        } else {
+            "detected"
+        },
+        auth_method: Some(auth_method),
+        source_description: Some(selection.source_description),
+        existing_profile,
+        local_state,
+        note: selection.has_both_sources.then_some(
+            "Both Gemini API key (.env) and OAuth cache were found. Detection follows .env precedence."
+                .to_owned(),
+        ),
+    })
 }
 
 fn import_claude(
@@ -954,6 +1339,64 @@ mod tests {
 
     fn run(aisw_home: &Path, user_home: &Path, shell: Option<&str>) -> Result<()> {
         run_inner(aisw_home, user_home, shell, true)
+    }
+
+    #[test]
+    fn ensure_aisw_home_reports_created_flags() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+
+        let (created_home, created_config) = ensure_aisw_home(&aisw_home).unwrap();
+        assert!(created_home);
+        assert!(created_config);
+
+        let (created_home, created_config) = ensure_aisw_home(&aisw_home).unwrap();
+        assert!(!created_home);
+        assert!(!created_config);
+    }
+
+    #[test]
+    fn detect_live_claude_reports_detected_oauth() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("home");
+        fs::create_dir_all(user_home.join(".claude")).unwrap();
+        fs::write(
+            user_home.join(".claude").join(".credentials.json"),
+            br#"{"oauthToken":"tok"}"#,
+        )
+        .unwrap();
+        std::env::set_var("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        let status = detect_live_claude(&aisw_home, &user_home, None).unwrap();
+        std::env::remove_var("AISW_CLAUDE_AUTH_STORAGE");
+
+        assert_eq!(status.tool, "claude");
+        assert_eq!(status.outcome, "detected");
+        assert_eq!(status.auth_method, Some("oauth"));
+        assert!(status
+            .source_description
+            .unwrap()
+            .contains(".credentials.json"));
+    }
+
+    #[test]
+    fn detect_live_gemini_prefers_env_when_both_sources_exist() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("home");
+        let gemini_dir = user_home.join(".gemini");
+        fs::create_dir_all(&gemini_dir).unwrap();
+        fs::write(gemini_dir.join(".env"), b"GEMINI_API_KEY=AIza-priority\n").unwrap();
+        fs::write(gemini_dir.join("oauth_creds.json"), br#"{"token":"oauth"}"#).unwrap();
+
+        let status = detect_live_gemini(&aisw_home, &user_home, None).unwrap();
+
+        assert_eq!(status.tool, "gemini");
+        assert_eq!(status.outcome, "detected");
+        assert_eq!(status.auth_method, Some("api_key"));
+        assert!(status.note.unwrap().contains(".env precedence"));
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -38,6 +38,10 @@ pub fn dispatch(cli: Cli) -> Result<()> {
                     .ok()
                     .map(|_| "pwsh".to_owned())
             });
+            if args.json {
+                init::run_machine(&home, &user_home, shell_env.as_deref(), &args)?;
+                return Ok(());
+            }
             if crate::runtime::is_non_interactive() && !args.yes {
                 anyhow::bail!(
                     "init requires confirmation and prompt input.\n  \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub fn run() -> Result<()> {
                 let failure = machine::parse_error(None, &err);
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&failure)
+                    machine::serialize_json(&failure)
                         .unwrap_or_else(|_| "{\"ok\":false}".to_owned())
                 );
                 std::process::exit(err.exit_code());

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,6 +1,8 @@
 use anyhow::Error;
 use serde::Serialize;
 
+use crate::runtime;
+
 use crate::error::AiswError;
 
 #[derive(Debug, Clone, Serialize)]
@@ -33,13 +35,114 @@ pub struct MachineFailureEnvelope {
     pub error: MachineError,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct ProgressEvent<T: Serialize> {
+    #[serde(rename = "type")]
+    pub event_type: &'static str,
+    pub seq: u64,
+    pub command: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub safe_to_cancel: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ok: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<T>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProgressReporter {
+    command: &'static str,
+    tool: Option<&'static str>,
+    profile: Option<String>,
+    seq: u64,
+}
+
+impl ProgressReporter {
+    pub fn new(
+        command: &'static str,
+        tool: Option<&'static str>,
+        profile: Option<String>,
+    ) -> Option<Self> {
+        runtime::is_progress_json().then_some(Self {
+            command,
+            tool,
+            profile,
+            seq: 0,
+        })
+    }
+
+    pub fn started(&mut self) -> anyhow::Result<()> {
+        self.emit::<serde_json::Value>("started", None, None, None, None, None)
+    }
+
+    pub fn info(&mut self, phase: &'static str, message: impl Into<String>) -> anyhow::Result<()> {
+        self.emit::<serde_json::Value>("info", Some(phase), None, Some(message.into()), None, None)
+    }
+
+    pub fn waiting_for_user(
+        &mut self,
+        phase: &'static str,
+        message: impl Into<String>,
+        safe_to_cancel: bool,
+    ) -> anyhow::Result<()> {
+        self.emit::<serde_json::Value>(
+            "waiting_for_user",
+            Some(phase),
+            Some(safe_to_cancel),
+            Some(message.into()),
+            None,
+            None,
+        )
+    }
+
+    pub fn result<T: Serialize>(&mut self, ok: bool, result: T) -> anyhow::Result<()> {
+        self.emit("result", None, None, None, Some(ok), Some(result))
+    }
+
+    fn emit<T: Serialize>(
+        &mut self,
+        event_type: &'static str,
+        phase: Option<&'static str>,
+        safe_to_cancel: Option<bool>,
+        message: Option<String>,
+        ok: Option<bool>,
+        result: Option<T>,
+    ) -> anyhow::Result<()> {
+        self.seq += 1;
+        println!(
+            "{}",
+            serialize_json(&ProgressEvent {
+                event_type,
+                seq: self.seq,
+                command: self.command,
+                tool: self.tool,
+                profile: self.profile.clone(),
+                phase,
+                safe_to_cancel,
+                message,
+                ok,
+                result,
+            })?
+        );
+        Ok(())
+    }
+}
+
 pub fn print_success<T: Serialize>(command: &'static str, result: T) -> anyhow::Result<()> {
     println!(
         "{}",
-        serde_json::to_string_pretty(&MachineEnvelope {
+        serialize_json(&MachineEnvelope {
             ok: true,
             command,
-            result,
+            result
         })?
     );
     Ok(())
@@ -52,7 +155,7 @@ pub fn print_failure(command: Option<&str>, err: &Error, exit_code: i32) {
         error: machine_error(err, exit_code),
     };
 
-    if let Ok(json) = serde_json::to_string_pretty(&failure) {
+    if let Ok(json) = serialize_json(&failure) {
         println!("{json}");
     } else {
         println!(
@@ -60,6 +163,14 @@ pub fn print_failure(command: Option<&str>, err: &Error, exit_code: i32) {
             command.unwrap_or("unknown"),
             exit_code
         );
+    }
+}
+
+pub fn serialize_json<T: Serialize>(value: &T) -> anyhow::Result<String> {
+    if runtime::is_progress_json() {
+        Ok(serde_json::to_string(value)?)
+    } else {
+        Ok(serde_json::to_string_pretty(value)?)
     }
 }
 

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -35,8 +35,42 @@ fn capabilities_json_reports_tool_capabilities() {
     let json = json_output(&env, &["capabilities", "--json"]);
     assert_eq!(json["features"]["api_key_stdin"], true);
     assert_eq!(json["features"]["mutation_json"], true);
+    assert_eq!(json["features"]["progress_json"], true);
+    assert_eq!(json["features"]["non_prompting_init"], true);
+    assert_eq!(json["features"]["detect_live_init"], true);
     assert_eq!(json["tools"]["gemini"]["state_modes"][0], "isolated");
     assert_eq!(json["tools"]["codex"]["fail_closed_keyring_identity"], true);
+}
+
+#[test]
+fn init_json_detect_live_returns_machine_bootstrap_state() {
+    let env = TestEnv::new();
+    std::fs::create_dir_all(env.fake_home.join(".claude")).unwrap();
+    std::fs::write(
+        env.fake_home.join(".claude").join(".credentials.json"),
+        br#"{"oauthToken":"tok"}"#,
+    )
+    .unwrap();
+
+    let output = env
+        .cmd()
+        .args(["init", "--json", "--no-shell-hook", "--detect-live"])
+        .env("SHELL", "/bin/zsh")
+        .env("AISW_CLAUDE_AUTH_STORAGE", "file")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "init");
+    assert_eq!(json["result"]["shell"]["action"], "skipped");
+    assert_eq!(json["result"]["shell"]["detected"], "zsh");
+    assert_eq!(json["result"]["live_accounts"][0]["tool"], "claude");
+    assert_eq!(json["result"]["live_accounts"][0]["outcome"], "detected");
+    assert_eq!(json["result"]["live_accounts"][0]["auth_method"], "oauth");
+    assert!(!env.fake_home.join(".zshrc").exists());
 }
 
 #[test]
@@ -182,4 +216,49 @@ fn backup_restore_json_reports_non_activation() {
     assert_eq!(json["ok"], true);
     assert_eq!(json["result"]["backup_id"], backup_id);
     assert_eq!(json["result"]["activated"], false);
+}
+
+#[test]
+fn add_oauth_progress_json_streams_ndjson_events() {
+    let env = TestEnv::new();
+    env.add_script_tool(
+        "claude",
+        "#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"login\" ]; then\n  /bin/mkdir -p \"$HOME/.claude\"\n  printf '%s' '{\"oauthToken\":\"tok\"}' > \"$HOME/.claude/.credentials.json\"\n  exit 0\nfi\necho 'claude 2.3.0'\n",
+    );
+    env.cmd().args(["init", "--yes"]).assert().success();
+
+    let events = {
+        let output = env
+            .cmd()
+            .args(["add", "claude", "work", "--progress-json"])
+            .env("AISW_CLAUDE_AUTH_STORAGE", "file")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(events[0]["type"], "started");
+    assert_eq!(events[0]["tool"], "claude");
+    assert_eq!(events[1]["phase"], "starting_upstream_auth");
+    assert_eq!(events[2]["type"], "waiting_for_user");
+    assert_eq!(events[2]["safe_to_cancel"], true);
+    assert_eq!(events[3]["phase"], "applying_changes");
+    assert_eq!(events.last().unwrap()["type"], "result");
+    assert_eq!(events.last().unwrap()["ok"], true);
+    assert_eq!(events.last().unwrap()["result"]["profile"], "work");
 }


### PR DESCRIPTION
## Summary
This follow-up GUI hardening PR adds the non-prompting bootstrap and progress-streaming contracts needed for desktop onboarding flows, while keeping the existing human CLI behavior unchanged.

## What changed
- add `aisw init --json --no-shell-hook --detect-live` for non-prompting GUI bootstrap
- report detected tools plus live credential discovery state without importing or modifying shell files
- add newline-delimited progress events for OAuth `aisw add ... --progress-json`
- emit compact machine JSON in progress mode so each event stays one line
- mark the new machine features in `aisw capabilities --json`
- document the new bootstrap, stdin-secret, and progress contracts

## Why
The first GUI contract PR covered discovery, mutation JSON, and safe API-key stdin input. The remaining gap was onboarding: a GUI needs to initialize `aisw` without touching shell rc files, detect existing live identities safely, and show progress during OAuth capture.

## Notes
- `init --json` intentionally requires `--no-shell-hook` so machine callers cannot mutate shell config by accident
- `init --json --detect-live` reports state only; importing remains an explicit follow-up action via `aisw add --from-live`
- `--progress-json` is additive and only affects callers that opt into machine progress mode

## Verification
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo +nightly llvm-cov --json --summary-only --branch --output-path coverage-summary.json --fail-under-lines 88 --fail-under-functions 80 --fail-under-regions 88`
- `.github/scripts/coverage-gate.sh coverage-summary.json`
