### PR TITLE
Report agent compatibility drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- `aisw status` and `aisw doctor` now identify agent releases outside the
+  audited compatibility baseline without exposing credentials or blocking
+  solely on version drift.
 - Added a versioned agent compatibility baseline covering the current Claude,
   Codex, Gemini, and Antigravity releases and the verification scope for each.
 - `aisw status` now reports the detected agent binary path and version in

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -452,9 +452,10 @@ Show per-tool state: installed binary, active profile, credential backend, live-
 
 When a tool is installed, status also reports the detected `binary_path` and
 `binary_version`. These identify the executable currently found on `PATH` and
-are diagnostic inputs for compatibility checks, not a guarantee that every
-upstream release is supported. Missing tools report `null` for both fields in
-JSON output.
+`binary_compatibility`. The latter is `verified` only for the pinned release
+in `compatibility_baseline`; older, newer, missing, or unparseable versions
+are warnings and do not hard-fail `status`. Missing tools report `null` for
+the binary fields in JSON output.
 
 | Flag | Effect |
 |---|---|

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -14,6 +14,11 @@ description: Claude Code, Codex CLI, Gemini CLI, and Antigravity CLI support mat
 | Gemini CLI | `gemini` | Enterprise auth, Vertex AI, API key | Full* | Full* | Full* |
 | Antigravity CLI | `agy` | OAuth | Full | Full | Full |
 
+`aisw status` reports whether the detected release matches the audited
+compatibility baseline. A non-verified release is a warning, not an automatic
+block; review [the versioned acceptance baseline](./acceptance-matrix.md)
+before relying on changed upstream auth/storage behavior.
+
 ## Binary detection
 
 `aisw` resolves each tool from `PATH` and confirms it is present by running `<binary> --version`. If a binary is not found, `aisw status` reports it as missing and `aisw use` for that tool is blocked with an error.

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -70,7 +70,22 @@ pub fn check_tool_binary(tool: Tool, path_var: &std::ffi::OsStr) -> CheckResult 
     match crate::tool_detection::detect_at_path(tool, path_var) {
         Some(detected) => {
             let detail = match detected.version {
-                Some(v) => format!("{} found ({})", detected.binary_path.display(), v),
+                Some(v) => {
+                    let compatibility = crate::compatibility::assess(tool, Some(&v));
+                    let detail = format!(
+                        "{} found ({}) — baseline {}",
+                        detected.binary_path.display(),
+                        v,
+                        crate::compatibility::baseline(tool)
+                    );
+                    return match compatibility {
+                        crate::compatibility::Status::Verified => CheckResult::pass(name, detail),
+                        _ => CheckResult::warn(
+                            name,
+                            format!("{detail}; compatibility is {}", compatibility.as_str()),
+                        ),
+                    };
+                }
                 None => format!("{} found", detected.binary_path.display()),
             };
             CheckResult::pass(name, detail)
@@ -428,13 +443,26 @@ mod tests {
         // Put a dummy executable named "claude" on a temp PATH.
         let dir = tempdir().unwrap();
         let bin = dir.path().join("claude");
-        fs::write(&bin, "#!/bin/sh\necho '0.1.0'").unwrap();
+        fs::write(&bin, "#!/bin/sh\necho 'claude 2.1.263'").unwrap();
         fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
 
         let path = std::ffi::OsString::from(dir.path());
         let result = check_tool_binary(Tool::Claude, &path);
         assert_eq!(result.status, CheckStatus::Pass);
         assert!(result.detail.contains("claude"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tool_binary_warns_when_release_is_outside_baseline() {
+        let dir = tempdir().unwrap();
+        let bin = dir.path().join("claude");
+        fs::write(&bin, "#!/bin/sh\necho 'claude 99.0.0'").unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let result = check_tool_binary(Tool::Claude, dir.path().as_os_str());
+        assert_eq!(result.status, CheckStatus::Warn);
+        assert!(result.detail.contains("newer_than_verified"));
     }
 
     #[test]

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -22,6 +22,8 @@ pub(crate) struct ToolStatus {
     pub binary_found: bool,
     pub binary_path: Option<String>,
     pub binary_version: Option<String>,
+    pub binary_compatibility: Option<String>,
+    pub compatibility_baseline: &'static str,
     pub stored_profiles: usize,
     pub active_profile: Option<String>,
     /// False when `active` points at a profile with no config entry.
@@ -156,6 +158,7 @@ pub(crate) fn collect_status(
     for tool in Tool::ALL {
         let detected = tool_detection::detect_at_path(tool, tool_path.as_os_str());
         let binary_found = detected.is_some();
+        let binary_version = detected.as_ref().and_then(|tool| tool.version.clone());
 
         let active_name = config.active_for(tool);
         let stored_profiles = config.profiles_for(tool).len();
@@ -179,7 +182,13 @@ pub(crate) fn collect_status(
             binary_path: detected
                 .as_ref()
                 .map(|tool| tool.binary_path.display().to_string()),
-            binary_version: detected.and_then(|tool| tool.version),
+            binary_version: binary_version.clone(),
+            binary_compatibility: detected.as_ref().map(|tool| {
+                crate::compatibility::assess(tool.tool, binary_version.as_deref())
+                    .as_str()
+                    .to_owned()
+            }),
+            compatibility_baseline: crate::compatibility::baseline(tool),
             stored_profiles,
             active_profile: active.profile,
             active_profile_registered: active.registered,
@@ -361,6 +370,11 @@ fn apply_status_filters(statuses: &mut Vec<ToolStatus>, args: &StatusArgs) {
                         .unwrap_or_default()
                         .to_ascii_lowercase()
                         .contains(&needle)
+                    || s.binary_compatibility
+                        .as_deref()
+                        .unwrap_or_default()
+                        .to_ascii_lowercase()
+                        .contains(&needle)
             });
         }
     }
@@ -525,6 +539,16 @@ fn print_text(statuses: &[ToolStatus], context_status: Option<&DerivedContextSta
         if let Some(version) = s.binary_version.as_deref() {
             output::print_kv("Version", version);
         }
+        if let Some(compatibility) = s.binary_compatibility.as_deref() {
+            output::print_kv("Compatibility", compatibility);
+            if compatibility != "verified" {
+                output::print_warning(format!(
+                    "installed {} is outside the audited baseline {}",
+                    s.tool.display_name(),
+                    s.compatibility_baseline
+                ));
+            }
+        }
         output::print_kv(
             "Active",
             output::ellipsize(
@@ -570,6 +594,8 @@ fn print_json(
                 "binary_found":         s.binary_found,
                 "binary_path":          s.binary_path,
                 "binary_version":       s.binary_version,
+                "binary_compatibility": s.binary_compatibility,
+                "compatibility_baseline": s.compatibility_baseline,
                 "stored_profiles":      s.stored_profiles,
                 "active_profile":       s.active_profile,
                 "auth_method":          s.auth_method,
@@ -1261,6 +1287,8 @@ mod tests {
                 binary_found: true,
                 binary_path: None,
                 binary_version: None,
+                binary_compatibility: None,
+                compatibility_baseline: crate::compatibility::baseline(Tool::Claude),
                 stored_profiles: 1,
                 active_profile: Some("work".to_owned()),
                 active_profile_registered: true,
@@ -1280,6 +1308,8 @@ mod tests {
                 binary_found: true,
                 binary_path: None,
                 binary_version: None,
+                binary_compatibility: None,
+                compatibility_baseline: crate::compatibility::baseline(Tool::Codex),
                 stored_profiles: 1,
                 active_profile: None,
                 active_profile_registered: true,
@@ -1324,6 +1354,8 @@ mod tests {
                 binary_found: true,
                 binary_path: None,
                 binary_version: None,
+                binary_compatibility: None,
+                compatibility_baseline: crate::compatibility::baseline(Tool::Claude),
                 stored_profiles: 1,
                 active_profile: Some("old".to_owned()),
                 active_profile_registered: true,
@@ -1343,6 +1375,8 @@ mod tests {
                 binary_found: true,
                 binary_path: None,
                 binary_version: None,
+                binary_compatibility: None,
+                compatibility_baseline: crate::compatibility::baseline(Tool::Codex),
                 stored_profiles: 1,
                 active_profile: Some("new".to_owned()),
                 active_profile_registered: true,

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -246,6 +246,8 @@ mod tests {
             binary_found: true,
             binary_path: None,
             binary_version: None,
+            binary_compatibility: None,
+            compatibility_baseline: crate::compatibility::baseline(tool),
             stored_profiles: 1,
             active_profile: Some("work".to_owned()),
             active_profile_registered: true,

--- a/src/compatibility.rs
+++ b/src/compatibility.rs
@@ -1,0 +1,96 @@
+use crate::types::Tool;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Verified,
+    OlderThanVerified,
+    NewerThanVerified,
+    Unknown,
+}
+
+impl Status {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Verified => "verified",
+            Self::OlderThanVerified => "older_than_verified",
+            Self::NewerThanVerified => "newer_than_verified",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Version(u64, u64, u64);
+
+pub fn baseline(tool: Tool) -> &'static str {
+    match tool {
+        Tool::Claude => "v2.1.263",
+        Tool::Codex => "rust-v0.153.4",
+        Tool::Gemini => "v0.58.0",
+        Tool::Antigravity => "1.1.27",
+    }
+}
+
+pub fn assess(tool: Tool, detected: Option<&str>) -> Status {
+    let Some(detected) = detected.and_then(parse_version) else {
+        return Status::Unknown;
+    };
+    let expected = parse_version(baseline(tool)).expect("compatibility baselines are valid");
+    match detected.cmp(&expected) {
+        std::cmp::Ordering::Less => Status::OlderThanVerified,
+        std::cmp::Ordering::Equal => Status::Verified,
+        std::cmp::Ordering::Greater => Status::NewerThanVerified,
+    }
+}
+
+fn parse_version(raw: &str) -> Option<Version> {
+    raw.split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '.')
+        .filter_map(|part| part.strip_prefix('v').or(Some(part)))
+        .find_map(|part| {
+            let mut components = part.split('.');
+            let version = Version(
+                components.next()?.parse().ok()?,
+                components.next()?.parse().ok()?,
+                components.next()?.parse().ok()?,
+            );
+            components.next().is_none().then_some(version)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_each_audited_release() {
+        for (tool, version) in [
+            (Tool::Claude, "claude 2.1.263"),
+            (Tool::Codex, "codex-cli 0.153.4"),
+            (Tool::Gemini, "gemini 0.58.0"),
+            (Tool::Antigravity, "agy 1.1.27"),
+        ] {
+            assert_eq!(assess(tool, Some(version)), Status::Verified);
+        }
+    }
+
+    #[test]
+    fn classifies_versions_relative_to_the_audit() {
+        assert_eq!(
+            assess(Tool::Claude, Some("claude 2.1.262")),
+            Status::OlderThanVerified
+        );
+        assert_eq!(
+            assess(Tool::Codex, Some("codex-cli 0.153.5")),
+            Status::NewerThanVerified
+        );
+    }
+
+    #[test]
+    fn treats_missing_and_unparseable_versions_as_unknown() {
+        assert_eq!(assess(Tool::Gemini, None), Status::Unknown);
+        assert_eq!(
+            assess(Tool::Gemini, Some("gemini development")),
+            Status::Unknown
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod backup;
 pub mod cli;
 pub mod commands;
+pub mod compatibility;
 pub mod config;
 pub mod error;
 pub mod live_apply;

--- a/tests/json_output_contract.rs
+++ b/tests/json_output_contract.rs
@@ -102,6 +102,8 @@ fn status_json_contract_snapshot() {
             "binary_found": true,
             "binary_path": "<path>",
             "binary_version": "claude 2.3.0",
+            "binary_compatibility": "newer_than_verified",
+            "compatibility_baseline": "v2.1.263",
             "stored_profiles": 1,
             "active_profile": "work",
             "auth_method": "api_key",
@@ -119,6 +121,8 @@ fn status_json_contract_snapshot() {
             "binary_found": true,
             "binary_path": "<path>",
             "binary_version": "codex 1.0.0",
+            "binary_compatibility": "newer_than_verified",
+            "compatibility_baseline": "rust-v0.153.4",
             "stored_profiles": 1,
             "active_profile": "work",
             "auth_method": "api_key",
@@ -136,6 +140,8 @@ fn status_json_contract_snapshot() {
             "binary_found": true,
             "binary_path": "<path>",
             "binary_version": "gemini 0.9.0",
+            "binary_compatibility": "older_than_verified",
+            "compatibility_baseline": "v0.58.0",
             "stored_profiles": 1,
             "active_profile": "work",
             "auth_method": "api_key",
@@ -153,6 +159,8 @@ fn status_json_contract_snapshot() {
             "binary_found": false,
             "binary_path": null,
             "binary_version": null,
+            "binary_compatibility": null,
+            "compatibility_baseline": "1.1.27",
             "stored_profiles": 0,
             "active_profile": null,
             "auth_method": null,
@@ -291,6 +299,8 @@ fn status_json_contract_preserved_with_filter_and_sort_flags() {
         "binary_found",
         "binary_path",
         "binary_version",
+        "binary_compatibility",
+        "compatibility_baseline",
         "stored_profiles",
         "active_profile",
         "auth_method",
@@ -309,7 +319,7 @@ fn status_json_contract_preserved_with_filter_and_sort_flags() {
             "missing key `{key}` in status entry"
         );
     }
-    assert_eq!(entry.len(), 15);
+    assert_eq!(entry.len(), 17);
 }
 
 #[test]

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -469,9 +469,10 @@ Show per-tool state: installed binary, active profile, credential backend, live-
 
 When a tool is installed, status also reports the detected `binary_path` and
 `binary_version`. These identify the executable currently found on `PATH` and
-are diagnostic inputs for compatibility checks, not a guarantee that every
-upstream release is supported. Missing tools report `null` for both fields in
-JSON output.
+`binary_compatibility`. The latter is `verified` only for the pinned release
+in `compatibility_baseline`; older, newer, missing, or unparseable versions
+are warnings and do not hard-fail `status`. Missing tools report `null` for
+the binary fields in JSON output.
 
 | Flag | Effect |
 |---|---|

--- a/website/src/content/docs/supported-tools.md
+++ b/website/src/content/docs/supported-tools.md
@@ -31,6 +31,11 @@ head:
 | Gemini CLI | `gemini` | Enterprise auth, Vertex AI, API key | Full* | Full* | Full* |
 | Antigravity CLI | `agy` | OAuth | Full | Full | Full |
 
+`aisw status` reports whether the detected release matches the audited
+compatibility baseline. A non-verified release is a warning, not an automatic
+block; review [the versioned acceptance baseline](./acceptance-matrix.md)
+before relying on changed upstream auth/storage behavior.
+
 ## Binary detection
 
 `aisw` resolves each tool from `PATH` and confirms it is present by running `<binary> --version`. If a binary is not found, `aisw status` reports it as missing and `aisw use` for that tool is blocked with an error.


### PR DESCRIPTION
Closes #64

## Why

`aisw` already records the installed agent version, but users still had to compare it manually with the audited compatibility baseline. That left upstream auth/storage changes discoverable only after a failure.

## What changed

- add one version parser/classifier shared by `status` and `doctor`
- report `verified`, `older_than_verified`, `newer_than_verified`, or `unknown`
- expose `binary_compatibility` and `compatibility_baseline` as additive status JSON fields
- make `doctor` warn on version drift without hard-failing solely on upstream version changes
- include compatibility state in human diagnostics and status search
- update canonical and generated docs and JSON contract coverage

## Trade-offs

The check compares semantic `major.minor.patch` values extracted from vendor `--version` output. It intentionally treats drift as advisory: a newer release may be compatible, but `aisw` has not audited its storage contract yet. No credentials or token contents are inspected.

## Verification

- `cargo fmt --check`
- `cargo test --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`
- `npm run sync-docs`
- `npm run build`
- `npm run check:seo`
- commit hooks: formatter, clippy, release build, full tests, completion smoke
