### PR TITLE
Preserve isolated Claude OAuth capture state

### DIFF
--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -33,6 +33,7 @@ use paths::live_credentials_path;
 // ---- Constants ----
 
 pub(super) const CREDENTIALS_FILE: &str = ".credentials.json";
+pub(super) const ACCOUNT_METADATA_FILE: &str = ".claude.json";
 pub(super) const OAUTH_ACCOUNT_FILE: &str = "oauth-account.json";
 pub(super) const OAUTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 pub(super) const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
@@ -1397,7 +1398,7 @@ mod tests {
              [ -n \"$CLAUDE_CONFIG_DIR\" ] || exit 7\n\
              printf '%s' \"$CLAUDE_CONFIG_DIR\" > \"$HOME/env_was_set\"\n\
              mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
-             echo '{}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
              exit 0\n",
         )
         .unwrap();
@@ -1516,7 +1517,7 @@ mod tests {
              [ -n \"$CLAUDE_CONFIG_DIR\" ] || exit 7\n\
              printf '%s %s' \"$1\" \"$2\" > \"$HOME/login_args\"\n\
              mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
-             echo '{}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
              exit 0\n",
         )
         .unwrap();
@@ -1539,6 +1540,100 @@ mod tests {
             fs::read_to_string(home.join("login_args")).unwrap(),
             "auth login"
         );
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn oauth_waits_for_nonempty_credentials_before_capture() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("home");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&bin_dir).unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let bin = bin_dir.join("claude");
+        fs::write(
+            &bin,
+            "#!/bin/sh\n\
+             mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
+             echo '{}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             sleep 0.1\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (ps, cs) = stores(dir.path());
+        oauth::add_oauth_with(
+            &ps,
+            &cs,
+            "work",
+            None,
+            &bin,
+            CredentialBackend::File,
+            std::time::Duration::from_secs(2),
+            TEST_POLL,
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(ps.profile_dir(Tool::Claude, "work").join(CREDENTIALS_FILE))
+                .unwrap()
+                .trim(),
+            r#"{"oauthToken":"tok"}"#
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn oauth_persists_metadata_from_profile_config_dir() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("home");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(
+            home.join(ACCOUNT_METADATA_FILE),
+            r#"{"oauthAccount":{"emailAddress":"native@example.com"}}"#,
+        )
+        .unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let bin = bin_dir.join("claude");
+        fs::write(
+            &bin,
+            "#!/bin/sh\n\
+             mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             echo '{\"oauthAccount\":{\"emailAddress\":\"profile@example.com\"}}' > \"$CLAUDE_CONFIG_DIR/.claude.json\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (ps, cs) = stores(dir.path());
+        oauth::add_oauth_with(
+            &ps,
+            &cs,
+            "work",
+            None,
+            &bin,
+            CredentialBackend::File,
+            std::time::Duration::from_secs(2),
+            TEST_POLL,
+        )
+        .unwrap();
+
+        let metadata: serde_json::Value = serde_json::from_slice(
+            &ps.read_file(Tool::Claude, "work", OAUTH_ACCOUNT_FILE)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(metadata["emailAddress"], "profile@example.com");
     }
 
     #[test]
@@ -1618,7 +1713,7 @@ mod tests {
              printf '%s %s' \"$1\" \"$2\" > \"$HOME/login_args\"\n\
              printf '%s' \"$CLAUDE_CONFIG_DIR\" > \"$HOME/env_was_set\"\n\
              mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
-             echo '{}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
              exit 0\n",
         )
         .unwrap();

--- a/src/auth/claude/oauth.rs
+++ b/src/auth/claude/oauth.rs
@@ -91,13 +91,12 @@ pub fn live_credentials_snapshot_for_import(
 
 // ---- OAuth account metadata ----
 
-fn read_live_oauth_account_metadata(user_home: &Path) -> Result<Option<Vec<u8>>> {
-    let path = live_account_metadata_path(user_home);
+fn read_oauth_account_metadata(path: &Path) -> Result<Option<Vec<u8>>> {
     if !path.exists() {
         return Ok(None);
     }
 
-    let contents = fs::read(&path).with_context(|| format!("could not read {}", path.display()))?;
+    let contents = fs::read(path).with_context(|| format!("could not read {}", path.display()))?;
     let value: serde_json::Value = serde_json::from_slice(&contents)
         .with_context(|| format!("could not parse {}", path.display()))?;
     let Some(oauth_account) = value.get("oauthAccount") else {
@@ -107,6 +106,10 @@ fn read_live_oauth_account_metadata(user_home: &Path) -> Result<Option<Vec<u8>>>
     serde_json::to_vec(oauth_account)
         .map(Some)
         .context("could not serialize Claude oauthAccount metadata")
+}
+
+fn read_live_oauth_account_metadata(user_home: &Path) -> Result<Option<Vec<u8>>> {
+    read_oauth_account_metadata(&live_account_metadata_path(user_home))
 }
 
 /// Reads the live OAuth account metadata for profile import.
@@ -197,15 +200,23 @@ pub fn restore_live_state_after_oauth_add(
     restore_live_oauth_account_metadata_snapshot(oauth_account_metadata, user_home)
 }
 
+fn persist_oauth_account_metadata(
+    profile_store: &ProfileStore,
+    name: &str,
+    metadata_path: &Path,
+) -> Result<()> {
+    let Some(metadata) = read_oauth_account_metadata(metadata_path)? else {
+        return Ok(());
+    };
+    profile_store.write_file(Tool::Claude, name, super::OAUTH_ACCOUNT_FILE, &metadata)
+}
+
 fn persist_live_oauth_account_metadata(
     profile_store: &ProfileStore,
     name: &str,
     user_home: &Path,
 ) -> Result<()> {
-    let Some(metadata) = read_live_oauth_account_metadata(user_home)? else {
-        return Ok(());
-    };
-    profile_store.write_file(Tool::Claude, name, super::OAUTH_ACCOUNT_FILE, &metadata)
+    persist_oauth_account_metadata(profile_store, name, &live_account_metadata_path(user_home))
 }
 
 /// Captures the current live OAuth account metadata into the named profile.
@@ -340,14 +351,16 @@ pub(super) fn add_oauth_with(
         name,
     )?;
 
-    if let Some(user_home) = dirs::home_dir() {
-        files::cleanup_profile_on_error(
-            persist_live_oauth_account_metadata(profile_store, name, &user_home),
-            profile_store,
-            Tool::Claude,
-            name,
-        )?;
-    }
+    let metadata_path = target_config_dir
+        .as_deref()
+        .map(|config_dir| config_dir.join(super::ACCOUNT_METADATA_FILE))
+        .unwrap_or_else(|| live_account_metadata_path(&user_home));
+    files::cleanup_profile_on_error(
+        persist_oauth_account_metadata(profile_store, name, &metadata_path),
+        profile_store,
+        Tool::Claude,
+        name,
+    )?;
 
     files::cleanup_profile_on_error(
         identity::ensure_unique_oauth_identity(
@@ -478,7 +491,7 @@ If you need a different Claude account, fully sign out of claude.com first, then
                 .unwrap_or_else(read_keychain_credentials)?;
             if let Some(current) = current {
                 let changed = keychain_before.as_deref() != Some(current.as_slice());
-                if changed {
+                if changed && has_nonempty_credential_payload(&current) {
                     child.terminate();
                     return Ok(current);
                 }
@@ -489,7 +502,7 @@ If you need a different Claude account, fully sign out of claude.com first, then
             let current = fs::read(&credential_path)
                 .with_context(|| format!("could not read {}", credential_path.display()))?;
             let changed = file_before.as_deref() != Some(current.as_slice());
-            if changed {
+            if changed && has_nonempty_credential_payload(&current) {
                 child.terminate();
                 return Ok(current);
             }
@@ -500,7 +513,7 @@ If you need a different Claude account, fully sign out of claude.com first, then
                 let current = fs::read(fallback_path)
                     .with_context(|| format!("could not read {}", fallback_path.display()))?;
                 let changed = fallback_before.as_deref() != Some(current.as_slice());
-                if changed {
+                if changed && has_nonempty_credential_payload(&current) {
                     child.terminate();
                     return Ok(current);
                 }
@@ -518,21 +531,29 @@ If you need a different Claude account, fully sign out of claude.com first, then
                     .map(read_keychain_credentials_for_service)
                     .unwrap_or_else(read_keychain_credentials)?;
                 if let Some(current) = current {
-                    if status.success() || keychain_before.is_none() {
+                    if (status.success() || keychain_before.is_none())
+                        && has_nonempty_credential_payload(&current)
+                    {
                         return Ok(current);
                     }
                 }
             }
 
             if credential_path.exists() && status.success() {
-                return fs::read(&credential_path)
-                    .with_context(|| format!("could not read {}", credential_path.display()));
+                let current = fs::read(&credential_path)
+                    .with_context(|| format!("could not read {}", credential_path.display()))?;
+                if has_nonempty_credential_payload(&current) {
+                    return Ok(current);
+                }
             }
 
             if let Some(fallback_path) = fallback_live_path.as_ref() {
                 if fallback_path.exists() && status.success() {
-                    return fs::read(fallback_path)
-                        .with_context(|| format!("could not read {}", fallback_path.display()));
+                    let current = fs::read(fallback_path)
+                        .with_context(|| format!("could not read {}", fallback_path.display()))?;
+                    if has_nonempty_credential_payload(&current) {
+                        return Ok(current);
+                    }
                 }
             }
 
@@ -559,6 +580,13 @@ If you need a different Claude account, fully sign out of claude.com first, then
 
         std::thread::sleep(poll_interval);
     }
+}
+
+fn has_nonempty_credential_payload(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .ok()
+        .and_then(|value| value.as_object().map(|object| !object.is_empty()))
+        .unwrap_or(false)
 }
 
 // ---- Automatic synchronization ----
@@ -676,4 +704,21 @@ fn resolve_live_oauth_identity(
         return Ok(None);
     };
     identity::resolve_identity_from_json_bytes(&metadata)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_nonempty_credential_payload;
+
+    #[test]
+    fn empty_object_is_not_a_captured_credential() {
+        assert!(!has_nonempty_credential_payload(br#"{}"#));
+    }
+
+    #[test]
+    fn populated_object_is_a_captured_credential() {
+        assert!(has_nonempty_credential_payload(
+            br#"{"claudeAiOauth":{"accessToken":"token"}}"#
+        ));
+    }
 }

--- a/src/auth/claude/paths.rs
+++ b/src/auth/claude/paths.rs
@@ -36,7 +36,7 @@ pub(super) fn live_credentials_paths(user_home: &Path) -> [PathBuf; 2] {
 /// Returns the path to `~/.claude.json`, where Claude stores OAuth account
 /// metadata (`oauthAccount` field).
 pub(super) fn live_account_metadata_path(user_home: &Path) -> PathBuf {
-    user_home.join(".claude.json")
+    user_home.join(super::ACCOUNT_METADATA_FILE)
 }
 
 /// Returns the Claude local state directory if it exists. Returns `None` when


### PR DESCRIPTION
## Summary

- Capture Claude OAuth account metadata from the isolated profile's `CLAUDE_CONFIG_DIR` instead of the native `~/.claude.json`.
- Ignore the empty `{}` credential placeholder Claude creates before it writes the completed OAuth payload.
- Add regression coverage for delayed credential population and profile-scoped account metadata.

## User Impact

On file-backed/scoped Claude OAuth setups, adding a second account could be misidentified as the already-imported native account and rejected as a duplicate. aisw could also terminate `claude auth login` as soon as `.credentials.json` appeared, before the token payload was written. This keeps both credentials and identity metadata tied to the isolated profile being created.

## CLI / UX Changes

- New flags/options: none
- Changed defaults: none
- New/updated output: none
- Error message changes: none

## Backward Compatibility

- [x] No breaking changes
- [ ] Breaking change (describe below)

Shared-state OAuth still reads native account metadata. Only OAuth flows already targeting an isolated config directory use that directory's `.claude.json`.

## Implementation Notes

Credential polling now accepts only a non-empty JSON object. This intentionally supports the existing credential shapes while rejecting Claude's transient empty object. Account metadata capture follows the same config root supplied to `claude auth login`.

## Tests & Validation

Run locally on Windows:

```text
cargo fmt --check                                           PASS
cargo test --locked --lib                                  PASS (388 passed, 1 ignored)
cargo test --locked --test windows_secure_backend_parity   PASS
cargo build --release --locked                             PASS
```

The two Unix shell-based regression tests are included for the Ubuntu/macOS CI jobs. Local `cargo clippy --all-targets` and `windows_integration_smoke` are currently blocked by pre-existing Windows-only test issues: an unguarded Unix `PermissionsExt::from_mode` use, and `dirs::home_dir()` importing the real native profile despite the test's environment-variable sandbox. Neither failure touches this diff; hosted CI will provide the canonical lint and matrix result.

## Manual Verification

```text
1. Start with native Claude account A already imported.
2. Run: aisw add claude second --credential-backend file
3. Authorize a different Claude account B.
4. Verify the second profile stores B's metadata and a non-empty credential payload, without a duplicate-account error for A.
```

## Documentation

- [x] No docs needed
- [ ] Docs updated (README / CONTRIBUTING / command help)

## Security & Privacy Checklist

- [x] No secrets/tokens/credentials committed
- [x] Logs and screenshots are redacted
- [x] Sensitive output paths are reviewed

## Release Notes

Fix isolated Claude OAuth capture so transient empty credentials and native account metadata cannot corrupt second-account creation.

## Linked Issues

No linked issue.