### PR TITLE
Add project bindings listing alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ aisw shell-hook <bash|zsh|fish|pwsh>
 aisw doctor [--json]
 aisw verify [--json]
 aisw repair [--json] [--dry-run|--apply] [--fix home,permissions]
+aisw project-bindings list [--json]
 ```
 
 ## Security

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -59,6 +59,7 @@ aisw rename claude work personal --json
 aisw backup restore 20260325T114502Z-claude-ci --yes --json
 aisw verify --json
 aisw repair --json --dry-run
+aisw project-bindings list --json
 aisw status --json
 aisw status --context --json
 aisw list --json
@@ -110,6 +111,9 @@ aisw context list --json | jq -r '.contexts[].name'
 
 # Activate a saved context and read the refreshed active profile map
 aisw context use work --json | jq '.result.active'
+
+# List user workspace rules plus the current repo-local binding
+aisw project-bindings list --json | jq '.result'
 
 # Find profiles with expired tokens
 aisw status --json | jq '.[] | select(.token_warning != null) | {tool, warning: .token_warning}'

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 ---
 title: Command reference
-description: Complete syntax and flag reference for all aisw commands  -  add, context, use, list, status, verify, repair, remove, rename, backup, workspace, init, uninstall, shell-hook, and doctor.
+description: Complete syntax and flag reference for all aisw commands  -  add, context, use, list, status, verify, repair, project-bindings, remove, rename, backup, workspace, init, uninstall, shell-hook, and doctor.
 ---
 
 # Command reference
@@ -48,6 +48,7 @@ aisw shell-hook <bash|zsh|fish|pwsh>
 aisw doctor [--json]
 aisw verify [--json]
 aisw repair [--json] [--dry-run|--apply] [--fix home,permissions]
+aisw project-bindings list [--json]
 ```
 
 `<tool>` is one of: `claude`, `codex`, `gemini`.
@@ -628,6 +629,25 @@ aisw repair
 aisw repair --json --dry-run
 aisw repair --apply --fix home
 aisw repair --json --apply --fix home,permissions
+```
+
+---
+
+## `aisw project-bindings list`
+
+```text
+aisw project-bindings list [--json]
+```
+
+List workspace binding rules that matter to GUI/project-aware flows.
+
+- Includes user-level workspace rules from `~/.aisw/workspaces.json`
+- Includes the current repo-local binding from `.git/info/aisw.json` when the current directory is inside a repo
+- Does not scan the filesystem for arbitrary repo-local binding files outside the current repo
+
+```sh
+aisw project-bindings list
+aisw project-bindings list --json
 ```
 
 ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -121,6 +121,10 @@ pub enum Command {
     /// Repair safe local aisw state issues such as missing home/config or broad permissions
     Repair(RepairArgs),
 
+    /// List saved workspace/project binding rules for GUI and automation
+    #[command(name = "project-bindings")]
+    ProjectBindings(ProjectBindingsArgs),
+
     /// Bind workspaces to expected contexts and enforce guardrails
     Workspace(WorkspaceArgs),
 }
@@ -162,6 +166,25 @@ pub struct RepairArgs {
     /// Limit repairs to one or more fix categories
     #[arg(long, value_enum, value_delimiter = ',', num_args = 1..)]
     pub fix: Vec<RepairFix>,
+}
+
+#[derive(Args, Debug)]
+pub struct ProjectBindingsArgs {
+    #[command(subcommand)]
+    pub command: ProjectBindingsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ProjectBindingsCommand {
+    /// List user workspace bindings and the current repo-local binding
+    List(ProjectBindingsListArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ProjectBindingsListArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -996,6 +1019,16 @@ mod tests {
         assert!(args.json);
         assert!(args.apply);
         assert_eq!(args.fix, vec![RepairFix::Home, RepairFix::Permissions]);
+    }
+
+    #[test]
+    fn project_bindings_list_json_parse() {
+        let cli = parse(&["project-bindings", "list", "--json"]).unwrap();
+        let Command::ProjectBindings(args) = cli.command else {
+            panic!("wrong command")
+        };
+        let ProjectBindingsCommand::List(args) = args.command;
+        assert!(args.json);
     }
 
     #[test]

--- a/src/commands/capabilities.rs
+++ b/src/commands/capabilities.rs
@@ -60,7 +60,7 @@ pub fn run(args: CapabilitiesArgs) -> Result<()> {
             repair: true,
             contexts: true,
             workspace_bindings: true,
-            project_bindings_alias: false,
+            project_bindings_alias: true,
         },
         tools: ToolCapabilitiesSet {
             claude: tool_capabilities(Tool::Claude),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod context;
 pub mod doctor;
 pub mod init;
 pub mod list;
+pub mod project_bindings;
 pub mod remove;
 pub mod rename;
 pub mod repair;
@@ -71,6 +72,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             }
         }
         Command::Repair(args) => repair::run(args, &home)?,
+        Command::ProjectBindings(args) => project_bindings::run(args, &home)?,
         Command::Workspace(args) => workspace::run(args, &home)?,
     }
     Ok(())

--- a/src/commands/project_bindings.rs
+++ b/src/commands/project_bindings.rs
@@ -1,0 +1,137 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::cli::{ProjectBindingsArgs, ProjectBindingsCommand, ProjectBindingsListArgs};
+use crate::machine;
+use crate::output;
+use crate::workspace::{
+    detect_repo, load_repo_local_config, repo_local_config_path, WorkspaceStore,
+};
+
+#[derive(Debug, Serialize)]
+struct ProjectBindingsResult {
+    cwd: String,
+    repo_local_binding: Option<RepoLocalBindingResult>,
+    user_bindings: UserBindingsResult,
+}
+
+#[derive(Debug, Serialize)]
+struct RepoLocalBindingResult {
+    repo_root: String,
+    config_path: String,
+    context: String,
+}
+
+#[derive(Debug, Serialize)]
+struct UserBindingsResult {
+    default_context: Option<String>,
+    path_rules: Vec<PathRuleResult>,
+    git_remote_rules: Vec<GitRemoteRuleResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct PathRuleResult {
+    path: String,
+    context: String,
+}
+
+#[derive(Debug, Serialize)]
+struct GitRemoteRuleResult {
+    pattern: String,
+    context: String,
+}
+
+pub fn run(args: ProjectBindingsArgs, home: &Path) -> Result<()> {
+    match args.command {
+        ProjectBindingsCommand::List(args) => list(args, home),
+    }
+}
+
+fn list(args: ProjectBindingsListArgs, home: &Path) -> Result<()> {
+    let cwd = std::env::current_dir().context("could not determine current directory")?;
+    let repo = detect_repo(&cwd)?;
+    let workspace_config = WorkspaceStore::new(home).load()?;
+
+    let repo_local_binding = if let Some(repo) = repo.as_ref() {
+        load_repo_local_config(repo)?.map(|local| RepoLocalBindingResult {
+            repo_root: repo.root.display().to_string(),
+            config_path: repo_local_config_path(repo).display().to_string(),
+            context: local.context,
+        })
+    } else {
+        None
+    };
+
+    let mut path_rules = workspace_config
+        .path_rules
+        .iter()
+        .map(|rule| PathRuleResult {
+            path: rule.path.clone(),
+            context: rule.context.clone(),
+        })
+        .collect::<Vec<_>>();
+    path_rules.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let mut git_remote_rules = workspace_config
+        .git_remote_rules
+        .iter()
+        .map(|rule| GitRemoteRuleResult {
+            pattern: rule.pattern.clone(),
+            context: rule.context.clone(),
+        })
+        .collect::<Vec<_>>();
+    git_remote_rules.sort_by(|a, b| a.pattern.cmp(&b.pattern));
+
+    let result = ProjectBindingsResult {
+        cwd: cwd.display().to_string(),
+        repo_local_binding,
+        user_bindings: UserBindingsResult {
+            default_context: workspace_config.default_context,
+            path_rules,
+            git_remote_rules,
+        },
+    };
+
+    if args.json {
+        machine::print_success("project_bindings_list", result)?;
+        return Ok(());
+    }
+
+    output::print_title("Project bindings");
+    output::print_kv("Cwd", &result.cwd);
+    if let Some(repo_local) = result.repo_local_binding.as_ref() {
+        output::print_blank_line();
+        output::print_kv("Repo root", &repo_local.repo_root);
+        output::print_kv("Repo config", &repo_local.config_path);
+        output::print_kv("Repo context", &repo_local.context);
+    }
+
+    output::print_blank_line();
+    output::print_kv(
+        "Default context",
+        result
+            .user_bindings
+            .default_context
+            .as_deref()
+            .unwrap_or("none"),
+    );
+
+    if result.user_bindings.path_rules.is_empty()
+        && result.user_bindings.git_remote_rules.is_empty()
+    {
+        output::print_blank_line();
+        output::print_empty_state("No user workspace bindings saved.");
+        return Ok(());
+    }
+
+    for rule in &result.user_bindings.path_rules {
+        output::print_kv(&format!("Path {}", rule.path), &rule.context);
+    }
+    for rule in &result.user_bindings.git_remote_rules {
+        output::print_kv(&format!("Remote {}", rule.pattern), &rule.context);
+    }
+
+    Ok(())
+}

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -40,6 +40,7 @@ fn capabilities_json_reports_tool_capabilities() {
     assert_eq!(json["features"]["detect_live_init"], true);
     assert_eq!(json["features"]["verify"], true);
     assert_eq!(json["features"]["repair"], true);
+    assert_eq!(json["features"]["project_bindings_alias"], true);
     assert_eq!(json["tools"]["gemini"]["state_modes"][0], "isolated");
     assert_eq!(json["tools"]["codex"]["fail_closed_keyring_identity"], true);
 }
@@ -422,6 +423,86 @@ fn context_remove_json_returns_remaining_contexts() {
     assert_eq!(json["command"], "context_remove");
     assert_eq!(json["result"]["removed_context"], "client-acme");
     assert_eq!(json["result"]["remaining_contexts"], serde_json::json!([]));
+}
+
+#[test]
+fn project_bindings_list_json_reports_user_and_repo_rules() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work",
+            "--api-key",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["context", "create", "client-acme", "--claude", "work"])
+        .assert()
+        .success();
+
+    let repo = env.fake_home.join("clients").join("acme");
+    std::fs::create_dir_all(repo.join(".git").join("info")).unwrap();
+    std::fs::write(
+        repo.join(".git").join("config"),
+        "[remote \"origin\"]\n\turl = git@github.com:acme/api.git\n",
+    )
+    .unwrap();
+
+    env.cmd()
+        .args(["workspace", "bind", "--default", "--context", "client-acme"])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            "--git-remote",
+            "github.com/acme/*",
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            repo.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+
+    let output = env
+        .cmd()
+        .current_dir(&repo)
+        .args(["project-bindings", "list", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "project_bindings_list");
+    assert_eq!(
+        json["result"]["repo_local_binding"]["context"],
+        "client-acme"
+    );
+    assert_eq!(
+        json["result"]["user_bindings"]["default_context"],
+        "client-acme"
+    );
+    assert_eq!(
+        json["result"]["user_bindings"]["git_remote_rules"][0]["pattern"],
+        "github.com/acme/*"
+    );
 }
 
 #[test]

--- a/tests/workspace_cmd.rs
+++ b/tests/workspace_cmd.rs
@@ -227,6 +227,79 @@ fn workspace_bind_default_and_git_remote_update_user_store() {
 }
 
 #[test]
+fn project_bindings_list_json_reports_current_repo_and_user_rules() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let repo = setup_repo(&env, "clients/acme", "git@github.com:acme/api.git");
+    let outside = env.fake_home.join("scratch").join("project");
+    fs::create_dir_all(&outside).unwrap();
+
+    env.cmd()
+        .args(["workspace", "bind", "--default", "--context", "client-acme"])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            "--git-remote",
+            "github.com/acme/*",
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            outside.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args([
+            "workspace",
+            "bind",
+            repo.to_str().unwrap(),
+            "--context",
+            "client-acme",
+        ])
+        .assert()
+        .success();
+
+    let output = env
+        .cmd()
+        .current_dir(repo.join("api"))
+        .args(["project-bindings", "list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(
+        json["result"]["repo_local_binding"]["context"],
+        "client-acme"
+    );
+    assert_eq!(
+        json["result"]["user_bindings"]["default_context"],
+        "client-acme"
+    );
+    assert_eq!(
+        json["result"]["user_bindings"]["path_rules"][0]["path"],
+        outside.display().to_string()
+    );
+    assert_eq!(
+        json["result"]["user_bindings"]["git_remote_rules"][0]["pattern"],
+        "github.com/acme/*"
+    );
+}
+
+#[test]
 fn strict_workspace_guard_blocks_wrapped_claude_before_launch() {
     let env = TestEnv::new();
     setup_profiles_and_contexts(&env);


### PR DESCRIPTION
## Summary
- add `aisw project-bindings list [--json]` as a GUI-facing alias over existing workspace binding state
- include user workspace rules plus the current repo-local binding when invoked inside a git repository
- expose the alias through `aisw capabilities --json`

## Why
The desktop client needs a read-only, capability-gated way to inspect project-aware switching state without reimplementing workspace logic or scanning arbitrary repositories.

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked`
