### PR TITLE
Add cautious repair command for GUI flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ aisw uninstall [--dry-run] [--remove-data] [--yes]
 aisw shell-hook <bash|zsh|fish|pwsh>
 aisw doctor [--json]
 aisw verify [--json]
+aisw repair [--json] [--dry-run|--apply] [--fix home,permissions]
 ```
 
 ## Security

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -54,6 +54,7 @@ aisw remove claude work --yes --json
 aisw rename claude work personal --json
 aisw backup restore 20260325T114502Z-claude-ci --yes --json
 aisw verify --json
+aisw repair --json --dry-run
 aisw status --json
 aisw status --context --json
 aisw list --json
@@ -93,6 +94,9 @@ aisw status --json | jq '.[] | select(.tool == "claude") | .active_profile_appli
 
 # Get a one-shot pass/warn/fail verification verdict
 aisw verify --json | jq -r '.summary.status'
+
+# Preview safe local repairs and count remaining issues
+aisw repair --json --dry-run | jq -r '.result.summary.issues_remaining'
 
 # List all stored Codex profile names
 aisw list codex --json | jq -r '.profiles[].name'

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 ---
 title: Command reference
-description: Complete syntax and flag reference for all aisw commands  -  add, context, use, list, status, verify, remove, rename, backup, workspace, init, uninstall, shell-hook, and doctor.
+description: Complete syntax and flag reference for all aisw commands  -  add, context, use, list, status, verify, repair, remove, rename, backup, workspace, init, uninstall, shell-hook, and doctor.
 ---
 
 # Command reference
@@ -47,6 +47,7 @@ aisw uninstall [--dry-run] [--remove-data] [--yes]
 aisw shell-hook <bash|zsh|fish|pwsh>
 aisw doctor [--json]
 aisw verify [--json]
+aisw repair [--json] [--dry-run|--apply] [--fix home,permissions]
 ```
 
 `<tool>` is one of: `claude`, `codex`, `gemini`.
@@ -588,6 +589,38 @@ Notes:
 ```sh
 aisw verify
 aisw verify --json
+```
+
+---
+
+## `aisw repair`
+
+```text
+aisw repair [--json] [--dry-run|--apply] [--fix home,permissions]
+```
+
+Preview or apply safe local repairs for aisw-managed state.
+
+- `home`: create `AISW_HOME` and a default `config.json` when missing
+- `permissions`: normalize aisw-managed directories to `0700` and files to `0600` on Unix
+
+| Flag | Effect |
+|---|---|
+| `--json` | Output a machine-readable repair result envelope |
+| `--dry-run` | Preview repair actions without mutating files |
+| `--apply` | Apply the selected safe fixes |
+| `--fix` | Limit repairs to one or more fix categories; accepts comma-separated values |
+
+Notes:
+- If neither `--dry-run` nor `--apply` is provided, `repair` defaults to dry-run mode.
+- `repair` is explicit and cautious. It does not reapply live credentials, restore backups, or modify shell rc files.
+- `--fix` defaults to all currently safe repair categories.
+
+```sh
+aisw repair
+aisw repair --json --dry-run
+aisw repair --apply --fix home
+aisw repair --json --apply --fix home,permissions
 ```
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -145,6 +145,7 @@ aisw status --context
 aisw status --json
 aisw status --context --json
 aisw verify --json
+aisw repair --json --dry-run
 
 # List all stored profiles
 aisw list

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,9 +13,10 @@ Run these first when something is wrong:
 aisw doctor
 aisw status --json
 aisw verify --json
+aisw repair --json --dry-run
 ```
 
-`doctor` checks binary detection, `~/.aisw/` permissions, shell hook status, and keyring availability. `status --json` shows the full state of every tool including live-match status and any credential warnings. `verify --json` combines both into a pass/warn/fail verdict with remediation hints.
+`doctor` checks binary detection, `~/.aisw/` permissions, shell hook status, and keyring availability. `status --json` shows the full state of every tool including live-match status and any credential warnings. `verify --json` combines both into a pass/warn/fail verdict with remediation hints. `repair --json --dry-run` previews safe local fixes for missing aisw state or broad permissions.
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,6 +118,9 @@ pub enum Command {
     /// Verify that aisw-managed state and live tool state are coherent
     Verify(VerifyArgs),
 
+    /// Repair safe local aisw state issues such as missing home/config or broad permissions
+    Repair(RepairArgs),
+
     /// Bind workspaces to expected contexts and enforce guardrails
     Workspace(WorkspaceArgs),
 }
@@ -134,6 +137,31 @@ pub struct VerifyArgs {
     /// Output results as JSON
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum RepairFix {
+    Home,
+    Permissions,
+}
+
+#[derive(Args, Debug)]
+pub struct RepairArgs {
+    /// Output results as JSON
+    #[arg(long)]
+    pub json: bool,
+
+    /// Preview safe repair actions without mutating files
+    #[arg(long, conflicts_with = "apply")]
+    pub dry_run: bool,
+
+    /// Apply the selected safe fixes
+    #[arg(long)]
+    pub apply: bool,
+
+    /// Limit repairs to one or more fix categories
+    #[arg(long, value_enum, value_delimiter = ',', num_args = 1..)]
+    pub fix: Vec<RepairFix>,
 }
 
 #[derive(Args, Debug)]
@@ -931,6 +959,17 @@ mod tests {
             panic!("wrong command")
         };
         assert!(args.json);
+    }
+
+    #[test]
+    fn repair_flags_parse() {
+        let cli = parse(&["repair", "--json", "--apply", "--fix", "home,permissions"]).unwrap();
+        let Command::Repair(args) = cli.command else {
+            panic!("wrong command")
+        };
+        assert!(args.json);
+        assert!(args.apply);
+        assert_eq!(args.fix, vec![RepairFix::Home, RepairFix::Permissions]);
     }
 
     #[test]

--- a/src/commands/capabilities.rs
+++ b/src/commands/capabilities.rs
@@ -57,7 +57,7 @@ pub fn run(args: CapabilitiesArgs) -> Result<()> {
             non_prompting_init: true,
             detect_live_init: true,
             verify: true,
-            repair: false,
+            repair: true,
             contexts: true,
             workspace_bindings: true,
             project_bindings_alias: false,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod init;
 pub mod list;
 pub mod remove;
 pub mod rename;
+pub mod repair;
 pub mod shell_hook;
 pub mod status;
 pub mod uninstall;
@@ -69,6 +70,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
                 std::process::exit(1);
             }
         }
+        Command::Repair(args) => repair::run(args, &home)?,
         Command::Workspace(args) => workspace::run(args, &home)?,
     }
     Ok(())

--- a/src/commands/repair.rs
+++ b/src/commands/repair.rs
@@ -1,0 +1,434 @@
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::cli::{RepairArgs, RepairFix};
+use crate::config::ConfigStore;
+use crate::machine;
+use crate::runtime;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RepairMode {
+    DryRun,
+    Apply,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RepairStatus {
+    Pass,
+    Warn,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ActionStatus {
+    Planned,
+    Applied,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RepairSummary {
+    status: RepairStatus,
+    issues_found: usize,
+    actions_planned: usize,
+    actions_applied: usize,
+    issues_remaining: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RepairAction {
+    fix: &'static str,
+    kind: &'static str,
+    path: String,
+    status: ActionStatus,
+    detail: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RepairResult {
+    mode: RepairMode,
+    requested_fixes: Vec<&'static str>,
+    summary: RepairSummary,
+    actions: Vec<RepairAction>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActionKind {
+    CreateDir,
+    CreateConfig,
+    SetDirPermissions,
+    SetFilePermissions,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedAction {
+    fix: RepairFix,
+    kind: ActionKind,
+    path: PathBuf,
+    detail: String,
+}
+
+pub fn run(args: RepairArgs, home: &Path) -> Result<()> {
+    let requested_fixes = normalized_fixes(&args.fix);
+    let mode = if args.apply {
+        RepairMode::Apply
+    } else {
+        RepairMode::DryRun
+    };
+
+    let actions = plan_actions(home, &requested_fixes)?;
+    let result = if mode == RepairMode::Apply {
+        apply_actions(home, &requested_fixes, actions)?
+    } else {
+        dry_run_result(&requested_fixes, actions)
+    };
+
+    if !runtime::is_quiet() {
+        if args.json {
+            machine::print_success("repair", result)?;
+        } else {
+            print_text(&result);
+        }
+    }
+
+    Ok(())
+}
+
+fn normalized_fixes(explicit: &[RepairFix]) -> Vec<RepairFix> {
+    if explicit.is_empty() {
+        vec![RepairFix::Home, RepairFix::Permissions]
+    } else {
+        explicit.to_vec()
+    }
+}
+
+fn plan_actions(home: &Path, requested_fixes: &[RepairFix]) -> Result<Vec<PlannedAction>> {
+    let mut actions = Vec::new();
+
+    if requested_fixes.contains(&RepairFix::Home) {
+        if !home.exists() {
+            actions.push(PlannedAction {
+                fix: RepairFix::Home,
+                kind: ActionKind::CreateDir,
+                path: home.to_path_buf(),
+                detail: "create AISW_HOME directory".to_owned(),
+            });
+        }
+
+        let config_path = home.join("config.json");
+        if !config_path.exists() {
+            actions.push(PlannedAction {
+                fix: RepairFix::Home,
+                kind: ActionKind::CreateConfig,
+                path: config_path,
+                detail: "create default config.json".to_owned(),
+            });
+        }
+    }
+
+    if requested_fixes.contains(&RepairFix::Permissions) && home.exists() {
+        collect_permission_repairs(home, &mut actions)?;
+    }
+
+    Ok(actions)
+}
+
+fn dry_run_result(requested_fixes: &[RepairFix], actions: Vec<PlannedAction>) -> RepairResult {
+    let issues_found = actions.len();
+    let status = if issues_found == 0 {
+        RepairStatus::Pass
+    } else {
+        RepairStatus::Warn
+    };
+
+    RepairResult {
+        mode: RepairMode::DryRun,
+        requested_fixes: requested_fixes
+            .iter()
+            .map(|fix| repair_fix_name(*fix))
+            .collect(),
+        summary: RepairSummary {
+            status,
+            issues_found,
+            actions_planned: issues_found,
+            actions_applied: 0,
+            issues_remaining: issues_found,
+        },
+        actions: actions
+            .into_iter()
+            .map(|action| RepairAction {
+                fix: repair_fix_name(action.fix),
+                kind: action_kind_name(action.kind),
+                path: action.path.display().to_string(),
+                status: ActionStatus::Planned,
+                detail: action.detail,
+            })
+            .collect(),
+    }
+}
+
+fn apply_actions(
+    home: &Path,
+    requested_fixes: &[RepairFix],
+    actions: Vec<PlannedAction>,
+) -> Result<RepairResult> {
+    for action in &actions {
+        apply_one(home, action)?;
+    }
+
+    let issues_remaining = plan_actions(home, requested_fixes)?.len();
+    let issues_found = actions.len();
+
+    Ok(RepairResult {
+        mode: RepairMode::Apply,
+        requested_fixes: requested_fixes
+            .iter()
+            .map(|fix| repair_fix_name(*fix))
+            .collect(),
+        summary: RepairSummary {
+            status: if issues_remaining == 0 {
+                RepairStatus::Pass
+            } else {
+                RepairStatus::Warn
+            },
+            issues_found,
+            actions_planned: issues_found,
+            actions_applied: issues_found,
+            issues_remaining,
+        },
+        actions: actions
+            .into_iter()
+            .map(|action| RepairAction {
+                fix: repair_fix_name(action.fix),
+                kind: action_kind_name(action.kind),
+                path: action.path.display().to_string(),
+                status: ActionStatus::Applied,
+                detail: action.detail,
+            })
+            .collect(),
+    })
+}
+
+fn apply_one(home: &Path, action: &PlannedAction) -> Result<()> {
+    match action.kind {
+        ActionKind::CreateDir => {
+            fs::create_dir_all(&action.path)
+                .with_context(|| format!("could not create {}", action.path.display()))?;
+        }
+        ActionKind::CreateConfig => {
+            fs::create_dir_all(home)
+                .with_context(|| format!("could not create {}", home.display()))?;
+            ConfigStore::new(home).load()?;
+        }
+        ActionKind::SetDirPermissions => {
+            set_dir_permissions_700(&action.path)?;
+        }
+        ActionKind::SetFilePermissions => {
+            set_file_permissions_600(&action.path)?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_permission_repairs(home: &Path, actions: &mut Vec<PlannedAction>) -> Result<()> {
+    let root_meta =
+        fs::symlink_metadata(home).with_context(|| format!("could not stat {}", home.display()))?;
+    if root_meta.is_dir() {
+        maybe_collect_dir_permissions(home, actions);
+    }
+    collect_permission_repairs_recursive(home, actions)
+}
+
+fn collect_permission_repairs_recursive(
+    path: &Path,
+    actions: &mut Vec<PlannedAction>,
+) -> Result<()> {
+    for entry in fs::read_dir(path).with_context(|| format!("could not read {}", path.display()))? {
+        let entry = entry.with_context(|| format!("error reading {}", path.display()))?;
+        let entry_path = entry.path();
+        let meta = fs::symlink_metadata(&entry_path)
+            .with_context(|| format!("could not stat {}", entry_path.display()))?;
+
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+
+        if meta.is_dir() {
+            maybe_collect_dir_permissions(&entry_path, actions);
+            collect_permission_repairs_recursive(&entry_path, actions)?;
+        } else if meta.is_file() {
+            maybe_collect_file_permissions(&entry_path, actions);
+        }
+    }
+
+    Ok(())
+}
+
+fn maybe_collect_dir_permissions(path: &Path, actions: &mut Vec<PlannedAction>) {
+    #[cfg(unix)]
+    {
+        let mode = match fs::metadata(path) {
+            Ok(meta) => meta.permissions().mode() & 0o777,
+            Err(_) => return,
+        };
+        if mode != 0o700 {
+            actions.push(PlannedAction {
+                fix: RepairFix::Permissions,
+                kind: ActionKind::SetDirPermissions,
+                path: path.to_path_buf(),
+                detail: format!("normalize directory permissions from {:04o} to 0700", mode),
+            });
+        }
+    }
+}
+
+fn maybe_collect_file_permissions(path: &Path, actions: &mut Vec<PlannedAction>) {
+    #[cfg(unix)]
+    {
+        let mode = match fs::metadata(path) {
+            Ok(meta) => meta.permissions().mode() & 0o777,
+            Err(_) => return,
+        };
+        if mode != 0o600 {
+            actions.push(PlannedAction {
+                fix: RepairFix::Permissions,
+                kind: ActionKind::SetFilePermissions,
+                path: path.to_path_buf(),
+                detail: format!("normalize file permissions from {:04o} to 0600", mode),
+            });
+        }
+    }
+}
+
+#[cfg(unix)]
+fn set_dir_permissions_700(path: &Path) -> Result<()> {
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("could not set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_dir_permissions_700(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_file_permissions_600(path: &Path) -> Result<()> {
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("could not set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_file_permissions_600(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn repair_fix_name(fix: RepairFix) -> &'static str {
+    match fix {
+        RepairFix::Home => "home",
+        RepairFix::Permissions => "permissions",
+    }
+}
+
+fn action_kind_name(kind: ActionKind) -> &'static str {
+    match kind {
+        ActionKind::CreateDir => "create_dir",
+        ActionKind::CreateConfig => "create_config",
+        ActionKind::SetDirPermissions => "set_dir_permissions",
+        ActionKind::SetFilePermissions => "set_file_permissions",
+    }
+}
+
+fn print_text(result: &RepairResult) {
+    crate::output::print_title("Repair");
+    crate::output::print_kv(
+        "Mode",
+        match result.mode {
+            RepairMode::DryRun => "dry_run",
+            RepairMode::Apply => "apply",
+        },
+    );
+    crate::output::print_kv(
+        "Status",
+        match result.summary.status {
+            RepairStatus::Pass => "pass",
+            RepairStatus::Warn => "warn",
+        },
+    );
+    crate::output::print_kv("Issues found", result.summary.issues_found.to_string());
+    crate::output::print_kv(
+        "Actions planned",
+        result.summary.actions_planned.to_string(),
+    );
+    crate::output::print_kv(
+        "Actions applied",
+        result.summary.actions_applied.to_string(),
+    );
+    crate::output::print_kv(
+        "Issues remaining",
+        result.summary.issues_remaining.to_string(),
+    );
+    crate::output::print_blank_line();
+
+    for action in &result.actions {
+        let verb = match action.status {
+            ActionStatus::Planned => "plan",
+            ActionStatus::Applied => "applied",
+        };
+        crate::output::print_info(format!(
+            "[{}] {} {} ({})",
+            verb, action.kind, action.path, action.fix
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn plan_actions_reports_missing_home_and_config() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("missing-home");
+
+        let actions = plan_actions(&home, &[RepairFix::Home, RepairFix::Permissions]).unwrap();
+
+        assert_eq!(actions.len(), 2);
+        assert!(matches!(actions[0].kind, ActionKind::CreateDir));
+        assert!(matches!(actions[1].kind, ActionKind::CreateConfig));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn plan_actions_reports_broad_permissions() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("aisw");
+        fs::create_dir_all(home.join("profiles").join("claude").join("work")).unwrap();
+        fs::write(home.join("config.json"), b"{}").unwrap();
+        fs::write(
+            home.join("profiles")
+                .join("claude")
+                .join("work")
+                .join("credentials.json"),
+            b"{}",
+        )
+        .unwrap();
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::set_permissions(home.join("config.json"), fs::Permissions::from_mode(0o644)).unwrap();
+
+        let actions = plan_actions(&home, &[RepairFix::Permissions]).unwrap();
+
+        assert!(actions
+            .iter()
+            .any(|action| matches!(action.kind, ActionKind::SetDirPermissions)));
+        assert!(actions
+            .iter()
+            .any(|action| matches!(action.kind, ActionKind::SetFilePermissions)));
+    }
+}

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -39,6 +39,7 @@ fn capabilities_json_reports_tool_capabilities() {
     assert_eq!(json["features"]["non_prompting_init"], true);
     assert_eq!(json["features"]["detect_live_init"], true);
     assert_eq!(json["features"]["verify"], true);
+    assert_eq!(json["features"]["repair"], true);
     assert_eq!(json["tools"]["gemini"]["state_modes"][0], "isolated");
     assert_eq!(json["tools"]["codex"]["fail_closed_keyring_identity"], true);
 }
@@ -89,6 +90,51 @@ fn verify_json_reports_failures_and_remediation() {
         .as_str()
         .unwrap()
         .contains("aisw use codex work"));
+}
+
+#[test]
+fn repair_json_dry_run_reports_planned_safe_fixes() {
+    let env = TestEnv::new();
+    let missing_home = env.dir.path().join("missing-aisw-home");
+
+    let output = env
+        .cmd()
+        .env("AISW_HOME", &missing_home)
+        .args(["repair", "--json", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "repair");
+    assert_eq!(json["result"]["mode"], "dry_run");
+    assert_eq!(json["result"]["summary"]["status"], "warn");
+    assert_eq!(json["result"]["summary"]["issues_remaining"], 2);
+    assert_eq!(json["result"]["actions"][0]["kind"], "create_dir");
+    assert!(!missing_home.exists());
+}
+
+#[test]
+fn repair_json_apply_creates_home_and_config() {
+    let env = TestEnv::new();
+    let missing_home = env.dir.path().join("missing-aisw-home");
+
+    let output = env
+        .cmd()
+        .env("AISW_HOME", &missing_home)
+        .args(["repair", "--json", "--apply", "--fix", "home"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["result"]["mode"], "apply");
+    assert_eq!(json["result"]["summary"]["status"], "pass");
+    assert!(missing_home.join("config.json").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `aisw repair` with `--json`, dry-run default, and explicit `--apply`
- support the first safe repair scope: missing `AISW_HOME`/`config.json` and broad aisw-managed permissions
- expose repair capability in the GUI contract and document the command surface

## Testing
- cargo test --locked
- cargo clippy --all-targets -- -D warnings
- cargo +nightly llvm-cov --json --summary-only --branch --output-path coverage-summary.json --fail-under-lines 88 --fail-under-functions 80 --fail-under-regions 88 && .github/scripts/coverage-gate.sh coverage-summary.json
- repo pre-commit hook
- repo pre-push hook