### PR TITLE
Expose an overall doctor JSON result

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -72,6 +72,11 @@ aisw backup list --json
 aisw doctor --json
 ```
 
+The machine-readable doctor result keeps its existing `checks` array and adds
+an additive top-level `ok` boolean. Use it when a caller needs the diagnostic
+result in the same JSON document rather than deriving it from individual
+checks; the command still exits non-zero when `ok` is `false`.
+
 With `--json`, success and expected command failures are emitted as structured JSON on stdout. Human-oriented stdout/stderr output is suppressed. The process still exits non-zero on failure.
 
 For OAuth-based `add`, use `--progress-json` to stream newline-delimited JSON progress events:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -641,6 +641,10 @@ aisw doctor
 aisw doctor --json
 ```
 
+`doctor --json` preserves the `checks` array and adds an additive top-level
+`ok` boolean. It is `true` when no check has status `fail`; the process still
+uses a non-zero exit code when `ok` is `false`.
+
 ---
 
 ## `aisw verify`

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -389,12 +389,15 @@ fn print_text(report: &DoctorReport) {
     }
 }
 
+#[derive(Serialize)]
+struct DoctorJsonOutput<'a> {
+    ok: bool,
+    checks: &'a [CheckResult],
+}
+
 fn print_json(report: &DoctorReport) -> Result<()> {
-    #[derive(Serialize)]
-    struct Output<'a> {
-        checks: &'a [CheckResult],
-    }
-    let out = serde_json::to_string_pretty(&Output {
+    let out = serde_json::to_string_pretty(&DoctorJsonOutput {
+        ok: !report.any_failed(),
         checks: &report.checks,
     })?;
     println!("{out}");
@@ -744,5 +747,30 @@ mod tests {
         let args = DoctorArgs { json: true };
         // Should not panic or error.
         let _ = run_in(args, &home, &user_home, std::ffi::OsStr::new(""));
+    }
+
+    #[test]
+    fn doctor_json_includes_overall_result_without_changing_checks() {
+        let report = DoctorReport {
+            checks: vec![CheckResult::pass("config/json", "valid")],
+        };
+        let output = serde_json::to_value(DoctorJsonOutput {
+            ok: !report.any_failed(),
+            checks: &report.checks,
+        })
+        .unwrap();
+
+        assert_eq!(output["ok"], true);
+        assert_eq!(output["checks"].as_array().unwrap().len(), 1);
+
+        let failed_report = DoctorReport {
+            checks: vec![CheckResult::fail("config/json", "invalid")],
+        };
+        let failed_output = serde_json::to_value(DoctorJsonOutput {
+            ok: !failed_report.any_failed(),
+            checks: &failed_report.checks,
+        })
+        .unwrap();
+        assert_eq!(failed_output["ok"], false);
     }
 }

--- a/website/src/content/docs/automation.md
+++ b/website/src/content/docs/automation.md
@@ -89,6 +89,11 @@ aisw backup list --json
 aisw doctor --json
 ```
 
+The machine-readable doctor result keeps its existing `checks` array and adds
+an additive top-level `ok` boolean. Use it when a caller needs the diagnostic
+result in the same JSON document rather than deriving it from individual
+checks; the command still exits non-zero when `ok` is `false`.
+
 With `--json`, success and expected command failures are emitted as structured JSON on stdout. Human-oriented stdout/stderr output is suppressed. The process still exits non-zero on failure.
 
 For OAuth-based `add`, use `--progress-json` to stream newline-delimited JSON progress events:

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -658,6 +658,10 @@ aisw doctor
 aisw doctor --json
 ```
 
+`doctor --json` preserves the `checks` array and adds an additive top-level
+`ok` boolean. It is `true` when no check has status `fail`; the process still
+uses a non-zero exit code when `ok` is `false`.
+
 ---
 
 ## `aisw verify`


### PR DESCRIPTION
Closes #86

## Why

`aisw doctor --json` exposed every check but not the overall result. Callers had to duplicate the CLI's pass/fail reduction, and that makes piped diagnostics harder to consume reliably.

## Decision

Add an additive top-level `ok` boolean while preserving the existing `checks` array and exit-code behavior. This gives GUI and CI integrations a direct result without changing existing check paths or requiring a schema migration.

The contract is documented in both the source docs and the website copy.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked --lib commands::doctor::tests::` — 25 passed
- `git diff --check`
