### PR TITLE
Distinguish credential layout states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Fixed
 
+- `status` now distinguishes present, missing, and unrecognized credential
+  layouts instead of treating any regular profile file as a credential.
 - Backup restore now commits profile metadata only after its files and secure
   credentials have been restored successfully, and applies file writes as one
   rollback-capable transaction.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -448,7 +448,8 @@ aisw list --active-only --json
 aisw status [--tool <tool>] [--search TEXT] [--sort name|recent] [--active-only] [--context] [--json]
 ```
 
-Show per-tool state: installed binary, active profile, credential backend, live-match status, and token expiry warnings.
+Show per-tool state: installed binary, active profile, credential backend,
+credential layout state, live-match status, and token expiry warnings.
 
 When a tool is installed, status also reports the detected `binary_path` and
 `binary_version`. These identify the executable currently found on `PATH` and
@@ -468,6 +469,10 @@ the binary fields in JSON output.
 
 Notes:
 - "Live match" indicates whether the tool's current live credentials match the `aisw`-recorded active profile.
+- `credential_state` is `present` when the known primary credential is stored,
+  `missing` when no profile files or secure credential exist, and `unknown` when
+  files exist but do not match a known credential layout. Unknown layouts are
+  warnings in `verify` and should be inspected before switching profiles.
 - Token expiry warnings appear when an OAuth token is expired or expires within 24 hours.
 - `--context` does not change the shape of plain `status --json` output.
 - `status --context --json` wraps the tool array in a `{ "tools": [...], "context": ... }` object.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,6 +23,11 @@ credential warnings. `verify --json` combines both into a pass/warn/fail
 verdict with remediation hints. `repair --json --dry-run` previews safe local
 fixes for missing aisw state or broad permissions.
 
+If `status --json` reports `credential_state: "unknown"`, the profile contains
+files but not a credential layout recognized for its tool and auth method. Do
+not overwrite it with `aisw use` until the upstream layout is reviewed; check
+the installed agent version against the [compatibility baseline](acceptance-matrix.md).
+
 If `doctor` reports an unsupported config schema, upgrade `aisw` before editing
 profiles. Older binaries deliberately refuse to rewrite newer config files so
 saved context and profile data cannot be silently discarded.

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 use std::path::Path;
 
 use anyhow::Result;
+use serde::Serialize;
 
 use crate::auth;
 use crate::cli::StatusArgs;
@@ -15,6 +16,14 @@ use crate::types::Tool;
 enum LiveActivation {
     Applied,
     NotApplied,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CredentialState {
+    Present,
+    Missing,
+    Unknown,
 }
 
 pub(crate) struct ToolStatus {
@@ -36,6 +45,7 @@ pub(crate) struct ToolStatus {
     pub state_mode: Option<String>,
     pub active_profile_added_at: Option<chrono::DateTime<chrono::Utc>>,
     pub active_profile_applied: Option<bool>,
+    pub credential_state: CredentialState,
     pub credentials_present: bool,
     pub permissions_ok: bool,
 }
@@ -200,6 +210,7 @@ pub(crate) fn collect_status(
             state_mode,
             active_profile_added_at: active.added_at,
             active_profile_applied: active.applied,
+            credential_state: active.credential_state,
             credentials_present: active.credentials_present,
             permissions_ok: active.permissions_ok,
         });
@@ -221,6 +232,7 @@ struct ActiveProfileStatus {
     antigravity_auth_classification: Option<String>,
     added_at: Option<chrono::DateTime<chrono::Utc>>,
     applied: Option<bool>,
+    credential_state: CredentialState,
     credentials_present: bool,
     permissions_ok: bool,
 }
@@ -237,6 +249,7 @@ impl Default for ActiveProfileStatus {
             antigravity_auth_classification: None,
             added_at: None,
             applied: None,
+            credential_state: CredentialState::Missing,
             credentials_present: false,
             permissions_ok: true,
         }
@@ -259,8 +272,14 @@ fn collect_active_profile_status(
     };
 
     let profile_dir = profile_store.profile_dir(tool, name);
-    let (credentials_present, permissions_ok) =
-        check_profile_storage(&profile_dir, tool, name, meta.credential_backend);
+    let (credential_state, permissions_ok) = check_profile_storage(
+        &profile_dir,
+        tool,
+        name,
+        meta.auth_method,
+        meta.credential_backend,
+    );
+    let credentials_present = credential_state == CredentialState::Present;
 
     // Only the owning tool's classifier runs; the others stay `None`.
     let mut claude_auth_classification = None;
@@ -335,6 +354,7 @@ fn collect_active_profile_status(
         antigravity_auth_classification,
         added_at: Some(meta.added_at),
         applied,
+        credential_state,
         credentials_present,
         permissions_ok,
     })
@@ -401,50 +421,60 @@ fn auth_label(method: AuthMethod) -> &'static str {
     }
 }
 
-/// Returns (credentials_present, permissions_ok).
-/// credentials_present: at least one regular file exists in the dir.
+/// Returns (credential_state, permissions_ok).
 /// permissions_ok: all regular files have 0600 permissions (unix only).
 fn check_profile_storage(
     dir: &Path,
     tool: Tool,
     profile_name: &str,
+    auth_method: AuthMethod,
     credential_backend: CredentialBackend,
-) -> (bool, bool) {
+) -> (CredentialState, bool) {
     if !dir.is_dir() {
-        return (false, true);
+        return (CredentialState::Missing, true);
     }
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return (false, true);
+    let Ok(files) = crate::auth::files::list_regular_files_recursive(dir) else {
+        return (CredentialState::Unknown, true);
     };
-    let mut found_file = false;
     let mut perms_ok = true;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_symlink() || !path.is_file() {
-            continue;
-        }
-        found_file = true;
+    for file in &files {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            if let Ok(meta) = std::fs::metadata(&path) {
+            if let Ok(meta) = std::fs::metadata(&file.path) {
                 if meta.permissions().mode() & 0o777 != 0o600 {
                     perms_ok = false;
                 }
             }
         }
     }
-    let credentials_present = match credential_backend {
-        CredentialBackend::File => found_file,
+    let credential_state = match credential_backend {
+        CredentialBackend::File => {
+            let primary = match (tool, auth_method) {
+                (Tool::Claude, _) => ".credentials.json",
+                (Tool::Codex, _) => "auth.json",
+                (Tool::Gemini, AuthMethod::ApiKey) => ".env",
+                (Tool::Gemini, AuthMethod::OAuth) => "oauth_creds.json",
+                (Tool::Antigravity, _) => "keyring-secret.json",
+            };
+            if files.iter().any(|file| file.file_name == primary) {
+                CredentialState::Present
+            } else if files.is_empty() {
+                CredentialState::Missing
+            } else {
+                CredentialState::Unknown
+            }
+        }
         CredentialBackend::SystemKeyring => {
-            auth::secure_store::read_profile_secret(tool, profile_name)
-                .ok()
-                .flatten()
-                .is_some()
+            match auth::secure_store::read_profile_secret(tool, profile_name) {
+                Ok(Some(_)) => CredentialState::Present,
+                Ok(None) => CredentialState::Missing,
+                Err(_) => CredentialState::Unknown,
+            }
         }
     };
 
-    (credentials_present, perms_ok)
+    (credential_state, perms_ok)
 }
 
 fn status_message(s: &ToolStatus) -> &'static str {
@@ -459,6 +489,9 @@ fn status_message(s: &ToolStatus) -> &'static str {
     }
     if !s.active_profile_registered {
         return "active profile is missing from aisw config \u{2014} run 'aisw repair --apply' or re-add it";
+    }
+    if s.credential_state == CredentialState::Unknown {
+        return "credential storage layout is unrecognized; inspect the profile before switching";
     }
     if !s.credentials_present {
         return match s.credential_backend.as_deref() {
@@ -605,6 +638,7 @@ fn print_json(
                 "antigravity_auth_classification": s.antigravity_auth_classification,
                 "state_mode":           s.state_mode,
                 "active_profile_applied": s.active_profile_applied,
+                "credential_state":     s.credential_state,
                 "credentials_present":  s.credentials_present,
                 "permissions_ok":       s.permissions_ok,
             })
@@ -1300,6 +1334,7 @@ mod tests {
                 state_mode: Some("isolated".to_owned()),
                 active_profile_added_at: Some(chrono::Utc::now()),
                 active_profile_applied: Some(true),
+                credential_state: CredentialState::Present,
                 credentials_present: true,
                 permissions_ok: true,
             },
@@ -1321,6 +1356,7 @@ mod tests {
                 state_mode: Some("isolated".to_owned()),
                 active_profile_added_at: None,
                 active_profile_applied: None,
+                credential_state: CredentialState::Missing,
                 credentials_present: false,
                 permissions_ok: true,
             },
@@ -1367,6 +1403,7 @@ mod tests {
                 state_mode: Some("isolated".to_owned()),
                 active_profile_added_at: Some(older),
                 active_profile_applied: Some(true),
+                credential_state: CredentialState::Present,
                 credentials_present: true,
                 permissions_ok: true,
             },
@@ -1388,6 +1425,7 @@ mod tests {
                 state_mode: Some("isolated".to_owned()),
                 active_profile_added_at: Some(newer),
                 active_profile_applied: Some(true),
+                credential_state: CredentialState::Present,
                 credentials_present: true,
                 permissions_ok: true,
             },

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -116,6 +116,13 @@ fn tool_verification(tool: &status::ToolStatus) -> ToolVerification {
             ));
             VerifyStatus::Warn
         }
+    } else if tool.credential_state == status::CredentialState::Unknown {
+        issues.push("managed credential layout is not recognized".to_owned());
+        remediation.push(
+            "Inspect 'aisw status --json' and verify the upstream credential layout before switching"
+                .to_owned(),
+        );
+        VerifyStatus::Warn
     } else if !tool.credentials_present {
         issues.push("managed credentials are missing".to_owned());
         remediation.push(format!(
@@ -259,6 +266,7 @@ mod tests {
             state_mode: Some("isolated".to_owned()),
             active_profile_added_at: None,
             active_profile_applied: Some(true),
+            credential_state: status::CredentialState::Present,
             credentials_present: true,
             permissions_ok: true,
         }
@@ -311,11 +319,24 @@ mod tests {
     fn verify_fails_when_managed_credentials_are_missing() {
         let mut tool = tool_status(Tool::Codex);
         tool.credentials_present = false;
+        tool.credential_state = status::CredentialState::Missing;
 
         let result = tool_verification(&tool);
 
         assert_eq!(result.status, VerifyStatus::Fail);
         assert!(result.issues[0].contains("managed credentials are missing"));
+    }
+
+    #[test]
+    fn verify_warns_when_credential_layout_is_unknown() {
+        let mut tool = tool_status(Tool::Codex);
+        tool.credential_state = status::CredentialState::Unknown;
+        tool.credentials_present = false;
+
+        let result = tool_verification(&tool);
+
+        assert_eq!(result.status, VerifyStatus::Warn);
+        assert!(result.issues[0].contains("layout"));
     }
 
     #[test]

--- a/tests/json_output_contract.rs
+++ b/tests/json_output_contract.rs
@@ -113,6 +113,7 @@ fn status_json_contract_snapshot() {
             "antigravity_auth_classification": null,
             "state_mode": "isolated",
             "active_profile_applied": expected_claude_active_applied,
+            "credential_state": "present",
             "credentials_present": true,
             "permissions_ok": true,
         },
@@ -132,6 +133,7 @@ fn status_json_contract_snapshot() {
             "antigravity_auth_classification": null,
             "state_mode": "isolated",
             "active_profile_applied": true,
+            "credential_state": "present",
             "credentials_present": true,
             "permissions_ok": true,
         },
@@ -151,6 +153,7 @@ fn status_json_contract_snapshot() {
             "antigravity_auth_classification": null,
             "state_mode": null,
             "active_profile_applied": true,
+            "credential_state": "present",
             "credentials_present": true,
             "permissions_ok": true,
         },
@@ -170,6 +173,7 @@ fn status_json_contract_snapshot() {
             "antigravity_auth_classification": null,
             "state_mode": null,
             "active_profile_applied": null,
+            "credential_state": "missing",
             "credentials_present": false,
             "permissions_ok": true,
         },
@@ -310,6 +314,7 @@ fn status_json_contract_preserved_with_filter_and_sort_flags() {
         "antigravity_auth_classification",
         "state_mode",
         "active_profile_applied",
+        "credential_state",
         "credentials_present",
         "permissions_ok",
     ];
@@ -319,7 +324,7 @@ fn status_json_contract_preserved_with_filter_and_sort_flags() {
             "missing key `{key}` in status entry"
         );
     }
-    assert_eq!(entry.len(), 17);
+    assert_eq!(entry.len(), 18);
 }
 
 #[test]

--- a/tests/status_cmd.rs
+++ b/tests/status_cmd.rs
@@ -124,6 +124,57 @@ fn status_shows_credentials_present_for_active_profile() {
 }
 
 #[test]
+fn status_reports_unknown_file_layout_without_calling_it_healthy() {
+    let env = TestEnv::new();
+    env.add_fake_tool("codex", "codex 1.0.0");
+    env.cmd()
+        .args([
+            "add",
+            "codex",
+            "work",
+            "--api-key",
+            VALID_CODEX_KEY,
+            "--set-active",
+        ])
+        .assert()
+        .success();
+
+    std::fs::remove_file(
+        env.aisw_home
+            .join("profiles")
+            .join("codex")
+            .join("work")
+            .join("auth.json"),
+    )
+    .unwrap();
+
+    let output = env
+        .cmd()
+        .args(["status", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("valid json");
+    let codex = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["tool"] == "codex")
+        .unwrap();
+
+    assert_eq!(codex["credential_state"], "unknown");
+    assert_eq!(codex["credentials_present"], false);
+
+    env.cmd()
+        .args(["status"])
+        .assert()
+        .success()
+        .stdout(contains("credential storage layout is unrecognized"));
+}
+
+#[test]
 fn status_reports_missing_system_keyring_credentials_explicitly() {
     let env = TestEnv::new();
     env.add_fake_tool("claude", "claude 2.3.0");

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -465,7 +465,8 @@ aisw list --active-only --json
 aisw status [--tool <tool>] [--search TEXT] [--sort name|recent] [--active-only] [--context] [--json]
 ```
 
-Show per-tool state: installed binary, active profile, credential backend, live-match status, and token expiry warnings.
+Show per-tool state: installed binary, active profile, credential backend,
+credential layout state, live-match status, and token expiry warnings.
 
 When a tool is installed, status also reports the detected `binary_path` and
 `binary_version`. These identify the executable currently found on `PATH` and
@@ -485,6 +486,10 @@ the binary fields in JSON output.
 
 Notes:
 - "Live match" indicates whether the tool's current live credentials match the `aisw`-recorded active profile.
+- `credential_state` is `present` when the known primary credential is stored,
+  `missing` when no profile files or secure credential exist, and `unknown` when
+  files exist but do not match a known credential layout. Unknown layouts are
+  warnings in `verify` and should be inspected before switching profiles.
 - Token expiry warnings appear when an OAuth token is expired or expires within 24 hours.
 - `--context` does not change the shape of plain `status --json` output.
 - `status --context --json` wraps the tool array in a `{ "tools": [...], "context": ... }` object.

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -40,6 +40,11 @@ credential warnings. `verify --json` combines both into a pass/warn/fail
 verdict with remediation hints. `repair --json --dry-run` previews safe local
 fixes for missing aisw state or broad permissions.
 
+If `status --json` reports `credential_state: "unknown"`, the profile contains
+files but not a credential layout recognized for its tool and auth method. Do
+not overwrite it with `aisw use` until the upstream layout is reviewed; check
+the installed agent version against the [compatibility baseline](acceptance-matrix.md).
+
 If `doctor` reports an unsupported config schema, upgrade `aisw` before editing
 profiles. Older binaries deliberately refuse to rewrite newer config files so
 saved context and profile data cannot be silently discarded.


### PR DESCRIPTION
Closes #72

## Why

`status` previously treated any regular file in a file-backed profile as a credential. That could report a profile as healthy after its primary secret was removed while unrelated config or metadata remained. It also collapsed secure-store read errors into “missing,” hiding whether the keyring was unavailable or the credential was absent.

## What changed

- add additive `credential_state` JSON output: `present`, `missing`, or `unknown`
- recognize each tool’s current primary credential layout by auth method
- classify non-empty unrecognized layouts and secure-store read errors as `unknown`
- keep the existing `credentials_present` boolean for compatibility
- make `verify` warn with remediation for unknown layouts
- add JSON, human-output, and contract regression coverage

## Trade-offs

The primary filenames remain intentionally narrow so metadata cannot masquerade as credentials. A changed upstream layout becomes an actionable warning rather than an automatic failure or silent pass; users can inspect the installed agent against the compatibility baseline before switching.

## Verification

- `npm run sync-docs`
- `npm run build`
- `npm run check:seo`
- `cargo fmt --check`
- status and JSON contract suites — 26 tests passed
- verify unit tests — 9 passed
- `cargo clippy --all-targets --locked -- -D warnings`
- full pre-commit and pre-push hooks — 576 tests passed, 1 ignored
