### PR TITLE
Fail clearly on future config schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Fixed
 
+- `aisw doctor` now fails clearly when `config.json` uses a schema newer than
+  the installed binary supports, instead of reporting the file as valid.
 - **Behavior change:** `aisw use --all` now exits non-zero when a tool switch fails. It previously exited `0` and reported success, contradicting the documented contract that a zero exit means success. On partial failure the `--json` output is now the standard failure envelope (`{"ok": false, "error": {...}}`) instead of `{"ok": true, ..., "warnings": [...]}`.
 - `aisw use --all` now honors `--emit-env` and `--state-mode`. `--emit-env` previously fell through to the human-readable summary, which a shell hook would then `eval`.
 - `aisw remove` no longer deletes credentials and profile files before checking whether a context still references the profile — the removal was rejected afterwards, leaving the data already destroyed.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -623,7 +623,10 @@ See [Shell integration](shell-integration.md) for details and completion setup.
 aisw doctor [--json]
 ```
 
-Check install and environment health: binary locations, `~/.aisw/` permissions, shell hook status, and keyring availability.
+Check install and environment health: binary locations, compatibility drift,
+`~/.aisw/` permissions, shell hook status, keyring availability, and config
+schema support. A future config schema is a hard failure with an upgrade
+remediation; agent version drift remains advisory.
 
 ```sh
 aisw doctor

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,16 @@ aisw verify --json
 aisw repair --json --dry-run
 ```
 
-`doctor` checks binary detection, `~/.aisw/` permissions, shell hook status, and keyring availability. `status --json` shows the full state of every tool including live-match status and any credential warnings. `verify --json` combines both into a pass/warn/fail verdict with remediation hints. `repair --json --dry-run` previews safe local fixes for missing aisw state or broad permissions.
+`doctor` checks binary detection, compatibility drift, `~/.aisw/` permissions,
+shell hook status, keyring availability, and config schema support. `status
+--json` shows the full state of every tool including live-match status and any
+credential warnings. `verify --json` combines both into a pass/warn/fail
+verdict with remediation hints. `repair --json --dry-run` previews safe local
+fixes for missing aisw state or broad permissions.
+
+If `doctor` reports an unsupported config schema, upgrade `aisw` before editing
+profiles. Older binaries deliberately refuse to rewrite newer config files so
+saved context and profile data cannot be silently discarded.
 
 ---
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -125,6 +125,14 @@ pub fn check_config(config_path: &Path) -> CheckResult {
             let version = v.get("version").and_then(|v| v.as_u64()).unwrap_or(0);
             if version == 0 {
                 CheckResult::warn(NAME, "config exists but has no version field".to_owned())
+            } else if version > crate::config::CURRENT_VERSION as u64 {
+                CheckResult::fail(
+                    NAME,
+                    format!(
+                        "config uses unsupported schema v{version} (this aisw supports up to v{}); upgrade aisw before changing profiles",
+                        crate::config::CURRENT_VERSION
+                    ),
+                )
             } else {
                 CheckResult::pass(NAME, format!("valid (schema v{version})"))
             }
@@ -482,6 +490,18 @@ mod tests {
         let result = check_config(&p);
         assert_eq!(result.status, CheckStatus::Pass);
         assert!(result.detail.contains("v1"));
+    }
+
+    #[test]
+    fn config_fails_for_a_future_schema_version() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("config.json");
+        fs::write(&p, r#"{"version":99,"profiles":{}}"#).unwrap();
+
+        let result = check_config(&p);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.detail.contains("unsupported schema v99"));
+        assert!(result.detail.contains("upgrade aisw"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::error::AiswError;
 use crate::types::{StateMode, Tool};
 
-const CURRENT_VERSION: u32 = 2;
+pub(crate) const CURRENT_VERSION: u32 = 2;
 const CONFIG_FILE: &str = "config.json";
 const CONFIG_LOCK_FILE: &str = "config.json.lock";
 const AISW_HOME_ENV: &str = "AISW_HOME";

--- a/tests/audit_regressions.rs
+++ b/tests/audit_regressions.rs
@@ -400,6 +400,32 @@ fn doctor_passes_for_a_healthy_profile_of_every_tool() {
     );
 }
 
+#[test]
+fn doctor_reports_future_config_schema_in_json() {
+    let env = TestEnv::new();
+    std::fs::write(
+        env.aisw_home.join("config.json"),
+        r#"{"version":99,"profiles":{}}"#,
+    )
+    .unwrap();
+
+    let output = env.output(&["doctor", "--json"]);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    let config_check = json["checks"]
+        .as_array()
+        .expect("checks array")
+        .iter()
+        .find(|check| check["name"] == "config/json")
+        .expect("config check");
+
+    assert_eq!(config_check["status"], "fail");
+    assert!(config_check["detail"]
+        .as_str()
+        .expect("config detail")
+        .contains("unsupported schema v99"));
+    assert!(!output.status.success());
+}
+
 /// The permission check must still catch a genuinely world-readable credential.
 #[test]
 #[cfg(unix)]

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -640,7 +640,10 @@ See [Shell integration](/aisw/shell-integration/) for details and completion set
 aisw doctor [--json]
 ```
 
-Check install and environment health: binary locations, `~/.aisw/` permissions, shell hook status, and keyring availability.
+Check install and environment health: binary locations, compatibility drift,
+`~/.aisw/` permissions, shell hook status, keyring availability, and config
+schema support. A future config schema is a hard failure with an upgrade
+remediation; agent version drift remains advisory.
 
 ```sh
 aisw doctor

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -33,7 +33,16 @@ aisw verify --json
 aisw repair --json --dry-run
 ```
 
-`doctor` checks binary detection, `~/.aisw/` permissions, shell hook status, and keyring availability. `status --json` shows the full state of every tool including live-match status and any credential warnings. `verify --json` combines both into a pass/warn/fail verdict with remediation hints. `repair --json --dry-run` previews safe local fixes for missing aisw state or broad permissions.
+`doctor` checks binary detection, compatibility drift, `~/.aisw/` permissions,
+shell hook status, keyring availability, and config schema support. `status
+--json` shows the full state of every tool including live-match status and any
+credential warnings. `verify --json` combines both into a pass/warn/fail
+verdict with remediation hints. `repair --json --dry-run` previews safe local
+fixes for missing aisw state or broad permissions.
+
+If `doctor` reports an unsupported config schema, upgrade `aisw` before editing
+profiles. Older binaries deliberately refuse to rewrite newer config files so
+saved context and profile data cannot be silently discarded.
 
 ---
 


### PR DESCRIPTION
Closes #66

## Why

`aisw doctor` previously treated a config with a future schema version as valid, even though the config loader correctly refuses to rewrite it. That made the health check give a false sense of safety after a newer aisw release or another writer had upgraded the schema.

## What changed

- fail the `config/json` doctor check for schema versions newer than the installed binary supports
- preserve the machine-readable failure and non-zero exit contract
- add unit and end-to-end regression coverage
- document the upgrade remediation in source docs and the website

## Trade-offs

Future schemas remain read-only to older binaries. This keeps the existing fail-closed data-preservation behavior and avoids inventing a migration path without schema knowledge.

## Verification

- `npm run sync-docs`
- `npm run build`
- `npm run check:seo`
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` — 572 passed, 1 ignored
- `cargo test --locked --test audit_regressions` — 18 passed
- `git diff --check` with trailing-space checks
