### PR TITLE
Make backup restore safer on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 ### Fixed
 
+- Backup restore now commits profile metadata only after its files and secure
+  credentials have been restored successfully, and applies file writes as one
+  rollback-capable transaction.
 - Failed backup snapshots now clean up partial files and secure-store backup
   entries instead of leaving incomplete recovery artifacts behind.
 - `aisw doctor` now fails clearly when `config.json` uses a schema newer than

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -554,7 +554,10 @@ aisw backup list --sort recent
 aisw backup restore <backup_id> [--yes] [--json]
 ```
 
-Restore profile files from a backup. Does not activate the profile; run `aisw use` after restore.
+Restore profile files and credentials from a backup. Profile metadata is saved
+only after restoration succeeds, and file writes are applied as one
+rollback-capable transaction. Does not activate the profile; run `aisw use`
+after restore.
 
 | Flag | Effect |
 |---|---|

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -197,6 +197,10 @@ find ~/.aisw -type f -maxdepth 3 | xargs ls -l
 
 **Expected behavior:** `aisw backup restore` restores profile files into storage only. It does not activate the profile.
 
+Failed validation does not register a new profile, and file-application errors
+roll back the file transaction. Resolve the reported filesystem or
+credential-store error and retry the same backup.
+
 **Fix:** After restoring, explicitly activate the profile:
 
 ```sh

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -186,21 +186,28 @@ impl BackupManager {
                 }
 
                 let dest_dir = profile_store.profile_dir(tool, &profile_name);
-                fs::create_dir_all(&dest_dir).with_context(|| {
-                    format!("could not create profile dir {}", dest_dir.display())
-                })?;
-
                 let profile_meta =
                     restore_profile_meta(config_store, tool, &profile_name, &profile_path)?;
                 profile_meta.credential_backend.validate_for_tool(tool)?;
-                config_store.upsert_profile(tool, &profile_name, profile_meta.clone())?;
+
+                let restored_files = restore_profile_tree(&profile_path, &dest_dir)?;
+                restored += restored_files;
 
                 if profile_meta.credential_backend == CredentialBackend::SystemKeyring {
                     secure_store::restore_profile_secret(tool, &profile_name, backup_id)?;
+                    if restored_files == 0 {
+                        fs::create_dir_all(&dest_dir).with_context(|| {
+                            format!("could not create profile dir {}", dest_dir.display())
+                        })?;
+                    }
                     restored += 1;
+                } else if restored_files == 0 {
+                    continue;
                 }
 
-                restored += restore_profile_tree(&profile_path, &dest_dir)?;
+                // Register the profile only after all credential and file
+                // restoration for this entry has succeeded.
+                config_store.upsert_profile(tool, &profile_name, profile_meta)?;
             }
         }
 
@@ -279,27 +286,19 @@ fn copy_profile_tree(src_root: &Path, dest_root: &Path) -> Result<()> {
 }
 
 fn restore_profile_tree(src_root: &Path, dest_root: &Path) -> Result<usize> {
-    let mut restored = 0usize;
+    let mut changes = Vec::new();
     for file in crate::auth::files::list_regular_files_recursive(src_root)? {
         if file.file_name == METADATA_FILE {
             continue;
         }
         let relative = file.file_name.to_string_lossy().into_owned();
         let dst = dest_root.join(&relative);
-        if let Some(parent) = dst.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("could not create {}", parent.display()))?;
-        }
-        fs::copy(&file.path, &dst).with_context(|| {
-            format!(
-                "could not restore {} to {}",
-                file.path.display(),
-                dst.display()
-            )
-        })?;
-        set_permissions_600(&dst)?;
-        restored += 1;
+        let contents = fs::read(&file.path)
+            .with_context(|| format!("could not read backup file {}", file.path.display()))?;
+        changes.push(crate::live_apply::LiveFileChange::write(dst, contents));
     }
+    let restored = changes.len();
+    crate::live_apply::apply_transaction(changes)?;
     Ok(restored)
 }
 
@@ -710,6 +709,34 @@ mod tests {
             .restore("2099-01-01T00-00-00.000Z-0000", &ps, &cs)
             .unwrap_err();
         assert!(err.to_string().contains("no backup found"));
+    }
+
+    #[test]
+    fn failed_restore_does_not_register_profile_metadata() {
+        let dir = tempdir().unwrap();
+        let profile_path = dir
+            .path()
+            .join(BACKUPS_DIR)
+            .join("empty-backup")
+            .join(Tool::Claude.dir_name())
+            .join("work");
+        fs::create_dir_all(&profile_path).unwrap();
+        write_metadata(
+            &profile_path.join(METADATA_FILE),
+            &BackupProfileMetadata {
+                profile_meta: profile_meta(),
+            },
+        )
+        .unwrap();
+
+        let m = manager(dir.path());
+        let ps = profile_store(dir.path());
+        let cs = ConfigStore::new(dir.path());
+        let err = m.restore("empty-backup", &ps, &cs).unwrap_err();
+
+        assert!(err.to_string().contains("contains no files to restore"));
+        assert!(cs.load().unwrap().profiles_for(Tool::Claude).is_empty());
+        assert!(!ps.exists(Tool::Claude, "work"));
     }
 
     #[test]

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -571,7 +571,10 @@ aisw backup list --sort recent
 aisw backup restore <backup_id> [--yes] [--json]
 ```
 
-Restore profile files from a backup. Does not activate the profile; run `aisw use` after restore.
+Restore profile files and credentials from a backup. Profile metadata is saved
+only after restoration succeeds, and file writes are applied as one
+rollback-capable transaction. Does not activate the profile; run `aisw use`
+after restore.
 
 | Flag | Effect |
 |---|---|

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -214,6 +214,10 @@ find ~/.aisw -type f -maxdepth 3 | xargs ls -l
 
 **Expected behavior:** `aisw backup restore` restores profile files into storage only. It does not activate the profile.
 
+Failed validation does not register a new profile, and file-application errors
+roll back the file transaction. Resolve the reported filesystem or
+credential-store error and retry the same backup.
+
 **Fix:** After restoring, explicitly activate the profile:
 
 ```sh


### PR DESCRIPTION
Closes #70

## Why

Backups are the recovery path for `verify`, `use`, and `remove`, but restore previously registered profile metadata before all restore work had completed. An empty or malformed backup could therefore leave config claiming a profile existed when no usable files had been restored. File copies were also committed one at a time, so a write failure could leave a partially updated profile.

## What changed

- apply restored profile files through aisw’s existing rollback-capable file transaction
- restore secure credentials before registering profile metadata
- register file-backed profiles only when at least one usable file was restored
- avoid creating empty profile directories for failed file-only restores
- document the ordering and failure behavior

## Trade-offs

This keeps legacy backup discovery and metadata inference intact. The transaction boundary covers file application and defers config registration; filesystem or credential-store failures that occur after a successful file transaction still remain explicit errors for retry and diagnosis.

## Verification

- `npm run sync-docs`
- `npm run build`
- `npm run check:seo`
- `cargo fmt --check`
- focused backup unit tests — 26 passed
- `cargo test --locked --test backup_cmd` — 16 passed
- `cargo clippy --all-targets --locked -- -D warnings`
- full pre-commit and pre-push hooks — 575 tests passed, 1 ignored
