### PR TITLE
Run the credential-store canary test

### DIFF
--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -39,4 +39,9 @@ jobs:
       - name: Run real credential-store canary (ignored test)
         env:
           AISW_ENABLE_REAL_CREDENTIAL_STORE_CANARY: "1"
-        run: cargo test --locked real_credential_store_roundtrip_canary -- --ignored --nocapture
+        run: cargo test --locked --test real_credential_store_canary -- --list | rg -F "real_credential_store_canary_covers_secure_auth_modes"
+
+      - name: Execute real credential-store canary
+        env:
+          AISW_ENABLE_REAL_CREDENTIAL_STORE_CANARY: "1"
+        run: cargo test --locked --test real_credential_store_canary real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture


### PR DESCRIPTION
Closes #60

## Why

The opt-in credential-store workflow filtered for a stale test name. Cargo can return success when a filter selects no tests, so the three-OS canary could be green without exercising the credential-store lifecycle.

## What changed

- validate that the intended ignored integration test is present
- execute the exact test target and function on Ubuntu, macOS, and Windows

## Verification

- `actionlint .github/workflows/credential-store-canary.yml`
- `cargo test --locked --test real_credential_store_canary -- --list`
- `cargo fmt --check`
- `cargo test --locked`
- commit hooks: formatter, clippy, release build, full tests, completion smoke
