### PR TITLE
Report Antigravity during live detection

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,7 +35,7 @@ aisw --version
 aisw init
 ```
 
-This creates `~/.aisw/`, offers to install the optional shell hook (recommended), and detects any accounts you are already logged into. If you are already signed into Claude Code, Codex, or Gemini, `init` will offer to import those credentials as named profiles so you start without re-authenticating. Antigravity support currently starts with explicit `add` flows rather than `init` auto-import.
+This creates `~/.aisw/`, offers to install the optional shell hook (recommended), and detects any accounts you are already logged into. If you are already signed into Claude Code, Codex, or Gemini, `init` will offer to import those credentials as named profiles so you start without re-authenticating. Antigravity live state is reported during `init --detect-live`; importing it still starts with an explicit `add` flow rather than automatic import.
 
 For GUI or other machine-driven onboarding, use the non-prompting bootstrap path instead:
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -214,6 +214,13 @@ fn detect_live_accounts(
             user_home,
             detected.get(&Tool::Gemini).and_then(|entry| entry.as_ref()),
         )?,
+        detect_live_antigravity(
+            aisw_home,
+            user_home,
+            detected
+                .get(&Tool::Antigravity)
+                .and_then(|entry| entry.as_ref()),
+        )?,
     ])
 }
 
@@ -845,6 +852,81 @@ fn detect_live_gemini(
     })
 }
 
+fn detect_live_antigravity(
+    aisw_home: &Path,
+    user_home: &Path,
+    detected: Option<&DetectedTool>,
+) -> Result<LiveAccountStatus> {
+    let profile_store = ProfileStore::new(aisw_home);
+    let config_store = ConfigStore::new(aisw_home);
+    let app_dir = auth::antigravity::live_app_dir(user_home);
+    let shared_dir = auth::antigravity::live_shared_dir(user_home);
+    let local_state = (app_dir.exists() || shared_dir.exists())
+        .then(|| user_home.join(".gemini").display().to_string());
+    let Some(snapshot) = auth::antigravity::live_credentials_snapshot_for_import(user_home)? else {
+        return Ok(LiveAccountStatus {
+            tool: Tool::Antigravity.binary_name(),
+            detected: detected.is_some(),
+            outcome: if local_state.is_some() {
+                "local_state_without_importable_auth"
+            } else {
+                "no_live_auth"
+            },
+            auth_method: None,
+            source_description: None,
+            existing_profile: None,
+            local_state,
+            note: None,
+        });
+    };
+
+    let Some(secret) = snapshot.keyring_secret.as_deref() else {
+        return Ok(LiveAccountStatus {
+            tool: Tool::Antigravity.binary_name(),
+            detected: detected.is_some(),
+            outcome: "local_state_without_importable_auth",
+            auth_method: None,
+            source_description: Some(format!(
+                "found {} config roots without a readable live keyring credential",
+                user_home.join(".gemini").display()
+            )),
+            existing_profile: None,
+            local_state,
+            note: Some(
+                "Antigravity config state exists, but its shared OS keyring credential was not readable."
+                    .to_owned(),
+            ),
+        });
+    };
+
+    let existing_profile = auth::identity::existing_antigravity_oauth_profile_for_live_secret(
+        &profile_store,
+        &config_store,
+        Some(secret),
+    )?;
+    let keyring_ref = snapshot.keyring_ref;
+
+    Ok(LiveAccountStatus {
+        tool: Tool::Antigravity.binary_name(),
+        detected: detected.is_some(),
+        outcome: if existing_profile.is_some() {
+            "already_managed"
+        } else {
+            "detected"
+        },
+        auth_method: Some("oauth"),
+        source_description: Some(format!(
+            "found {} ({}/{})",
+            auth::system_keyring::display_name(),
+            keyring_ref.service,
+            keyring_ref.account
+        )),
+        existing_profile,
+        local_state,
+        note: None,
+    })
+}
+
 fn import_claude(
     aisw_home: &Path,
     user_home: &Path,
@@ -1411,6 +1493,43 @@ mod tests {
         assert_eq!(status.outcome, "detected");
         assert_eq!(status.auth_method, Some("api_key"));
         assert!(status.note.unwrap().contains(".env precedence"));
+    }
+
+    #[test]
+    fn detect_live_antigravity_reports_shared_keyring_oauth() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("home");
+        let keyring_root = tmp.path().join("keyring");
+        fs::create_dir_all(auth::antigravity::live_app_dir(&user_home)).unwrap();
+        fs::write(
+            auth::antigravity::live_app_dir(&user_home).join("settings.json"),
+            br#"{"theme":"dark"}"#,
+        )
+        .unwrap();
+        let _keyring =
+            crate::auth::test_overrides::EnvVarGuard::set("AISW_KEYRING_TEST_DIR", &keyring_root);
+        auth::system_keyring::upsert_generic_password(
+            "gemini",
+            "antigravity",
+            br#"{"email":"agy@example.com"}"#,
+        )
+        .unwrap();
+
+        let status = detect_live_antigravity(&aisw_home, &user_home, None).unwrap();
+
+        assert_eq!(status.tool, "agy");
+        assert_eq!(status.outcome, "detected");
+        assert_eq!(status.auth_method, Some("oauth"));
+        assert_eq!(
+            status.local_state,
+            Some(user_home.join(".gemini").display().to_string())
+        );
+        assert!(status
+            .source_description
+            .unwrap()
+            .contains("gemini/antigravity"));
     }
 
     #[test]

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -264,6 +264,13 @@ fn init_json_detect_live_returns_machine_bootstrap_state() {
     assert_eq!(json["result"]["live_accounts"][0]["tool"], "claude");
     assert_eq!(json["result"]["live_accounts"][0]["outcome"], "detected");
     assert_eq!(json["result"]["live_accounts"][0]["auth_method"], "oauth");
+    let antigravity = json["result"]["live_accounts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|account| account["tool"] == "agy")
+        .expect("Antigravity should be included in live detection");
+    assert_eq!(antigravity["outcome"], "no_live_auth");
     assert!(!env.fake_home.join(".zshrc").exists());
 }
 

--- a/website/src/content/docs/quickstart.md
+++ b/website/src/content/docs/quickstart.md
@@ -52,7 +52,7 @@ aisw --version
 aisw init
 ```
 
-This creates `~/.aisw/`, offers to install the optional shell hook (recommended), and detects any accounts you are already logged into. If you are already signed into Claude Code, Codex, or Gemini, `init` will offer to import those credentials as named profiles so you start without re-authenticating. Antigravity support currently starts with explicit `add` flows rather than `init` auto-import.
+This creates `~/.aisw/`, offers to install the optional shell hook (recommended), and detects any accounts you are already logged into. If you are already signed into Claude Code, Codex, or Gemini, `init` will offer to import those credentials as named profiles so you start without re-authenticating. Antigravity live state is reported during `init --detect-live`; importing it still starts with an explicit `add` flow rather than automatic import.
 
 For GUI or other machine-driven onboarding, use the non-prompting bootstrap path instead:
 


### PR DESCRIPTION
Closes #90

## Why

`init --json --no-shell-hook --detect-live` is the machine onboarding path for discovering existing agent state, but its payload omitted Antigravity even though `aisw` supports its shared OAuth keyring and config roots. Automation could therefore miss an already-authenticated Antigravity installation.

## What changed

- Add Antigravity to `live_accounts` with detected, already-managed, and local-state-without-readable-auth outcomes.
- Report the shared keyring identity and `~/.gemini` state location without exposing credential contents.
- Keep imports explicit via `aisw add antigravity ...`; `init` does not mutate or auto-import Antigravity state.
- Add unit and GUI contract coverage and document the behavior.

This follows the current upstream model: Antigravity authenticates through the OS keyring and shared Gemini roots, while its API-key path is outside this change.

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked detect_live_antigravity_reports_shared_keyring_oauth`
- `cargo test --locked --test gui_contract init_json_detect_live_returns_machine_bootstrap_state`
- `cargo test --locked --test acceptance_matrix_consistency`
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`
