### PR TITLE
Add GUI-safe verify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ aisw backup restore <backup_id> [--yes]
 aisw uninstall [--dry-run] [--remove-data] [--yes]
 aisw shell-hook <bash|zsh|fish|pwsh>
 aisw doctor [--json]
+aisw verify [--json]
 ```
 
 ## Security

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -53,6 +53,7 @@ aisw use claude work --json
 aisw remove claude work --yes --json
 aisw rename claude work personal --json
 aisw backup restore 20260325T114502Z-claude-ci --yes --json
+aisw verify --json
 aisw status --json
 aisw status --context --json
 aisw list --json
@@ -89,6 +90,9 @@ aisw status --context --json | jq -r '.context.active'
 
 # Check whether the live credentials match the active Claude profile
 aisw status --json | jq '.[] | select(.tool == "claude") | .active_profile_applied'
+
+# Get a one-shot pass/warn/fail verification verdict
+aisw verify --json | jq -r '.summary.status'
 
 # List all stored Codex profile names
 aisw list codex --json | jq -r '.profiles[].name'

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 ---
 title: Command reference
-description: Complete syntax and flag reference for all aisw commands  -  add, context, use, list, status, remove, rename, backup, workspace, init, uninstall, shell-hook, and doctor.
+description: Complete syntax and flag reference for all aisw commands  -  add, context, use, list, status, verify, remove, rename, backup, workspace, init, uninstall, shell-hook, and doctor.
 ---
 
 # Command reference
@@ -46,6 +46,7 @@ aisw backup restore <backup_id> [--yes]
 aisw uninstall [--dry-run] [--remove-data] [--yes]
 aisw shell-hook <bash|zsh|fish|pwsh>
 aisw doctor [--json]
+aisw verify [--json]
 ```
 
 `<tool>` is one of: `claude`, `codex`, `gemini`.
@@ -559,6 +560,34 @@ Check install and environment health: binary locations, `~/.aisw/` permissions, 
 ```sh
 aisw doctor
 aisw doctor --json
+```
+
+---
+
+## `aisw verify`
+
+```text
+aisw verify [--json]
+```
+
+Read-only confidence check that combines installation health with live profile coherence.
+
+- Reuses `doctor` checks for binaries, config, shell hook, keyring, and permissions.
+- Verifies whether each active tool's live credentials still match the profile `aisw` records as active.
+- Returns non-zero when concrete failures are found, such as live mismatch, missing managed credentials, or missing binaries.
+
+| Flag | Effect |
+|---|---|
+| `--json` | Output a machine-readable verification report |
+
+Notes:
+- `verify` is stricter than `status --json`: it adds an overall pass/warn/fail verdict and remediation hints.
+- `verify` is read-only. It never reapplies credentials or modifies shell files.
+- On macOS, Claude file-backed live verification can remain observational because the live Keychain state is not always inspectable.
+
+```sh
+aisw verify
+aisw verify --json
 ```
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -144,6 +144,7 @@ aisw status --context
 # Machine-readable (for scripts)
 aisw status --json
 aisw status --context --json
+aisw verify --json
 
 # List all stored profiles
 aisw list

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,9 +12,10 @@ Run these first when something is wrong:
 ```sh
 aisw doctor
 aisw status --json
+aisw verify --json
 ```
 
-`doctor` checks binary detection, `~/.aisw/` permissions, shell hook status, and keyring availability. `status --json` shows the full state of every tool including live-match status and any credential warnings.
+`doctor` checks binary detection, `~/.aisw/` permissions, shell hook status, and keyring availability. `status --json` shows the full state of every tool including live-match status and any credential warnings. `verify --json` combines both into a pass/warn/fail verdict with remediation hints.
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,12 +115,22 @@ pub enum Command {
     /// Run a health check on the aisw installation and tool environment
     Doctor(DoctorArgs),
 
+    /// Verify that aisw-managed state and live tool state are coherent
+    Verify(VerifyArgs),
+
     /// Bind workspaces to expected contexts and enforce guardrails
     Workspace(WorkspaceArgs),
 }
 
 #[derive(Args, Debug)]
 pub struct DoctorArgs {
+    /// Output results as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct VerifyArgs {
     /// Output results as JSON
     #[arg(long)]
     pub json: bool,
@@ -912,6 +922,15 @@ mod tests {
             panic!("wrong command")
         };
         assert!(args.yes);
+    }
+
+    #[test]
+    fn verify_json_flag() {
+        let cli = parse(&["verify", "--json"]).unwrap();
+        let Command::Verify(args) = cli.command else {
+            panic!("wrong command")
+        };
+        assert!(args.json);
     }
 
     #[test]

--- a/src/commands/capabilities.rs
+++ b/src/commands/capabilities.rs
@@ -56,7 +56,7 @@ pub fn run(args: CapabilitiesArgs) -> Result<()> {
             progress_json: true,
             non_prompting_init: true,
             detect_live_init: true,
-            verify: false,
+            verify: true,
             repair: false,
             contexts: true,
             workspace_bindings: true,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod shell_hook;
 pub mod status;
 pub mod uninstall;
 pub mod use_;
+pub mod verify;
 pub mod version;
 pub mod workspace;
 
@@ -58,6 +59,12 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Command::Backup(args) => backup::run(args.command, &home)?,
         Command::Doctor(args) => {
             let passed = doctor::run(args, &home)?;
+            if !passed {
+                std::process::exit(1);
+            }
+        }
+        Command::Verify(args) => {
+            let passed = verify::run(args, &home)?;
             if !passed {
                 std::process::exit(1);
             }

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -1,0 +1,381 @@
+use std::path::Path;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::cli::VerifyArgs;
+use crate::commands::{doctor, status};
+use crate::runtime;
+use crate::types::Tool;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum VerifyStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ToolVerification {
+    tool: &'static str,
+    status: VerifyStatus,
+    active_profile: Option<String>,
+    stored_profiles: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    issues: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    remediation: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct VerifySummary {
+    status: VerifyStatus,
+    passed: usize,
+    warnings: usize,
+    failed: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct VerifyReport {
+    summary: VerifySummary,
+    tools: Vec<ToolVerification>,
+    doctor: Vec<doctor::CheckResult>,
+}
+
+pub fn run(args: VerifyArgs, home: &Path) -> Result<bool> {
+    let user_home = dirs::home_dir().unwrap_or_else(|| Path::new(".").to_path_buf());
+    let path_var = std::env::var_os("PATH").unwrap_or_default();
+    run_in(args, home, &user_home, path_var.as_os_str())
+}
+
+pub(crate) fn run_in(
+    args: VerifyArgs,
+    home: &Path,
+    user_home: &Path,
+    path_var: &std::ffi::OsStr,
+) -> Result<bool> {
+    let report = collect(home, user_home, path_var)?;
+    let passed = report.summary.status != VerifyStatus::Fail;
+
+    if !runtime::is_quiet() {
+        if args.json {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        } else {
+            print_text(&report);
+        }
+    }
+
+    Ok(passed)
+}
+
+fn collect(home: &Path, user_home: &Path, path_var: &std::ffi::OsStr) -> Result<VerifyReport> {
+    let doctor_report = doctor::collect(home, user_home, path_var);
+    let tool_statuses = status::collect_status(home, user_home, &path_var.to_os_string())?;
+    let tools = tool_statuses
+        .iter()
+        .map(tool_verification)
+        .collect::<Vec<_>>();
+    let summary = summarize(&doctor_report.checks, &tools);
+
+    Ok(VerifyReport {
+        summary,
+        tools,
+        doctor: doctor_report.checks,
+    })
+}
+
+fn tool_verification(tool: &status::ToolStatus) -> ToolVerification {
+    let mut issues = Vec::new();
+    let mut remediation = Vec::new();
+    let status = if !tool.binary_found {
+        issues.push("tool binary not found on PATH".to_owned());
+        remediation.push(format!(
+            "Install {} or run 'aisw doctor --json'",
+            tool.tool.binary_name()
+        ));
+        VerifyStatus::Fail
+    } else if tool.active_profile.is_none() {
+        if tool.stored_profiles > 0 {
+            issues.push("profiles are stored, but no active profile is selected".to_owned());
+            remediation.push(format!(
+                "Run 'aisw use {} <profile>'",
+                tool.tool.binary_name()
+            ));
+            VerifyStatus::Warn
+        } else {
+            issues.push("no managed profiles stored".to_owned());
+            remediation.push(format!(
+                "Run 'aisw add {} <profile>' or import with 'aisw init --json --no-shell-hook --detect-live'",
+                tool.tool.binary_name()
+            ));
+            VerifyStatus::Warn
+        }
+    } else if !tool.credentials_present {
+        issues.push("managed credentials are missing".to_owned());
+        remediation.push(format!(
+            "Restore the profile from backup or re-run 'aisw add {} {}'",
+            tool.tool.binary_name(),
+            tool.active_profile.as_deref().unwrap_or("<profile>")
+        ));
+        VerifyStatus::Fail
+    } else if !tool.permissions_ok {
+        issues.push("managed credential permissions are too broad".to_owned());
+        remediation
+            .push("Run 'aisw doctor --json' to inspect the failing permission check".to_owned());
+        VerifyStatus::Fail
+    } else if tool.active_profile_applied == Some(false) {
+        issues.push("live tool credentials do not match the recorded active profile".to_owned());
+        remediation.push(format!(
+            "Run 'aisw use {} {}' to reapply the active profile",
+            tool.tool.binary_name(),
+            tool.active_profile.as_deref().unwrap_or("<profile>")
+        ));
+        VerifyStatus::Fail
+    } else if tool.tool == Tool::Claude
+        && tool.credential_backend.as_deref() == Some("file")
+        && cfg!(target_os = "macos")
+        && tool.active_profile_applied.is_none()
+    {
+        issues.push(
+            "live macOS Keychain state was not verified for this Claude file-backed profile"
+                .to_owned(),
+        );
+        remediation.push("Use 'aisw status --json' for the current live-match signal, or switch once with 'aisw use claude <profile>'.".to_owned());
+        VerifyStatus::Warn
+    } else {
+        VerifyStatus::Pass
+    };
+
+    ToolVerification {
+        tool: tool.tool.binary_name(),
+        status,
+        active_profile: tool.active_profile.clone(),
+        stored_profiles: tool.stored_profiles,
+        issues,
+        remediation,
+    }
+}
+
+fn summarize(doctor_checks: &[doctor::CheckResult], tools: &[ToolVerification]) -> VerifySummary {
+    let mut passed = 0usize;
+    let mut warnings = 0usize;
+    let mut failed = 0usize;
+
+    for check in doctor_checks {
+        match check.status {
+            doctor::CheckStatus::Pass => passed += 1,
+            doctor::CheckStatus::Warn => warnings += 1,
+            doctor::CheckStatus::Fail => failed += 1,
+        }
+    }
+
+    for tool in tools {
+        match tool.status {
+            VerifyStatus::Pass => passed += 1,
+            VerifyStatus::Warn => warnings += 1,
+            VerifyStatus::Fail => failed += 1,
+        }
+    }
+
+    let status = if failed > 0 {
+        VerifyStatus::Fail
+    } else if warnings > 0 {
+        VerifyStatus::Warn
+    } else {
+        VerifyStatus::Pass
+    };
+
+    VerifySummary {
+        status,
+        passed,
+        warnings,
+        failed,
+    }
+}
+
+fn print_text(report: &VerifyReport) {
+    crate::output::print_title("Verify");
+    crate::output::print_kv(
+        "Summary",
+        match report.summary.status {
+            VerifyStatus::Pass => "pass",
+            VerifyStatus::Warn => "warn",
+            VerifyStatus::Fail => "fail",
+        },
+    );
+    crate::output::print_kv("Passed", report.summary.passed.to_string());
+    crate::output::print_kv("Warnings", report.summary.warnings.to_string());
+    crate::output::print_kv("Failed", report.summary.failed.to_string());
+    crate::output::print_blank_line();
+
+    for tool in &report.tools {
+        crate::output::print_tool_section(match tool.tool {
+            "claude" => Tool::Claude,
+            "codex" => Tool::Codex,
+            _ => Tool::Gemini,
+        });
+        crate::output::print_kv(
+            "Status",
+            match tool.status {
+                VerifyStatus::Pass => "pass",
+                VerifyStatus::Warn => "warn",
+                VerifyStatus::Fail => "fail",
+            },
+        );
+        crate::output::print_kv("Active", tool.active_profile.as_deref().unwrap_or("none"));
+        for issue in &tool.issues {
+            crate::output::print_info(issue);
+        }
+        for fix in &tool.remediation {
+            crate::output::print_fix(fix);
+        }
+        crate::output::print_blank_line();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool_status(tool: Tool) -> status::ToolStatus {
+        status::ToolStatus {
+            tool,
+            binary_found: true,
+            stored_profiles: 1,
+            active_profile: Some("work".to_owned()),
+            auth_method: Some("api_key".to_owned()),
+            credential_backend: Some("file".to_owned()),
+            state_mode: Some("isolated".to_owned()),
+            active_profile_added_at: None,
+            active_profile_applied: Some(true),
+            credentials_present: true,
+            permissions_ok: true,
+        }
+    }
+
+    #[test]
+    fn verify_fails_when_tool_binary_is_missing() {
+        let mut tool = tool_status(Tool::Gemini);
+        tool.binary_found = false;
+
+        let result = tool_verification(&tool);
+
+        assert_eq!(result.status, VerifyStatus::Fail);
+        assert!(result.issues[0].contains("binary"));
+        assert!(result.remediation[0].contains("aisw doctor --json"));
+    }
+
+    #[test]
+    fn verify_warns_when_profiles_exist_but_none_active() {
+        let mut tool = tool_status(Tool::Claude);
+        tool.active_profile = None;
+        tool.auth_method = None;
+        tool.credential_backend = None;
+        tool.active_profile_applied = None;
+        tool.credentials_present = false;
+
+        let claude = tool_verification(&tool);
+        assert_eq!(claude.status, VerifyStatus::Warn);
+        assert!(claude.issues[0].contains("no active profile"));
+    }
+
+    #[test]
+    fn verify_warns_when_no_profiles_are_stored() {
+        let mut tool = tool_status(Tool::Claude);
+        tool.stored_profiles = 0;
+        tool.active_profile = None;
+        tool.auth_method = None;
+        tool.credential_backend = None;
+        tool.active_profile_applied = None;
+        tool.credentials_present = false;
+
+        let result = tool_verification(&tool);
+
+        assert_eq!(result.status, VerifyStatus::Warn);
+        assert!(result.issues[0].contains("no managed profiles"));
+        assert!(result.remediation[0].contains("aisw add claude"));
+    }
+
+    #[test]
+    fn verify_fails_when_managed_credentials_are_missing() {
+        let mut tool = tool_status(Tool::Codex);
+        tool.credentials_present = false;
+
+        let result = tool_verification(&tool);
+
+        assert_eq!(result.status, VerifyStatus::Fail);
+        assert!(result.issues[0].contains("managed credentials are missing"));
+    }
+
+    #[test]
+    fn verify_fails_when_permissions_are_too_broad() {
+        let mut tool = tool_status(Tool::Codex);
+        tool.permissions_ok = false;
+
+        let result = tool_verification(&tool);
+
+        assert_eq!(result.status, VerifyStatus::Fail);
+        assert!(result.issues[0].contains("permissions"));
+    }
+
+    #[test]
+    fn verify_fails_when_live_state_mismatches_active_profile() {
+        let mut tool = tool_status(Tool::Codex);
+        tool.active_profile_applied = Some(false);
+
+        let codex = tool_verification(&tool);
+        assert_eq!(codex.status, VerifyStatus::Fail);
+        assert!(codex.issues[0].contains("live tool credentials do not match"));
+    }
+
+    #[test]
+    fn verify_passes_when_active_profile_matches_live_state() {
+        let result = tool_verification(&tool_status(Tool::Codex));
+
+        assert_eq!(result.status, VerifyStatus::Pass);
+        assert!(result.issues.is_empty());
+        assert!(result.remediation.is_empty());
+    }
+
+    #[test]
+    fn summarize_counts_pass_warn_and_fail() {
+        let summary = summarize(
+            &[
+                doctor::CheckResult {
+                    name: "config".to_owned(),
+                    status: doctor::CheckStatus::Pass,
+                    detail: "ok".to_owned(),
+                },
+                doctor::CheckResult {
+                    name: "shell".to_owned(),
+                    status: doctor::CheckStatus::Warn,
+                    detail: "warn".to_owned(),
+                },
+            ],
+            &[
+                ToolVerification {
+                    tool: "claude",
+                    status: VerifyStatus::Pass,
+                    active_profile: Some("work".to_owned()),
+                    stored_profiles: 1,
+                    issues: Vec::new(),
+                    remediation: Vec::new(),
+                },
+                ToolVerification {
+                    tool: "codex",
+                    status: VerifyStatus::Fail,
+                    active_profile: Some("work".to_owned()),
+                    stored_profiles: 1,
+                    issues: vec!["mismatch".to_owned()],
+                    remediation: vec!["aisw use codex work".to_owned()],
+                },
+            ],
+        );
+
+        assert_eq!(summary.status, VerifyStatus::Fail);
+        assert_eq!(summary.passed, 2);
+        assert_eq!(summary.warnings, 1);
+        assert_eq!(summary.failed, 1);
+    }
+}

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -38,8 +38,57 @@ fn capabilities_json_reports_tool_capabilities() {
     assert_eq!(json["features"]["progress_json"], true);
     assert_eq!(json["features"]["non_prompting_init"], true);
     assert_eq!(json["features"]["detect_live_init"], true);
+    assert_eq!(json["features"]["verify"], true);
     assert_eq!(json["tools"]["gemini"]["state_modes"][0], "isolated");
     assert_eq!(json["tools"]["codex"]["fail_closed_keyring_identity"], true);
+}
+
+#[test]
+fn verify_json_reports_failures_and_remediation() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.add_fake_tool("codex", "codex 1.0.0");
+    env.add_fake_tool("gemini", "gemini 0.9.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "codex",
+            "work",
+            "--api-key",
+            "sk-codex-test-key-12345",
+        ])
+        .assert()
+        .success();
+    env.cmd().args(["use", "codex", "work"]).assert().success();
+
+    std::fs::write(
+        env.fake_home.join(".codex").join("auth.json"),
+        br#"{"token":"different"}"#,
+    )
+    .unwrap();
+
+    let output = env.output(&["verify", "--json"]);
+    assert!(!output.status.success());
+    assert!(output.stderr.is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["summary"]["status"], "fail");
+    assert!(json["doctor"].is_array());
+    let codex = json["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tool| tool["tool"] == "codex")
+        .unwrap();
+    assert_eq!(codex["status"], "fail");
+    assert!(codex["issues"][0]
+        .as_str()
+        .unwrap()
+        .contains("live tool credentials do not match"));
+    assert!(codex["remediation"][0]
+        .as_str()
+        .unwrap()
+        .contains("aisw use codex work"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `aisw verify` with a JSON machine contract for GUI health checks
- combine doctor checks with per-tool profile/live-state verification and actionable remediation
- advertise verify support in capabilities and document the new command in automation/docs

## Testing
- cargo test --test gui_contract
- cargo test --locked
- cargo clippy --all-targets -- -D warnings
- cargo +nightly llvm-cov --json --summary-only --branch --output-path coverage-summary.json --fail-under-lines 88 --fail-under-functions 80 --fail-under-regions 88
- .github/scripts/coverage-gate.sh coverage-summary.json