### PR TITLE
Make backup snapshots transactional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Fixed
 
+- Failed backup snapshots now clean up partial files and secure-store backup
+  entries instead of leaving incomplete recovery artifacts behind.
 - `aisw doctor` now fails clearly when `config.json` uses a schema newer than
   the installed binary supports, instead of reporting the file as valid.
 - **Behavior change:** `aisw use --all` now exits non-zero when a tool switch fails. It previously exited `0` and reported success, contradicting the documented contract that a zero exit means success. On partial failure the `--json` output is now the standard failure envelope (`{"ok": false, "error": {...}}`) instead of `{"ok": true, ..., "warnings": [...]}`.

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -61,18 +61,39 @@ impl BackupManager {
         fs::create_dir_all(&dest)
             .with_context(|| format!("could not create backup directory {}", dest.display()))?;
 
-        if profile_meta.credential_backend == CredentialBackend::SystemKeyring {
-            secure_store::snapshot_profile_secret(tool, name, &backup_id)?;
+        let result = (|| {
+            copy_profile_tree(profile_dir, &dest)?;
+
+            write_metadata(
+                &dest.join(METADATA_FILE),
+                &BackupProfileMetadata {
+                    profile_meta: profile_meta.clone(),
+                },
+            )?;
+
+            if profile_meta.credential_backend == CredentialBackend::SystemKeyring {
+                secure_store::snapshot_profile_secret(tool, name, &backup_id)?;
+            }
+
+            Ok::<(), anyhow::Error>(())
+        })();
+
+        if let Err(mut err) = result {
+            if profile_meta.credential_backend == CredentialBackend::SystemKeyring {
+                if let Err(cleanup_err) = secure_store::delete_backup_secret(tool, name, &backup_id)
+                {
+                    err = err.context(format!(
+                        "could not clean up secure backup credentials: {cleanup_err}"
+                    ));
+                }
+            }
+            if let Err(cleanup_err) = fs::remove_dir_all(self.backups_dir().join(&backup_id)) {
+                err = err.context(format!(
+                    "could not clean up partial backup directory: {cleanup_err}"
+                ));
+            }
+            return Err(err);
         }
-
-        copy_profile_tree(profile_dir, &dest)?;
-
-        write_metadata(
-            &dest.join(METADATA_FILE),
-            &BackupProfileMetadata {
-                profile_meta: profile_meta.clone(),
-            },
-        )?;
 
         Ok(dest)
     }
@@ -575,6 +596,20 @@ mod tests {
         assert!(backup_path.is_dir());
         assert!(backup_path.join(".credentials.json").exists());
         assert!(backup_path.join(METADATA_FILE).exists());
+    }
+
+    #[test]
+    fn failed_snapshot_removes_partial_backup() {
+        let dir = tempdir().unwrap();
+        let missing_profile_dir = dir.path().join("missing-profile");
+        let m = manager(dir.path());
+
+        let err = m
+            .snapshot(Tool::Claude, "work", &missing_profile_dir, &profile_meta())
+            .unwrap_err();
+
+        assert!(err.to_string().contains("could not read"));
+        assert!(m.list().unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #68

## Why

Backups are created before `aisw use` and `aisw remove` mutate live state. If copying a profile or writing backup metadata failed, the old implementation could leave an incomplete backup directory. For system-keyring profiles, a later failure could also leave a secure-store backup entry with no usable filesystem backup.

That weakens the recovery path exactly when it is needed most.

## What changed

- treat file and secure-store snapshotting as one operation
- remove the exact partial backup directory on any snapshot failure
- remove a secure-store backup entry when cleanup is required
- preserve the original failure while surfacing cleanup failures as additional context
- add regression coverage for failed snapshots

## Trade-offs

Cleanup is best effort because filesystem or keyring failures can themselves be unrecoverable. Those secondary failures are retained in the returned error so operators can investigate rather than receiving a misleading success.

## Verification

- `cargo fmt --check`
- `cargo test --locked --lib backup::tests::` — 25 passed
- `cargo test --locked --test backup_cmd` — 16 passed
- `cargo clippy --all-targets --locked -- -D warnings`
- full pre-commit and pre-push hooks — 574 tests passed, 1 ignored
- `git diff --check` with trailing-space checks
