### PR TITLE
Add versioned agent compatibility baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added a versioned agent compatibility baseline covering the current Claude,
+  Codex, Gemini, and Antigravity releases and the verification scope for each.
 - `aisw status` now reports the detected agent binary path and version in
   human and JSON output, giving compatibility checks a trustworthy view of
   which upstream executable is active without exposing credentials.

--- a/docs/acceptance-matrix.md
+++ b/docs/acceptance-matrix.md
@@ -2,6 +2,17 @@
 
 This matrix records the current end-to-end acceptance status for supported `aisw` auth backends. It is intentionally narrower than the vendor storage inventory in [AUTH_STORAGE_MATRIX.md](../AUTH_STORAGE_MATRIX.md): this document tracks what `aisw` actually supports, how it behaves, and how that behavior is verified.
 
+## Versioned compatibility baseline
+
+The baseline below records the upstream releases checked against `aisw` `0.3.8` at commit `f28aaf9`, verified on 2026-09-08. The release pins make the audit reproducible; they are not a guarantee that a future upstream release preserves the same storage contracts. Verification is based on the repository's unit and integration tests plus the documented upstream release and authentication behavior; it does not claim that each vendor binary was installed on every listed operating system in CI.
+
+| Agent | Upstream release | OS coverage | Compatibility basis | Result | Sources |
+| --- | --- | --- | --- | --- | --- |
+| Claude Code | `v2.1.263` | macOS, Linux, Windows | `cargo test --locked`; file credentials and system-keyring paths in the status above | Pass for `aisw`-supported paths; macOS Keychain behavior remains acceptance-matrix-limited | [release](https://github.com/anthropics/claude-code/releases/tag/v2.1.263), [CLI usage](https://docs.anthropic.com/en/docs/claude-code/cli-usage) |
+| Codex CLI | `rust-v0.153.4` | macOS, Linux, Windows | `cargo test --locked`; isolated ChatGPT auth, file API keys, and shared-mode guard | Pass for `aisw`-supported paths | [release](https://github.com/openai/codex/releases/tag/rust-v0.153.4) |
+| Gemini CLI | `v0.58.0` | macOS, Linux, Windows | `cargo test --locked`; file/API-key/Vertex paths and the documented individual-tier sunset | Pass for supported paths; Google AI Pro, Ultra, and free-tier individual accounts are upstream-sunset | [release](https://github.com/google-gemini/gemini-cli/releases/tag/v0.58.0), [sunset announcement](https://github.com/google-gemini/gemini-cli/discussions/28017) |
+| Antigravity CLI | `1.1.27` | macOS, Linux, Windows | `cargo test --locked`; shared OAuth keyring and documented config-root paths | Pass for `aisw`-supported shared OAuth paths; upstream API-key mode is not yet managed by `aisw` | [release](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.27), [authentication docs](https://antigravity.google/docs/cli-install?app=antigravity) |
+
 ## Status
 
 | Tool | Live auth/storage situation | `init` import | `use` switch | Expected behavior | Verification |

--- a/tests/acceptance_matrix_consistency.rs
+++ b/tests/acceptance_matrix_consistency.rs
@@ -97,3 +97,39 @@ fn acceptance_matrix_references_existing_files_and_tests() {
         }
     }
 }
+
+#[test]
+fn acceptance_matrix_records_current_versioned_agent_baseline() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let matrix_path = repo_root.join("docs").join("acceptance-matrix.md");
+    let matrix = std::fs::read_to_string(&matrix_path)
+        .expect("acceptance-matrix.md should be readable in repo");
+
+    assert!(
+        matrix.contains("## Versioned compatibility baseline"),
+        "acceptance matrix should include a versioned compatibility section"
+    );
+    assert!(
+        matrix.contains("verified on 2026-09-08"),
+        "versioned compatibility baseline should record its verification date"
+    );
+    assert!(
+        matrix.contains("against `aisw` `0.3.8` at commit `f28aaf9`"),
+        "versioned compatibility baseline should identify the aisw baseline"
+    );
+
+    for expected in [
+        ("Claude Code", "v2.1.263"),
+        ("Codex CLI", "rust-v0.153.4"),
+        ("Gemini CLI", "v0.58.0"),
+        ("Antigravity CLI", "1.1.27"),
+    ] {
+        let row_marker = format!("| {} | `{}` |", expected.0, expected.1);
+        assert!(
+            matrix.contains(&row_marker),
+            "versioned compatibility baseline is missing {} {}",
+            expected.0,
+            expected.1
+        );
+    }
+}


### PR DESCRIPTION
Closes #58

## Why

The acceptance matrix described auth behavior but did not identify the upstream agent releases or the `aisw` revision that had been audited. That made compatibility claims difficult to reproduce as vendor CLIs evolve.

## What changed

- add a versioned compatibility baseline for Claude Code, Codex CLI, Gemini CLI, and Antigravity CLI
- record OS scope, verification date, `aisw` baseline, test basis, results, and official upstream sources
- state explicitly that the pins are an audit baseline, not a guarantee for future upstream storage contracts
- add a consistency test that requires every supported agent release row and the baseline date
- document the change in `CHANGELOG.md`

## Trade-offs

This records the repository's automated behavioral verification and official upstream release/authentication documentation. It does not claim that every vendor binary was installed on every OS in CI, which would overstate the evidence available from the current test matrix.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`
- commit hooks: formatter, clippy, release build, full tests, completion smoke
