### PR TITLE
Add JSON output for workspace binding mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ aisw context remove <name> [--yes] [--json]
 aisw context rename <old> <new> [--json]
 aisw use <tool> <profile> [--state-mode isolated|shared] [--emit-env]
 aisw use --all --profile <profile> [--emit-env]
-aisw workspace bind [PATH] --context <name>
-aisw workspace bind --git-remote <PATTERN> --context <name>
-aisw workspace bind --default --context <name>
+aisw workspace bind [PATH] --context <name> [--json]
+aisw workspace bind --git-remote <PATTERN> --context <name> [--json]
+aisw workspace bind --default --context <name> [--json]
 aisw workspace status [--json]
 aisw workspace doctor [--json]
-aisw workspace guard --mode warn|strict
+aisw workspace guard --mode warn|strict [--json]
 aisw list [tool] [--json]
 aisw status [--context] [--json]
 aisw remove <tool> <profile> [--yes] [--force]

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -59,6 +59,8 @@ aisw rename claude work personal --json
 aisw backup restore 20260325T114502Z-claude-ci --yes --json
 aisw verify --json
 aisw repair --json --dry-run
+aisw workspace bind --default --context work --json
+aisw workspace guard --mode strict --json
 aisw project-bindings list --json
 aisw status --json
 aisw status --context --json
@@ -111,6 +113,12 @@ aisw context list --json | jq -r '.contexts[].name'
 
 # Activate a saved context and read the refreshed active profile map
 aisw context use work --json | jq '.result.active'
+
+# Update the default workspace context and inspect the refreshed binding snapshot
+aisw workspace bind --default --context work --json | jq '.result.project_bindings.user_bindings'
+
+# Persist strict workspace guard mode and confirm the saved mode
+aisw workspace guard --mode strict --json | jq -r '.result.guard_mode'
 
 # List user workspace rules plus the current repo-local binding
 aisw project-bindings list --json | jq '.result'

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,12 +31,12 @@ aisw context remove <name> [--yes] [--json]
 aisw context rename <old> <new> [--json]
 aisw use <tool> <profile> [--state-mode isolated|shared] [--emit-env]
 aisw use --all --profile <profile> [--state-mode isolated|shared] [--emit-env]
-aisw workspace bind [PATH] --context <name>
-aisw workspace bind --git-remote <PATTERN> --context <name>
-aisw workspace bind --default --context <name>
+aisw workspace bind [PATH] --context <name> [--json]
+aisw workspace bind --git-remote <PATTERN> --context <name> [--json]
+aisw workspace bind --default --context <name> [--json]
 aisw workspace status [--json]
 aisw workspace doctor [--json]
-aisw workspace guard --mode warn|strict
+aisw workspace guard --mode warn|strict [--json]
 aisw list [tool] [--tool <tool>] [--search TEXT] [--sort name|recent] [--active-only] [--json]
 aisw status [--tool <tool>] [--search TEXT] [--sort name|recent] [--active-only] [--context] [--json]
 aisw remove <tool> <profile> [--yes] [--force]
@@ -303,9 +303,9 @@ See [Workspace guardrails](workspace.md) for a full explanation of the feature, 
 ### `aisw workspace bind`
 
 ```text
-aisw workspace bind [PATH] --context <name>
-aisw workspace bind --git-remote <PATTERN> --context <name>
-aisw workspace bind --default --context <name>
+aisw workspace bind [PATH] --context <name> [--json]
+aisw workspace bind --git-remote <PATTERN> --context <name> [--json]
+aisw workspace bind --default --context <name> [--json]
 ```
 
 Create or update a workspace binding. The context must already exist.
@@ -316,12 +316,14 @@ Create or update a workspace binding. The context must already exist.
 | `--context NAME` | Expected context name for this location |
 | `--git-remote PATTERN` | Bind by git remote URL pattern. Supports `*` wildcards. |
 | `--default` | Set the fallback context for locations with no more specific rule. |
+| `--json` | Output a machine-readable mutation envelope with the refreshed bindings snapshot |
 
 ```sh
 aisw workspace bind . --context client-acme
 aisw workspace bind --git-remote "github.com/acme/*" --context client-acme
 aisw workspace bind ~/clients --context client-acme
 aisw workspace bind --default --context personal
+aisw workspace bind --default --context personal --json
 ```
 
 ### `aisw workspace status`
@@ -353,10 +355,12 @@ aisw workspace doctor --json
 ### `aisw workspace guard`
 
 ```text
-aisw workspace guard --mode warn|strict
+aisw workspace guard --mode warn|strict [--json]
 ```
 
 Set the default guard mode, saved to `~/.aisw/workspaces.json`.
+
+With `--json`, the success envelope includes the updated `guard_mode` and the same bindings snapshot returned by `aisw project-bindings list --json`.
 
 | Mode | Effect |
 |---|---|
@@ -366,6 +370,7 @@ Set the default guard mode, saved to `~/.aisw/workspaces.json`.
 ```sh
 aisw workspace guard --mode warn
 aisw workspace guard --mode strict
+aisw workspace guard --mode strict --json
 ```
 
 ---
@@ -641,6 +646,7 @@ aisw project-bindings list [--json]
 
 List workspace binding rules that matter to GUI/project-aware flows.
 
+- Includes saved `guard_mode`
 - Includes user-level workspace rules from `~/.aisw/workspaces.json`
 - Includes the current repo-local binding from `.git/info/aisw.json` when the current directory is inside a repo
 - Does not scan the filesystem for arbitrary repo-local binding files outside the current repo

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -142,12 +142,14 @@ The prompt check also runs when you change directories, so you get a heads-up as
 ### `aisw workspace bind`
 
 ```text
-aisw workspace bind [PATH] --context <name>
-aisw workspace bind --git-remote <PATTERN> --context <name>
-aisw workspace bind --default --context <name>
+aisw workspace bind [PATH] --context <name> [--json]
+aisw workspace bind --git-remote <PATTERN> --context <name> [--json]
+aisw workspace bind --default --context <name> [--json]
 ```
 
 Create or update a workspace binding.
+
+Pass `--json` when driving the command from a GUI or script that needs a structured mutation result and refreshed bindings snapshot.
 
 | Flag | Effect |
 |---|---|
@@ -247,10 +249,12 @@ aisw workspace doctor --json
 ### `aisw workspace guard`
 
 ```text
-aisw workspace guard --mode warn|strict
+aisw workspace guard --mode warn|strict [--json]
 ```
 
 Set the default guard mode. The setting is saved to `~/.aisw/workspaces.json`.
+
+With `--json`, the success envelope includes the saved `guard_mode` and the refreshed project bindings snapshot.
 
 ```sh
 aisw workspace guard --mode warn    # warn but allow launch

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -227,6 +227,10 @@ pub struct WorkspaceBindArgs {
     /// Set the default context when no workspace-specific rule matches
     #[arg(long, conflicts_with_all = ["path", "git_remote"])]
     pub default: bool,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -248,6 +252,10 @@ pub struct WorkspaceGuardArgs {
     /// Default workspace guard mode
     #[arg(long, value_enum)]
     pub mode: WorkspaceGuardMode,
+
+    /// Output result as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -832,6 +840,42 @@ mod tests {
         assert!(args.claude);
         assert!(!args.codex);
         assert!(args.gemini);
+    }
+
+    #[test]
+    fn workspace_bind_json_parse() {
+        let cli = parse(&[
+            "workspace",
+            "bind",
+            "--git-remote",
+            "github.com/acme/*",
+            "--context",
+            "client-acme",
+            "--json",
+        ])
+        .unwrap();
+        let Command::Workspace(args) = cli.command else {
+            panic!("wrong command")
+        };
+        let WorkspaceCommand::Bind(args) = args.command else {
+            panic!("wrong subcommand")
+        };
+        assert_eq!(args.git_remote.as_deref(), Some("github.com/acme/*"));
+        assert_eq!(args.context, "client-acme");
+        assert!(args.json);
+    }
+
+    #[test]
+    fn workspace_guard_json_parse() {
+        let cli = parse(&["workspace", "guard", "--mode", "strict", "--json"]).unwrap();
+        let Command::Workspace(args) = cli.command else {
+            panic!("wrong command")
+        };
+        let WorkspaceCommand::Guard(args) = args.command else {
+            panic!("wrong subcommand")
+        };
+        assert_eq!(args.mode, WorkspaceGuardMode::Strict);
+        assert!(args.json);
     }
 
     #[test]

--- a/src/commands/project_bindings.rs
+++ b/src/commands/project_bindings.rs
@@ -11,36 +11,37 @@ use crate::workspace::{
 };
 
 #[derive(Debug, Serialize)]
-struct ProjectBindingsResult {
-    cwd: String,
-    repo_local_binding: Option<RepoLocalBindingResult>,
-    user_bindings: UserBindingsResult,
+pub(crate) struct ProjectBindingsResult {
+    pub cwd: String,
+    pub repo_local_binding: Option<RepoLocalBindingResult>,
+    pub user_bindings: UserBindingsResult,
 }
 
 #[derive(Debug, Serialize)]
-struct RepoLocalBindingResult {
-    repo_root: String,
-    config_path: String,
-    context: String,
+pub(crate) struct RepoLocalBindingResult {
+    pub repo_root: String,
+    pub config_path: String,
+    pub context: String,
 }
 
 #[derive(Debug, Serialize)]
-struct UserBindingsResult {
-    default_context: Option<String>,
-    path_rules: Vec<PathRuleResult>,
-    git_remote_rules: Vec<GitRemoteRuleResult>,
+pub(crate) struct UserBindingsResult {
+    pub guard_mode: String,
+    pub default_context: Option<String>,
+    pub path_rules: Vec<PathRuleResult>,
+    pub git_remote_rules: Vec<GitRemoteRuleResult>,
 }
 
 #[derive(Debug, Serialize)]
-struct PathRuleResult {
-    path: String,
-    context: String,
+pub(crate) struct PathRuleResult {
+    pub path: String,
+    pub context: String,
 }
 
 #[derive(Debug, Serialize)]
-struct GitRemoteRuleResult {
-    pattern: String,
-    context: String,
+pub(crate) struct GitRemoteRuleResult {
+    pub pattern: String,
+    pub context: String,
 }
 
 pub fn run(args: ProjectBindingsArgs, home: &Path) -> Result<()> {
@@ -51,7 +52,53 @@ pub fn run(args: ProjectBindingsArgs, home: &Path) -> Result<()> {
 
 fn list(args: ProjectBindingsListArgs, home: &Path) -> Result<()> {
     let cwd = std::env::current_dir().context("could not determine current directory")?;
-    let repo = detect_repo(&cwd)?;
+    let result = snapshot(home, &cwd)?;
+
+    if args.json {
+        machine::print_success("project_bindings_list", result)?;
+        return Ok(());
+    }
+
+    output::print_title("Project bindings");
+    output::print_kv("Cwd", &result.cwd);
+    if let Some(repo_local) = result.repo_local_binding.as_ref() {
+        output::print_blank_line();
+        output::print_kv("Repo root", &repo_local.repo_root);
+        output::print_kv("Repo config", &repo_local.config_path);
+        output::print_kv("Repo context", &repo_local.context);
+    }
+
+    output::print_blank_line();
+    output::print_kv("Guard mode", &result.user_bindings.guard_mode);
+    output::print_kv(
+        "Default context",
+        result
+            .user_bindings
+            .default_context
+            .as_deref()
+            .unwrap_or("none"),
+    );
+
+    if result.user_bindings.path_rules.is_empty()
+        && result.user_bindings.git_remote_rules.is_empty()
+    {
+        output::print_blank_line();
+        output::print_empty_state("No user workspace bindings saved.");
+        return Ok(());
+    }
+
+    for rule in &result.user_bindings.path_rules {
+        output::print_kv(&format!("Path {}", rule.path), &rule.context);
+    }
+    for rule in &result.user_bindings.git_remote_rules {
+        output::print_kv(&format!("Remote {}", rule.pattern), &rule.context);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn snapshot(home: &Path, cwd: &Path) -> Result<ProjectBindingsResult> {
+    let repo = detect_repo(cwd)?;
     let workspace_config = WorkspaceStore::new(home).load()?;
 
     let repo_local_binding = if let Some(repo) = repo.as_ref() {
@@ -84,54 +131,14 @@ fn list(args: ProjectBindingsListArgs, home: &Path) -> Result<()> {
         .collect::<Vec<_>>();
     git_remote_rules.sort_by(|a, b| a.pattern.cmp(&b.pattern));
 
-    let result = ProjectBindingsResult {
+    Ok(ProjectBindingsResult {
         cwd: cwd.display().to_string(),
         repo_local_binding,
         user_bindings: UserBindingsResult {
+            guard_mode: workspace_config.guard_mode.display_name().to_owned(),
             default_context: workspace_config.default_context,
             path_rules,
             git_remote_rules,
         },
-    };
-
-    if args.json {
-        machine::print_success("project_bindings_list", result)?;
-        return Ok(());
-    }
-
-    output::print_title("Project bindings");
-    output::print_kv("Cwd", &result.cwd);
-    if let Some(repo_local) = result.repo_local_binding.as_ref() {
-        output::print_blank_line();
-        output::print_kv("Repo root", &repo_local.repo_root);
-        output::print_kv("Repo config", &repo_local.config_path);
-        output::print_kv("Repo context", &repo_local.context);
-    }
-
-    output::print_blank_line();
-    output::print_kv(
-        "Default context",
-        result
-            .user_bindings
-            .default_context
-            .as_deref()
-            .unwrap_or("none"),
-    );
-
-    if result.user_bindings.path_rules.is_empty()
-        && result.user_bindings.git_remote_rules.is_empty()
-    {
-        output::print_blank_line();
-        output::print_empty_state("No user workspace bindings saved.");
-        return Ok(());
-    }
-
-    for rule in &result.user_bindings.path_rules {
-        output::print_kv(&format!("Path {}", rule.path), &rule.context);
-    }
-    for rule in &result.user_bindings.git_remote_rules {
-        output::print_kv(&format!("Remote {}", rule.pattern), &rule.context);
-    }
-
-    Ok(())
+    })
 }

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -441,7 +441,7 @@ fn print_switch_summary(resolved: &ResolvedProfileSwitch, home: &Path) {
     let title = format!(
         "{} \u{2192} {}",
         resolved.tool.display_name(),
-        &resolved.profile_name
+        resolved.profile_name
     );
     output::print_title(&title);
     output::print_kv("Auth", auth_label(resolved.profile_meta.auth_method));

--- a/src/commands/workspace.rs
+++ b/src/commands/workspace.rs
@@ -7,7 +7,9 @@ use crate::cli::{
     WorkspaceArgs, WorkspaceBindArgs, WorkspaceCheckArgs, WorkspaceCommand, WorkspaceDoctorArgs,
     WorkspaceGuardArgs, WorkspaceStatusArgs,
 };
+use crate::commands::project_bindings::snapshot as project_bindings_snapshot;
 use crate::config::ConfigStore;
+use crate::machine;
 use crate::output;
 use crate::types::Tool;
 use crate::workspace::{
@@ -30,12 +32,27 @@ pub fn run(args: WorkspaceArgs, home: &Path) -> Result<()> {
 fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
     let config = ConfigStore::new(home).load()?;
     validate_context_exists(&config, &args.context)?;
+    let cwd = std::env::current_dir().context("could not determine current directory")?;
 
     if args.default {
         let store = WorkspaceStore::new(home);
         let mut workspace_config = store.load()?;
         workspace_config.default_context = Some(args.context.clone());
         store.save(&workspace_config)?;
+
+        if args.json {
+            machine::print_success(
+                "workspace_bind",
+                json!({
+                    "binding": {
+                        "scope": "default",
+                        "context": args.context,
+                    },
+                    "project_bindings": project_bindings_snapshot(home, &cwd)?,
+                }),
+            )?;
+            return Ok(());
+        }
 
         output::print_title("Updated workspace default");
         output::print_kv("Context", &args.context);
@@ -51,6 +68,21 @@ fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
         upsert_git_remote_rule(&mut workspace_config, &normalized, &args.context);
         store.save(&workspace_config)?;
 
+        if args.json {
+            machine::print_success(
+                "workspace_bind",
+                json!({
+                    "binding": {
+                        "scope": "git_remote",
+                        "pattern": normalized,
+                        "context": args.context,
+                    },
+                    "project_bindings": project_bindings_snapshot(home, &cwd)?,
+                }),
+            )?;
+            return Ok(());
+        }
+
         output::print_title("Bound workspace remote");
         output::print_kv("Pattern", &normalized);
         output::print_kv("Context", &args.context);
@@ -63,6 +95,23 @@ fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
     let path = resolve_target_path(target)?;
     if let Some(repo) = detect_repo(&path)? {
         save_repo_local_config(&repo, &args.context)?;
+
+        if args.json {
+            machine::print_success(
+                "workspace_bind",
+                json!({
+                    "binding": {
+                        "scope": "repo_local",
+                        "repo_root": repo.root.display().to_string(),
+                        "config_path": repo_local_config_path(&repo).display().to_string(),
+                        "context": args.context,
+                    },
+                    "project_bindings": project_bindings_snapshot(home, &cwd)?,
+                }),
+            )?;
+            return Ok(());
+        }
+
         output::print_title("Bound workspace repo");
         output::print_kv("Repo", repo.root.display().to_string());
         output::print_kv(
@@ -83,6 +132,21 @@ fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
         &args.context,
     );
     store.save(&workspace_config)?;
+
+    if args.json {
+        machine::print_success(
+            "workspace_bind",
+            json!({
+                "binding": {
+                    "scope": "path",
+                    "path": path.display().to_string(),
+                    "context": args.context,
+                },
+                "project_bindings": project_bindings_snapshot(home, &cwd)?,
+            }),
+        )?;
+        return Ok(());
+    }
 
     output::print_title("Bound workspace path");
     output::print_kv("Path", path.display().to_string());
@@ -265,6 +329,18 @@ fn guard(args: WorkspaceGuardArgs, home: &Path) -> Result<()> {
     let mut config = store.load()?;
     config.guard_mode = GuardMode::from(args.mode);
     store.save(&config)?;
+
+    if args.json {
+        let cwd = std::env::current_dir().context("could not determine current directory")?;
+        machine::print_success(
+            "workspace_guard",
+            json!({
+                "guard_mode": config.guard_mode.display_name(),
+                "project_bindings": project_bindings_snapshot(home, &cwd)?,
+            }),
+        )?;
+        return Ok(());
+    }
 
     output::print_title("Updated workspace guard");
     output::print_kv("Mode", config.guard_mode.display_name());

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -46,6 +46,62 @@ fn capabilities_json_reports_tool_capabilities() {
 }
 
 #[test]
+fn workspace_bind_json_returns_binding_and_snapshot() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+    env.cmd().args(["init", "--yes"]).assert().success();
+    env.cmd()
+        .args([
+            "add",
+            "claude",
+            "work",
+            "--api-key",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["context", "create", "client-acme", "--claude", "work"])
+        .assert()
+        .success();
+
+    let json = json_output(
+        &env,
+        &[
+            "workspace",
+            "bind",
+            "--git-remote",
+            "git@github.com:acme/*",
+            "--context",
+            "client-acme",
+            "--json",
+        ],
+    );
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "workspace_bind");
+    assert_eq!(json["result"]["binding"]["scope"], "git_remote");
+    assert_eq!(json["result"]["binding"]["pattern"], "github.com/acme/*");
+    assert_eq!(
+        json["result"]["project_bindings"]["user_bindings"]["guard_mode"],
+        "warn"
+    );
+}
+
+#[test]
+fn workspace_guard_json_returns_updated_mode_and_snapshot() {
+    let env = TestEnv::new();
+
+    let json = json_output(&env, &["workspace", "guard", "--mode", "strict", "--json"]);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["command"], "workspace_guard");
+    assert_eq!(json["result"]["guard_mode"], "strict");
+    assert_eq!(
+        json["result"]["project_bindings"]["user_bindings"]["guard_mode"],
+        "strict"
+    );
+}
+
+#[test]
 fn verify_json_reports_failures_and_remediation() {
     let env = TestEnv::new();
     env.add_fake_tool("claude", "claude 2.3.0");

--- a/tests/workspace_cmd.rs
+++ b/tests/workspace_cmd.rs
@@ -281,6 +281,7 @@ fn project_bindings_list_json_reports_current_repo_and_user_rules() {
         .clone();
 
     let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["result"]["user_bindings"]["guard_mode"], "warn");
     assert_eq!(
         json["result"]["repo_local_binding"]["context"],
         "client-acme"
@@ -296,6 +297,52 @@ fn project_bindings_list_json_reports_current_repo_and_user_rules() {
     assert_eq!(
         json["result"]["user_bindings"]["git_remote_rules"][0]["pattern"],
         "github.com/acme/*"
+    );
+}
+
+#[test]
+fn workspace_bind_and_guard_json_return_machine_envelopes() {
+    let env = TestEnv::new();
+    setup_profiles_and_contexts(&env);
+    let repo = setup_repo(&env, "clients/acme", "git@github.com:acme/api.git");
+
+    let bind_output = env
+        .cmd()
+        .current_dir(repo.join("api"))
+        .args([
+            "workspace",
+            "bind",
+            "..",
+            "--context",
+            "client-acme",
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let bind_json: serde_json::Value = serde_json::from_slice(&bind_output).unwrap();
+    assert_eq!(bind_json["ok"], true);
+    assert_eq!(bind_json["command"], "workspace_bind");
+    assert_eq!(bind_json["result"]["binding"]["scope"], "repo_local");
+    assert_eq!(bind_json["result"]["binding"]["context"], "client-acme");
+
+    let guard_output = env
+        .cmd()
+        .args(["workspace", "guard", "--mode", "strict", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let guard_json: serde_json::Value = serde_json::from_slice(&guard_output).unwrap();
+    assert_eq!(guard_json["ok"], true);
+    assert_eq!(guard_json["command"], "workspace_guard");
+    assert_eq!(guard_json["result"]["guard_mode"], "strict");
+    assert_eq!(
+        guard_json["result"]["project_bindings"]["user_bindings"]["guard_mode"],
+        "strict"
     );
 }
 


### PR DESCRIPTION
## Summary
- add `--json` support to `aisw workspace bind` and `aisw workspace guard`
- include a refreshed project bindings snapshot in both mutation results so GUIs can update state without scraping human output
- expose saved `guard_mode` from `aisw project-bindings list --json`

## Why
The GUI contract already covered profiles, contexts, verify/repair, and read-only project binding inspection. This closes the remaining gap for managing workspace-aware switching state without relying on text parsing.

## Testing
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked`
