### PR TITLE
Add JSON output for context mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ Credentials are stored in the native OS keyring where available (macOS Keychain,
 ```text
 aisw init [--yes]
 aisw add <tool> <profile> [--api-key KEY] [--from-env] [--from-live] [--label TEXT] [--credential-backend file|system-keyring] [--set-active] [--yes]
-aisw context create <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>]
+aisw context create <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>] [--json]
 aisw context list [--search TEXT] [--json]
-aisw context use <name> [--state-mode isolated|shared] [--emit-env]
-aisw context set <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>]
-aisw context unset <name> [--claude] [--codex] [--gemini]
-aisw context remove <name> [--yes]
-aisw context rename <old> <new>
+aisw context use <name> [--state-mode isolated|shared] [--emit-env] [--json]
+aisw context set <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>] [--json]
+aisw context unset <name> [--claude] [--codex] [--gemini] [--json]
+aisw context remove <name> [--yes] [--json]
+aisw context rename <old> <new> [--json]
 aisw use <tool> <profile> [--state-mode isolated|shared] [--emit-env]
 aisw use --all --profile <profile> [--emit-env]
 aisw workspace bind [PATH] --context <name>

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -50,6 +50,10 @@ aisw capabilities --json
 aisw init --json --no-shell-hook --detect-live
 aisw add claude work --api-key-stdin --json
 aisw use claude work --json
+aisw context create work --claude work-claude --codex work-codex --json
+aisw context use work --json
+aisw context rename work client-acme --json
+aisw context remove client-acme --yes --json
 aisw remove claude work --yes --json
 aisw rename claude work personal --json
 aisw backup restore 20260325T114502Z-claude-ci --yes --json
@@ -103,6 +107,9 @@ aisw list codex --json | jq -r '.profiles[].name'
 
 # List all saved contexts
 aisw context list --json | jq -r '.contexts[].name'
+
+# Activate a saved context and read the refreshed active profile map
+aisw context use work --json | jq '.result.active'
 
 # Find profiles with expired tokens
 aisw status --json | jq '.[] | select(.token_warning != null) | {tool, warning: .token_warning}'

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,13 +22,13 @@ aisw [--no-color] [--non-interactive] [--quiet] <command> ...
 ```text
 aisw init [--yes] [--json --no-shell-hook [--detect-live]]
 aisw add <tool> <profile> [--api-key KEY|--api-key-stdin] [--from-env] [--from-live] [--label TEXT] [--credential-backend file|system-keyring] [--set-active] [--yes] [--json|--progress-json]
-aisw context create <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>]
+aisw context create <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>] [--json]
 aisw context list [--search TEXT] [--json]
-aisw context use <name> [--state-mode isolated|shared] [--emit-env]
-aisw context set <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>]
-aisw context unset <name> [--claude] [--codex] [--gemini]
-aisw context remove <name> [--yes]
-aisw context rename <old> <new>
+aisw context use <name> [--state-mode isolated|shared] [--emit-env] [--json]
+aisw context set <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>] [--json]
+aisw context unset <name> [--claude] [--codex] [--gemini] [--json]
+aisw context remove <name> [--yes] [--json]
+aisw context rename <old> <new> [--json]
 aisw use <tool> <profile> [--state-mode isolated|shared] [--emit-env]
 aisw use --all --profile <profile> [--state-mode isolated|shared] [--emit-env]
 aisw workspace bind [PATH] --context <name>
@@ -182,13 +182,14 @@ Practical framing:
 ### `aisw context create`
 
 ```text
-aisw context create <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>]
+aisw context create <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>] [--json]
 ```
 
 Create a saved context. At least one tool mapping is required.
 
 ```sh
 aisw context create acme --claude acme-claude --codex acme-codex
+aisw context create acme --claude acme-claude --json
 ```
 
 ### `aisw context list`
@@ -213,7 +214,7 @@ aisw context list --json
 ### `aisw context use`
 
 ```text
-aisw context use <name> [--state-mode isolated|shared] [--emit-env]
+aisw context use <name> [--state-mode isolated|shared] [--emit-env] [--json]
 ```
 
 Activate every mapped tool in a saved context as one transaction.
@@ -223,6 +224,7 @@ Activate every mapped tool in a saved context as one transaction.
 | `--state-mode isolated` | Set `CLAUDE_CONFIG_DIR` and `CODEX_HOME` to profile directories (default) |
 | `--state-mode shared` | Unset `CLAUDE_CONFIG_DIR` and `CODEX_HOME` for Claude and Codex |
 | `--emit-env` | Print shell export/unset lines to stdout instead of writing them to the session |
+| `--json` | Output a machine-readable activation result envelope |
 
 Notes:
 - Default state mode is `isolated`.
@@ -233,55 +235,60 @@ Notes:
 ```sh
 aisw context use acme
 aisw context use acme --state-mode shared
+aisw context use acme --json
 eval "$(aisw context use acme --emit-env)"
 ```
 
 ### `aisw context set`
 
 ```text
-aisw context set <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>]
+aisw context set <name> [--claude <profile>] [--codex <profile>] [--gemini <profile>] [--json]
 ```
 
 Update one or more mappings without disturbing the others.
 
 ```sh
 aisw context set acme --gemini acme-gemini
+aisw context set acme --gemini acme-gemini --json
 ```
 
 ### `aisw context unset`
 
 ```text
-aisw context unset <name> [--claude] [--codex] [--gemini]
+aisw context unset <name> [--claude] [--codex] [--gemini] [--json]
 ```
 
 Remove one or more mappings from a context. The command fails if it would leave the context empty.
 
 ```sh
 aisw context unset acme --codex
+aisw context unset acme --codex --json
 ```
 
 ### `aisw context remove`
 
 ```text
-aisw context remove <name> [--yes]
+aisw context remove <name> [--yes] [--json]
 ```
 
 Delete a saved context. This does not change live credentials or active per-tool profiles.
 
 ```sh
 aisw context remove acme --yes
+aisw context remove acme --yes --json
 ```
 
 ### `aisw context rename`
 
 ```text
-aisw context rename <old> <new>
+aisw context rename <old> <new> [--json]
 ```
 
 Rename a saved context. This does not change live credentials or active per-tool profiles.
 
 ```sh
 aisw context rename acme client-acme
+aisw context rename acme client-acme --json
 ```
 
 ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,6 +389,10 @@ pub struct ContextCreateArgs {
     /// Gemini profile to include
     #[arg(long, value_name = "PROFILE")]
     pub gemini: Option<String>,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -415,6 +419,10 @@ pub struct ContextUseArgs {
     /// Used internally by the shell hook — not intended for direct use.
     #[arg(long, hide = true)]
     pub emit_env: bool,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -433,6 +441,10 @@ pub struct ContextSetArgs {
     /// Gemini profile to set
     #[arg(long, value_name = "PROFILE")]
     pub gemini: Option<String>,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -451,6 +463,10 @@ pub struct ContextUnsetArgs {
     /// Remove the Gemini mapping
     #[arg(long)]
     pub gemini: bool,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -461,6 +477,10 @@ pub struct ContextRemoveArgs {
     /// Skip the confirmation prompt
     #[arg(long)]
     pub yes: bool,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -470,6 +490,10 @@ pub struct ContextRenameArgs {
 
     /// New context name
     pub new_name: String,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -755,11 +779,12 @@ mod tests {
         assert_eq!(args.claude.as_deref(), Some("acme-claude"));
         assert_eq!(args.codex.as_deref(), Some("acme-codex"));
         assert_eq!(args.gemini, None);
+        assert!(!args.json);
     }
 
     #[test]
     fn context_use_emit_env_is_hidden_but_parseable() {
-        let cli = parse(&["context", "use", "work", "--emit-env"]).unwrap();
+        let cli = parse(&["context", "use", "work", "--emit-env", "--json"]).unwrap();
         let Command::Context(args) = cli.command else {
             panic!("wrong command")
         };
@@ -768,6 +793,7 @@ mod tests {
         };
         assert_eq!(args.context_name, "work");
         assert!(args.emit_env);
+        assert!(args.json);
     }
 
     #[test]

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -10,9 +10,13 @@ use crate::cli::{
     ContextArgs, ContextCommand, ContextCreateArgs, ContextListArgs, ContextRemoveArgs,
     ContextRenameArgs, ContextSetArgs, ContextUnsetArgs, ContextUseArgs,
 };
-use crate::commands::use_::{apply_resolved_profile_switch, ResolvedProfileSwitch};
+use crate::commands::use_::{
+    active_map, apply_resolved_profile_switch, backup_ids_for, diff_backup_ids, live_match_map,
+    state_mode_map, ResolvedProfileSwitch,
+};
 use crate::config::{Config, ConfigStore, ContextEntry, ContextProfiles};
 use crate::live_apply::LiveFileChange;
+use crate::machine;
 use crate::output;
 use crate::profile::validate_profile_name;
 use crate::types::{StateMode, Tool};
@@ -48,10 +52,24 @@ fn create(args: ContextCreateArgs, home: &Path) -> Result<()> {
         context_profiles.insert(tool, profile);
     }
 
-    store.create_context(
+    let config = store.create_context(
         &args.context_name,
         ContextEntry::new(context_profiles, Utc::now()),
     )?;
+
+    if args.json {
+        let entry = config
+            .context(&args.context_name)
+            .context("created context missing from config")?;
+        machine::print_success(
+            "context_create",
+            serde_json::json!({
+                "context": context_json(&args.context_name, entry),
+                "context_count": config.contexts().len(),
+            }),
+        )?;
+        return Ok(());
+    }
 
     output::print_title("Created context");
     output::print_kv("Context", &args.context_name);
@@ -144,7 +162,21 @@ fn set(args: ContextSetArgs, home: &Path) -> Result<()> {
         created_at: existing.created_at,
         updated_at: Utc::now(),
     };
-    store.upsert_context(&args.context_name, updated)?;
+    let config = store.upsert_context(&args.context_name, updated)?;
+
+    if args.json {
+        let entry = config
+            .context(&args.context_name)
+            .context("updated context missing from config")?;
+        machine::print_success(
+            "context_set",
+            serde_json::json!({
+                "context": context_json(&args.context_name, entry),
+                "context_count": config.contexts().len(),
+            }),
+        )?;
+        return Ok(());
+    }
 
     output::print_title("Updated context");
     output::print_kv("Context", &args.context_name);
@@ -194,7 +226,21 @@ fn unset(args: ContextUnsetArgs, home: &Path) -> Result<()> {
         created_at: existing.created_at,
         updated_at: Utc::now(),
     };
-    store.upsert_context(&args.context_name, updated)?;
+    let config = store.upsert_context(&args.context_name, updated)?;
+
+    if args.json {
+        let entry = config
+            .context(&args.context_name)
+            .context("updated context missing from config")?;
+        machine::print_success(
+            "context_unset",
+            serde_json::json!({
+                "context": context_json(&args.context_name, entry),
+                "context_count": config.contexts().len(),
+            }),
+        )?;
+        return Ok(());
+    }
 
     output::print_title("Updated context");
     output::print_kv("Context", &args.context_name);
@@ -211,7 +257,18 @@ fn remove(args: ContextRemoveArgs, home: &Path) -> Result<()> {
              Re-run with --yes."
         );
     }
-    ConfigStore::new(home).remove_context(&args.context_name)?;
+    let config = ConfigStore::new(home).remove_context(&args.context_name)?;
+
+    if args.json {
+        machine::print_success(
+            "context_remove",
+            serde_json::json!({
+                "removed_context": args.context_name,
+                "remaining_contexts": remaining_context_names(&config),
+            }),
+        )?;
+        return Ok(());
+    }
 
     output::print_title("Removed context");
     output::print_kv("Context", &args.context_name);
@@ -223,7 +280,22 @@ fn remove(args: ContextRemoveArgs, home: &Path) -> Result<()> {
 
 fn rename(args: ContextRenameArgs, home: &Path) -> Result<()> {
     validate_profile_name(&args.new_name)?;
-    ConfigStore::new(home).rename_context(&args.old_name, &args.new_name)?;
+    let config = ConfigStore::new(home).rename_context(&args.old_name, &args.new_name)?;
+
+    if args.json {
+        let entry = config
+            .context(&args.new_name)
+            .context("renamed context missing from config")?;
+        machine::print_success(
+            "context_rename",
+            serde_json::json!({
+                "old_name": args.old_name,
+                "new_name": args.new_name,
+                "context": context_json(&args.new_name, entry),
+            }),
+        )?;
+        return Ok(());
+    }
 
     output::print_title("Renamed context");
     output::print_kv("Previous", &args.old_name);
@@ -269,6 +341,7 @@ fn use_context(_args: ContextUseArgs, _home: &Path) -> Result<()> {
         return Ok(());
     }
 
+    let before_backup_ids = backup_ids_for(home, None)?;
     let snapshots = snapshot_live_state_for_context(&switches, &user_home)?;
     let activations = switches
         .iter()
@@ -295,6 +368,23 @@ fn use_context(_args: ContextUseArgs, _home: &Path) -> Result<()> {
     if let Err(err) = apply_result {
         restore_live_state_for_context(&snapshots, &user_home)?;
         return Err(err);
+    }
+
+    if args.json {
+        let after_backup_ids = backup_ids_for(home, None)?;
+        machine::print_success(
+            "context_use",
+            serde_json::json!({
+                "context": args.context_name,
+                "affected_tools": switches.iter().map(|switch| switch.tool.binary_name()).collect::<Vec<_>>(),
+                "active": active_map(home, &Tool::ALL)?,
+                "state_mode": state_mode_map(home, &Tool::ALL)?,
+                "live_match": live_match_map(home, &user_home, &Tool::ALL)?,
+                "backup_ids": diff_backup_ids(&before_backup_ids, &after_backup_ids),
+                "warnings": Vec::<String>::new(),
+            }),
+        )?;
+        return Ok(());
     }
 
     output::print_title("Activated context");
@@ -536,4 +626,19 @@ fn normalized_profiles_json(profiles: &ContextProfiles) -> serde_json::Value {
         "codex": profiles.get(Tool::Codex),
         "gemini": profiles.get(Tool::Gemini),
     })
+}
+
+fn context_json(name: &str, entry: &ContextEntry) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "profiles": normalized_profiles_json(&entry.profiles),
+        "created_at": entry.created_at,
+        "updated_at": entry.updated_at,
+    })
+}
+
+fn remaining_context_names(config: &Config) -> Vec<String> {
+    let mut names = config.contexts().keys().cloned().collect::<Vec<_>>();
+    names.sort();
+    names
 }

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -636,7 +636,7 @@ fn auth_label(method: AuthMethod) -> &'static str {
     }
 }
 
-fn backup_ids_for(home: &Path, tool: Option<Tool>) -> Result<Vec<String>> {
+pub(crate) fn backup_ids_for(home: &Path, tool: Option<Tool>) -> Result<Vec<String>> {
     let mut ids = BackupManager::new(home)
         .list()?
         .into_iter()
@@ -651,7 +651,7 @@ fn backup_ids_for(home: &Path, tool: Option<Tool>) -> Result<Vec<String>> {
     Ok(ids)
 }
 
-fn diff_backup_ids(before: &[String], after: &[String]) -> Vec<String> {
+pub(crate) fn diff_backup_ids(before: &[String], after: &[String]) -> Vec<String> {
     after
         .iter()
         .filter(|id| !before.iter().any(|existing| existing == *id))
@@ -659,7 +659,7 @@ fn diff_backup_ids(before: &[String], after: &[String]) -> Vec<String> {
         .collect()
 }
 
-fn active_map(home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
+pub(crate) fn active_map(home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
     let config = ConfigStore::new(home).load()?;
     let mut map = serde_json::Map::new();
     for tool in tools {
@@ -674,7 +674,7 @@ fn active_map(home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
     Ok(serde_json::Value::Object(map))
 }
 
-fn state_mode_map(home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
+pub(crate) fn state_mode_map(home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
     let config = ConfigStore::new(home).load()?;
     let mut map = serde_json::Map::new();
     for tool in tools {
@@ -690,7 +690,11 @@ fn state_mode_map(home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
     Ok(serde_json::Value::Object(map))
 }
 
-fn live_match_map(home: &Path, user_home: &Path, tools: &[Tool]) -> Result<serde_json::Value> {
+pub(crate) fn live_match_map(
+    home: &Path,
+    user_home: &Path,
+    tools: &[Tool],
+) -> Result<serde_json::Value> {
     let statuses = crate::commands::status::collect_status(
         home,
         user_home,

--- a/tests/context_cmd.rs
+++ b/tests/context_cmd.rs
@@ -282,6 +282,59 @@ fn context_use_writes_live_files_and_updates_active_profiles() {
 }
 
 #[test]
+fn context_use_json_reports_machine_activation_state() {
+    let env = TestEnv::new();
+    setup_profiles(&env);
+
+    env.cmd()
+        .args([
+            "context",
+            "create",
+            "work",
+            "--claude",
+            "acme-claude",
+            "--codex",
+            "acme-codex",
+        ])
+        .assert()
+        .success();
+
+    let output = env.output(&["context", "use", "work", "--json"]);
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "context_use");
+    assert_eq!(json["result"]["context"], "work");
+    assert_eq!(json["result"]["active"]["claude"], "acme-claude");
+    assert_eq!(json["result"]["active"]["codex"], "acme-codex");
+    assert_eq!(json["result"]["active"]["gemini"], serde_json::Value::Null);
+}
+
+#[test]
+fn context_rename_json_reports_new_context_state() {
+    let env = TestEnv::new();
+    setup_profiles(&env);
+
+    env.cmd()
+        .args(["context", "create", "work", "--claude", "acme-claude"])
+        .assert()
+        .success();
+
+    let output = env.output(&["context", "rename", "work", "client-acme", "--json"]);
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "context_rename");
+    assert_eq!(json["result"]["old_name"], "work");
+    assert_eq!(json["result"]["new_name"], "client-acme");
+    assert_eq!(json["result"]["context"]["name"], "client-acme");
+}
+
+#[test]
 fn failed_context_use_rolls_back_live_state_and_active_profiles() {
     let env = TestEnv::new();
     env.add_fake_tool("claude", "claude 2.3.0");

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -314,6 +314,117 @@ fn backup_restore_json_reports_non_activation() {
 }
 
 #[test]
+fn context_create_json_returns_saved_mapping() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work",
+            "--api-key",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ])
+        .assert()
+        .success();
+
+    let json = json_output(
+        &env,
+        &[
+            "context",
+            "create",
+            "client-acme",
+            "--claude",
+            "work",
+            "--json",
+        ],
+    );
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "context_create");
+    assert_eq!(json["result"]["context"]["name"], "client-acme");
+    assert_eq!(json["result"]["context"]["profiles"]["claude"], "work");
+}
+
+#[test]
+fn context_use_json_returns_active_state_and_context_name() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.add_fake_tool("codex", "codex 1.0.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work-claude",
+            "--api-key",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "add",
+            "codex",
+            "work-codex",
+            "--api-key",
+            "sk-codex-test-key-12345",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "context",
+            "create",
+            "work",
+            "--claude",
+            "work-claude",
+            "--codex",
+            "work-codex",
+        ])
+        .assert()
+        .success();
+
+    let json = json_output(&env, &["context", "use", "work", "--json"]);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "context_use");
+    assert_eq!(json["result"]["context"], "work");
+    assert_eq!(json["result"]["active"]["claude"], "work-claude");
+    assert_eq!(json["result"]["active"]["codex"], "work-codex");
+    assert!(json["result"]["backup_ids"].as_array().is_some());
+}
+
+#[test]
+fn context_remove_json_returns_remaining_contexts() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work",
+            "--api-key",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["context", "create", "client-acme", "--claude", "work"])
+        .assert()
+        .success();
+
+    let json = json_output(
+        &env,
+        &["context", "remove", "client-acme", "--yes", "--json"],
+    );
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "context_remove");
+    assert_eq!(json["result"]["removed_context"], "client-acme");
+    assert_eq!(json["result"]["remaining_contexts"], serde_json::json!([]));
+}
+
+#[test]
 fn add_oauth_progress_json_streams_ndjson_events() {
     let env = TestEnv::new();
     env.add_script_tool(


### PR DESCRIPTION
## Summary
- add `--json` support for context create, use, set, unset, remove, and rename
- return machine envelopes for saved-context mutations and refreshed activation state for `context use --json`
- document the new machine-mode surface and cover it with CLI, integration, and GUI-contract tests

## Testing
- cargo fmt --all
- cargo test --test gui_contract context_
- cargo test --test context_cmd context_
- cargo test --lib context_
- cargo clippy --all-targets -- -D warnings
- cargo test --locked
- repo pre-commit hook
- repo pre-push hook