### PR TITLE
Make use all atomic across tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ aisw version [--json]
 aisw capabilities [--json]
 ```
 
-`aisw use --all` switches every tool that has a profile with the given name. Tools without one are skipped; if a tool has that profile but fails to switch, the command reports the failure and exits non-zero.
+`aisw use --all` switches every tool that has a profile with the given name. Tools without one are skipped; matching profiles are resolved before live state changes, and a failure rolls back earlier switches before the command exits non-zero.
 
 ## Scripting and exit codes
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -191,6 +191,9 @@ Branch on `error.kind`, not on the message text  -  `kind` is stable, the messag
 - A tool with no such profile is **skipped**, and the command still succeeds.
 - A tool that has the profile but fails to switch is **reported**, and the command exits non-zero with the standard failure envelope.
 
+Matching profiles are resolved before live state changes. If one switch fails,
+aisw restores the live state changed by earlier tools and exits non-zero.
+
 So a zero exit means every tool that could switch did switch. If you need to know which tools were affected, read `result.affected_tools` from `--json` on success.
 
 ## Applying profiles without the shell hook

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -169,7 +169,7 @@ Activate a stored profile as the live account.
 Notes:
 - `--state-mode` applies to Claude Code and Codex CLI only. Gemini and Antigravity do not support it. With `--all`, it is applied only to the tools that support it rather than failing the whole switch.
 - Switching is atomic: the previous live state is snapshotted before any write. A failed write triggers a full rollback.
-- With `--all`, a tool that has no profile of that name is skipped and the command still succeeds. A tool that has the profile but fails to switch is reported and the command exits non-zero.
+- With `--all`, matching profiles are resolved before any live state is changed. A tool that has no profile of that name is skipped; if a matching tool fails, all earlier live switches are rolled back and the command exits non-zero.
 - With shell hook active, `aisw use` also emits the environment variable exports into the current shell session.
 - `--emit-env` is used internally by the shell hook. You can use it directly to apply exports in a subshell: `eval "$(aisw use claude work --emit-env)"`.
 - Codex shared mode remains supported for API-key profiles.

--- a/docs/security.md
+++ b/docs/security.md
@@ -61,7 +61,7 @@ All operations are local filesystem and OS keyring operations. You can audit thi
 
 ### Transactional writes
 
-Profile activation uses a snapshot-and-apply model. Before writing any live credential file, the current live state is captured. If any file write fails partway through, the snapshot is restored atomically. You never end up with a partially applied profile.
+Profile activation uses a snapshot-and-apply model. Before writing any live credential file, the current live state is captured. If any file write fails partway through, the snapshot is restored atomically. Individual switches and cross-tool `use --all` operations never leave a partially applied live profile set.
 
 This is particularly important for Claude Code, which stores credentials across multiple locations (the credentials file and OAuth account metadata in `~/.claude.json`). A failed write to either location triggers a full rollback.
 

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -1,5 +1,4 @@
-use std::collections::{HashMap, HashSet};
-use std::ffi::OsString;
+use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -12,11 +11,11 @@ use crate::cli::{
 };
 use crate::commands::use_::{
     active_map, apply_resolved_profile_switch, backup_ids_for, diff_backup_ids, live_match_map,
-    state_mode_map, ResolvedProfileSwitch,
+    restore_live_state_for_switches, snapshot_live_state_for_switches, state_mode_map,
+    ResolvedProfileSwitch,
 };
 use crate::config::{Config, ConfigStore, ContextEntry, ContextProfiles};
 use crate::error::AiswError;
-use crate::live_apply::LiveFileChange;
 use crate::machine;
 use crate::output;
 use crate::profile::validate_profile_name;
@@ -352,7 +351,7 @@ fn use_context(_args: ContextUseArgs, _home: &Path) -> Result<()> {
     }
 
     let before_backup_ids = backup_ids_for(home, None)?;
-    let snapshots = snapshot_live_state_for_context(&switches, &user_home)?;
+    let snapshots = snapshot_live_state_for_switches(&switches, &user_home)?;
     let activations = switches
         .iter()
         .map(|switch| {
@@ -376,7 +375,7 @@ fn use_context(_args: ContextUseArgs, _home: &Path) -> Result<()> {
     })();
 
     if let Err(err) = apply_result {
-        restore_live_state_for_context(&snapshots, &user_home)?;
+        restore_live_state_for_switches(&snapshots, &user_home)?;
         return Err(err);
     }
 
@@ -525,159 +524,6 @@ fn resolve_context_switches(
         });
     }
     Ok(switches)
-}
-
-#[derive(Debug, Clone)]
-enum LiveStateSnapshot {
-    Claude {
-        credentials: Option<auth::claude::LiveCredentialSnapshot>,
-        oauth_account_metadata: Option<Vec<u8>>,
-    },
-    Codex {
-        files: Vec<FileSnapshot>,
-    },
-    Gemini {
-        dir: std::path::PathBuf,
-        files: Vec<NamedFileSnapshot>,
-    },
-    Antigravity {
-        snapshot: auth::antigravity::LiveSnapshot,
-    },
-}
-
-#[derive(Debug, Clone)]
-struct FileSnapshot {
-    path: std::path::PathBuf,
-    bytes: Option<Vec<u8>>,
-}
-
-#[derive(Debug, Clone)]
-struct NamedFileSnapshot {
-    file_name: OsString,
-    bytes: Vec<u8>,
-}
-
-fn snapshot_live_state_for_context(
-    switches: &[ResolvedProfileSwitch],
-    user_home: &Path,
-) -> Result<HashMap<Tool, LiveStateSnapshot>> {
-    let mut snapshots = HashMap::new();
-    for switch in switches {
-        let snapshot = match switch.tool {
-            Tool::Claude => LiveStateSnapshot::Claude {
-                credentials: auth::claude::live_credentials_snapshot_for_import(user_home)?,
-                oauth_account_metadata: auth::claude::read_live_oauth_account_metadata_for_import(
-                    user_home,
-                )?,
-            },
-            Tool::Codex => LiveStateSnapshot::Codex {
-                files: vec![
-                    snapshot_file(user_home.join(".codex").join("auth.json"))?,
-                    snapshot_file(user_home.join(".codex").join("config.toml"))?,
-                ],
-            },
-            Tool::Gemini => {
-                let dir = user_home.join(".gemini");
-                LiveStateSnapshot::Gemini {
-                    files: snapshot_regular_files(&dir)?,
-                    dir,
-                }
-            }
-            Tool::Antigravity => LiveStateSnapshot::Antigravity {
-                snapshot: auth::antigravity::capture_live_snapshot(user_home)?,
-            },
-        };
-        snapshots.insert(switch.tool, snapshot);
-    }
-    Ok(snapshots)
-}
-
-fn restore_live_state_for_context(
-    snapshots: &HashMap<Tool, LiveStateSnapshot>,
-    user_home: &Path,
-) -> Result<()> {
-    for tool in Tool::ALL.iter().rev() {
-        let Some(snapshot) = snapshots.get(tool) else {
-            continue;
-        };
-        match snapshot {
-            LiveStateSnapshot::Claude {
-                credentials,
-                oauth_account_metadata,
-            } => auth::claude::restore_live_state_after_oauth_add(
-                credentials.clone(),
-                oauth_account_metadata.clone(),
-                user_home,
-            )?,
-            LiveStateSnapshot::Codex { files } => restore_file_snapshots(files)?,
-            LiveStateSnapshot::Gemini { dir, files } => restore_regular_files(dir, files)?,
-            LiveStateSnapshot::Antigravity { snapshot } => {
-                auth::antigravity::restore_snapshot_to_live(snapshot, user_home)?
-            }
-        }
-    }
-    Ok(())
-}
-
-fn snapshot_file(path: std::path::PathBuf) -> Result<FileSnapshot> {
-    let bytes = if path.exists() {
-        Some(std::fs::read(&path).with_context(|| format!("could not read {}", path.display()))?)
-    } else {
-        None
-    };
-    Ok(FileSnapshot { path, bytes })
-}
-
-fn snapshot_regular_files(dir: &Path) -> Result<Vec<NamedFileSnapshot>> {
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut files = Vec::new();
-    for file in auth::files::list_regular_files(dir)? {
-        files.push(NamedFileSnapshot {
-            file_name: file.file_name,
-            bytes: std::fs::read(&file.path)
-                .with_context(|| format!("could not read {}", file.path.display()))?,
-        });
-    }
-    Ok(files)
-}
-
-fn restore_file_snapshots(files: &[FileSnapshot]) -> Result<()> {
-    let changes = files
-        .iter()
-        .map(|snapshot| match &snapshot.bytes {
-            Some(bytes) => LiveFileChange::write(snapshot.path.clone(), bytes.clone()),
-            None => LiveFileChange::delete(snapshot.path.clone()),
-        })
-        .collect::<Vec<_>>();
-    crate::live_apply::apply_transaction(changes)
-}
-
-fn restore_regular_files(dir: &Path, files: &[NamedFileSnapshot]) -> Result<()> {
-    let mut changes = Vec::new();
-    let expected = files
-        .iter()
-        .map(|file| file.file_name.clone())
-        .collect::<HashSet<_>>();
-
-    if dir.exists() {
-        for current in auth::files::list_regular_files(dir)? {
-            if !expected.contains(&current.file_name) {
-                changes.push(LiveFileChange::delete(current.path));
-            }
-        }
-    }
-
-    for file in files {
-        changes.push(LiveFileChange::write(
-            dir.join(&file.file_name),
-            file.bytes.clone(),
-        ));
-    }
-
-    crate::live_apply::apply_transaction(changes)
 }
 
 fn normalized_profiles_json(profiles: &ContextProfiles) -> serde_json::Value {

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -1384,6 +1384,34 @@ mod tests {
     }
 
     #[test]
+    fn all_flag_resolves_matching_profiles_before_mutating() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let user_home = tmp.path().join("uhome");
+        fs::create_dir_all(&home).unwrap();
+        setup_claude_api_key_profile(&home, "work");
+        setup_gemini_api_key_profile(&home, "work");
+
+        let config_path = home.join("config.json");
+        let mut config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        config["profiles"]["gemini"]["work"]["credential_backend"] =
+            serde_json::json!("system_keyring");
+        fs::write(&config_path, serde_json::to_vec_pretty(&config).unwrap()).unwrap();
+
+        let err = run_all_in("work", None, false, false, &home, &user_home).unwrap_err();
+        assert!(err.to_string().contains("gemini"));
+        assert!(!user_home.join(".claude").join(".credentials.json").exists());
+        assert_eq!(
+            ConfigStore::new(&home)
+                .load()
+                .unwrap()
+                .active_for(Tool::Claude),
+            None
+        );
+    }
+
+    #[test]
     fn use_creates_backup_when_enabled() {
         let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::io::IsTerminal;
 use std::path::Path;
 
@@ -9,6 +11,7 @@ use crate::backup::BackupManager;
 use crate::cli::UseArgs;
 use crate::config::{AuthMethod, ConfigStore, ProfileMeta};
 use crate::error::AiswError;
+use crate::live_apply::LiveFileChange;
 use crate::machine;
 use crate::output;
 use crate::profile::ProfileStore;
@@ -22,6 +25,36 @@ pub(crate) struct ResolvedProfileSwitch {
     pub profile_meta: ProfileMeta,
     pub state_mode: StateMode,
     pub backup_on_switch: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum LiveStateSnapshot {
+    Claude {
+        credentials: Option<auth::claude::LiveCredentialSnapshot>,
+        oauth_account_metadata: Option<Vec<u8>>,
+    },
+    Codex {
+        files: Vec<FileSnapshot>,
+    },
+    Gemini {
+        dir: std::path::PathBuf,
+        files: Vec<NamedFileSnapshot>,
+    },
+    Antigravity {
+        snapshot: auth::antigravity::LiveSnapshot,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FileSnapshot {
+    path: std::path::PathBuf,
+    bytes: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NamedFileSnapshot {
+    file_name: OsString,
+    bytes: Vec<u8>,
 }
 
 pub fn run(args: UseArgs, home: &Path) -> Result<()> {
@@ -65,10 +98,9 @@ pub(crate) fn run_all_in(
 ) -> Result<()> {
     let config_store = ConfigStore::new(home);
     let config = config_store.load()?;
-    let mut switched = 0usize;
+    let mut switches = Vec::new();
     let mut errors = Vec::new();
     let before_backup_ids = backup_ids_for(home, None)?;
-    let mut affected_tools = Vec::new();
 
     for tool in Tool::ALL {
         let profiles = config.profiles_for(tool);
@@ -84,44 +116,76 @@ pub(crate) fn run_all_in(
         // `--state-mode` only applies to tools that support it; passing it to
         // the others would make the whole `--all` switch fail.
         let tool_state_mode = state_mode_override.filter(|_| tool.supports_state_mode());
-        match run_for_tool(
+        match resolve_profile_switch_request(
             tool,
             Some(profile_name),
             tool_state_mode,
             emit_env,
-            false,
             home,
             user_home,
         ) {
-            Ok(()) => {
-                switched += 1;
-                affected_tools.push(tool);
-            }
+            Ok(resolved) => switches.push(resolved),
             Err(e) => errors.push(format!("{}: {}", tool, e)),
         }
     }
 
-    if switched == 0 && errors.is_empty() {
+    if switches.is_empty() && errors.is_empty() {
         anyhow::bail!("no tool has a profile named '{}'", profile_name);
     }
 
-    // A tool without a matching profile is a *skip* and stays successful, but a
-    // tool that was attempted and failed must not exit 0 — scripts rely on the
-    // exit code to know whether the switch actually happened.
     if !errors.is_empty() {
         anyhow::bail!(
             "{} of {} attempted tool switches failed:\n  {}",
             errors.len(),
-            errors.len() + switched,
+            errors.len() + switches.len(),
             errors.join("\n  ")
         );
     }
 
-    // In --emit-env mode stdout is a shell script the caller evals; anything
-    // else written there would be executed as shell input.
+    let activations = switches
+        .iter()
+        .map(|switch| {
+            (
+                switch.tool,
+                switch.profile_name.clone(),
+                switch
+                    .tool
+                    .supports_state_mode()
+                    .then_some(switch.state_mode),
+            )
+        })
+        .collect::<Vec<_>>();
+
     if emit_env {
+        for switch in &switches {
+            apply_resolved_profile_switch(switch, true, home, user_home)?;
+        }
+        config_store.activate_profiles(&activations)?;
         return Ok(());
     }
+
+    let snapshots = snapshot_live_state_for_switches(&switches, user_home)?;
+    let apply_result = (|| -> Result<()> {
+        for switch in &switches {
+            apply_resolved_profile_switch(switch, false, home, user_home)?;
+        }
+        config_store.activate_profiles(&activations)?;
+        Ok(())
+    })();
+
+    if let Err(err) = apply_result {
+        return match restore_live_state_for_switches(&snapshots, user_home) {
+            Ok(()) => Err(err),
+            Err(rollback_err) => Err(err.context(format!(
+                "use --all failed and live-state rollback also failed: {rollback_err:#}"
+            ))),
+        };
+    }
+
+    let affected_tools = switches
+        .iter()
+        .map(|switch| switch.tool)
+        .collect::<Vec<_>>();
 
     if json {
         let after_backup_ids = backup_ids_for(home, None)?;
@@ -727,6 +791,129 @@ fn resolve_profile_name(
 
 fn stdin_stdout_are_tty() -> bool {
     std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+}
+
+pub(crate) fn snapshot_live_state_for_switches(
+    switches: &[ResolvedProfileSwitch],
+    user_home: &Path,
+) -> Result<HashMap<Tool, LiveStateSnapshot>> {
+    let mut snapshots = HashMap::new();
+    for switch in switches {
+        let snapshot = match switch.tool {
+            Tool::Claude => LiveStateSnapshot::Claude {
+                credentials: auth::claude::live_credentials_snapshot_for_import(user_home)?,
+                oauth_account_metadata: auth::claude::read_live_oauth_account_metadata_for_import(
+                    user_home,
+                )?,
+            },
+            Tool::Codex => LiveStateSnapshot::Codex {
+                files: vec![
+                    snapshot_file(user_home.join(".codex").join("auth.json"))?,
+                    snapshot_file(user_home.join(".codex").join("config.toml"))?,
+                ],
+            },
+            Tool::Gemini => {
+                let dir = user_home.join(".gemini");
+                LiveStateSnapshot::Gemini {
+                    files: snapshot_regular_files(&dir)?,
+                    dir,
+                }
+            }
+            Tool::Antigravity => LiveStateSnapshot::Antigravity {
+                snapshot: auth::antigravity::capture_live_snapshot(user_home)?,
+            },
+        };
+        snapshots.insert(switch.tool, snapshot);
+    }
+    Ok(snapshots)
+}
+
+pub(crate) fn restore_live_state_for_switches(
+    snapshots: &HashMap<Tool, LiveStateSnapshot>,
+    user_home: &Path,
+) -> Result<()> {
+    for tool in Tool::ALL.iter().rev() {
+        let Some(snapshot) = snapshots.get(tool) else {
+            continue;
+        };
+        match snapshot {
+            LiveStateSnapshot::Claude {
+                credentials,
+                oauth_account_metadata,
+            } => auth::claude::restore_live_state_after_oauth_add(
+                credentials.clone(),
+                oauth_account_metadata.clone(),
+                user_home,
+            )?,
+            LiveStateSnapshot::Codex { files } => restore_file_snapshots(files)?,
+            LiveStateSnapshot::Gemini { dir, files } => restore_regular_files(dir, files)?,
+            LiveStateSnapshot::Antigravity { snapshot } => {
+                auth::antigravity::restore_snapshot_to_live(snapshot, user_home)?
+            }
+        }
+    }
+    Ok(())
+}
+
+fn snapshot_file(path: std::path::PathBuf) -> Result<FileSnapshot> {
+    let bytes = if path.exists() {
+        Some(std::fs::read(&path).with_context(|| format!("could not read {}", path.display()))?)
+    } else {
+        None
+    };
+    Ok(FileSnapshot { path, bytes })
+}
+
+fn snapshot_regular_files(dir: &Path) -> Result<Vec<NamedFileSnapshot>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    for file in auth::files::list_regular_files(dir)? {
+        files.push(NamedFileSnapshot {
+            file_name: file.file_name,
+            bytes: std::fs::read(&file.path)
+                .with_context(|| format!("could not read {}", file.path.display()))?,
+        });
+    }
+    Ok(files)
+}
+
+fn restore_file_snapshots(files: &[FileSnapshot]) -> Result<()> {
+    let changes = files
+        .iter()
+        .map(|snapshot| match &snapshot.bytes {
+            Some(bytes) => LiveFileChange::write(snapshot.path.clone(), bytes.clone()),
+            None => LiveFileChange::delete(snapshot.path.clone()),
+        })
+        .collect::<Vec<_>>();
+    crate::live_apply::apply_transaction(changes)
+}
+
+fn restore_regular_files(dir: &Path, files: &[NamedFileSnapshot]) -> Result<()> {
+    let mut changes = Vec::new();
+    let expected = files
+        .iter()
+        .map(|file| file.file_name.clone())
+        .collect::<HashSet<_>>();
+
+    if dir.exists() {
+        for current in auth::files::list_regular_files(dir)? {
+            if !expected.contains(&current.file_name) {
+                changes.push(LiveFileChange::delete(current.path));
+            }
+        }
+    }
+
+    for file in files {
+        changes.push(LiveFileChange::write(
+            dir.join(&file.file_name),
+            file.bytes.clone(),
+        ));
+    }
+
+    crate::live_apply::apply_transaction(changes)
 }
 
 fn select_profile_interactively(

--- a/tests/audit_regressions.rs
+++ b/tests/audit_regressions.rs
@@ -624,6 +624,43 @@ fn use_all_rolls_back_prior_live_switches_and_active_profiles() {
     assert_eq!(config["active"]["codex"], "current");
 }
 
+/// `use --all` must reject an invalid matching profile before touching a tool
+/// that appears earlier in the deterministic switch order.
+#[test]
+fn use_all_resolves_all_profiles_before_mutation() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 1.0.0");
+    env.add_fake_tool("gemini", "gemini 1.0.0");
+    env.cmd()
+        .args(["add", "claude", "work", "--api-key", CLAUDE_KEY])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["add", "gemini", "work", "--api-key", GEMINI_KEY])
+        .assert()
+        .success();
+
+    let config_path = env.aisw_home.join("config.json");
+    let mut config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+    config["profiles"]["gemini"]["work"]["credential_backend"] =
+        serde_json::json!("system_keyring");
+    std::fs::write(&config_path, serde_json::to_vec_pretty(&config).unwrap()).unwrap();
+
+    let output = env.output(&["use", "--all", "--profile", "work"]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("gemini"));
+    assert!(!env
+        .fake_home
+        .join(".claude")
+        .join(".credentials.json")
+        .exists());
+
+    let config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+    assert_eq!(config["active"]["claude"], serde_json::Value::Null);
+}
+
 /// `init --json` looked up the rc file for whatever `$SHELL` reported and hit
 /// an `unreachable!()` for anything but bash/zsh/fish/pwsh — so it aborted with
 /// exit 101 under a plain `/bin/sh`, which is the default in most containers.

--- a/tests/audit_regressions.rs
+++ b/tests/audit_regressions.rs
@@ -8,6 +8,8 @@ mod common;
 use common::TestEnv;
 
 const CLAUDE_KEY: &str = "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const CLAUDE_KEY_ALT: &str = "sk-ant-api03-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const CODEX_KEY_ALT: &str = "sk-codex-test-key-67890";
 
 /// Gemini stores API keys as `GEMINI_API_KEY=<key>` in a `.env` file the CLI
 /// sources. Validation only rejected empty keys, so a key containing a newline
@@ -566,6 +568,60 @@ fn use_all_exits_non_zero_when_a_tool_switch_fails() {
         "the failing tool should be named: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+/// `use --all` must restore every earlier live switch when a later tool fails,
+/// matching the transaction guarantee provided by `context use`.
+#[test]
+fn use_all_rolls_back_prior_live_switches_and_active_profiles() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 1.0.0");
+    env.add_fake_tool("codex", "codex 1.0.0");
+
+    env.cmd()
+        .args(["add", "claude", "current", "--api-key", CLAUDE_KEY_ALT])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["add", "codex", "current", "--api-key", CODEX_KEY_ALT])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["add", "claude", "work", "--api-key", CLAUDE_KEY])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["add", "codex", "work", "--api-key", CODEX_KEY])
+        .assert()
+        .success();
+
+    env.cmd()
+        .args(["use", "claude", "current"])
+        .assert()
+        .success();
+    env.cmd()
+        .args(["use", "codex", "current"])
+        .assert()
+        .success();
+
+    let claude_live_path = env.fake_home.join(".claude").join(".credentials.json");
+    let codex_live_path = env.fake_home.join(".codex").join("auth.json");
+    let claude_before = std::fs::read(&claude_live_path).unwrap();
+    let codex_before = std::fs::read(&codex_live_path).unwrap();
+
+    std::fs::remove_dir_all(env.aisw_home.join("profiles").join("codex").join("work")).unwrap();
+
+    let output = env.output(&["use", "--all", "--profile", "work"]);
+    assert!(!output.status.success(), "the later codex switch must fail");
+
+    assert_eq!(std::fs::read(&claude_live_path).unwrap(), claude_before);
+    assert_eq!(std::fs::read(&codex_live_path).unwrap(), codex_before);
+
+    let config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(env.aisw_home.join("config.json")).unwrap())
+            .unwrap();
+    assert_eq!(config["active"]["claude"], "current");
+    assert_eq!(config["active"]["codex"], "current");
 }
 
 /// `init --json` looked up the rc file for whatever `$SHELL` reported and hit

--- a/website/src/content/docs/automation.md
+++ b/website/src/content/docs/automation.md
@@ -208,6 +208,9 @@ Branch on `error.kind`, not on the message text  -  `kind` is stable, the messag
 - A tool with no such profile is **skipped**, and the command still succeeds.
 - A tool that has the profile but fails to switch is **reported**, and the command exits non-zero with the standard failure envelope.
 
+Matching profiles are resolved before live state changes. If one switch fails,
+aisw restores the live state changed by earlier tools and exits non-zero.
+
 So a zero exit means every tool that could switch did switch. If you need to know which tools were affected, read `result.affected_tools` from `--json` on success.
 
 ## Applying profiles without the shell hook

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -186,7 +186,7 @@ Activate a stored profile as the live account.
 Notes:
 - `--state-mode` applies to Claude Code and Codex CLI only. Gemini and Antigravity do not support it. With `--all`, it is applied only to the tools that support it rather than failing the whole switch.
 - Switching is atomic: the previous live state is snapshotted before any write. A failed write triggers a full rollback.
-- With `--all`, a tool that has no profile of that name is skipped and the command still succeeds. A tool that has the profile but fails to switch is reported and the command exits non-zero.
+- With `--all`, matching profiles are resolved before any live state is changed. A tool that has no profile of that name is skipped; if a matching tool fails, all earlier live switches are rolled back and the command exits non-zero.
 - With shell hook active, `aisw use` also emits the environment variable exports into the current shell session.
 - `--emit-env` is used internally by the shell hook. You can use it directly to apply exports in a subshell: `eval "$(aisw use claude work --emit-env)"`.
 - Codex shared mode remains supported for API-key profiles.

--- a/website/src/content/docs/security.md
+++ b/website/src/content/docs/security.md
@@ -78,7 +78,7 @@ All operations are local filesystem and OS keyring operations. You can audit thi
 
 ### Transactional writes
 
-Profile activation uses a snapshot-and-apply model. Before writing any live credential file, the current live state is captured. If any file write fails partway through, the snapshot is restored atomically. You never end up with a partially applied profile.
+Profile activation uses a snapshot-and-apply model. Before writing any live credential file, the current live state is captured. If any file write fails partway through, the snapshot is restored atomically. Individual switches and cross-tool `use --all` operations never leave a partially applied live profile set.
 
 This is particularly important for Claude Code, which stores credentials across multiple locations (the credentials file and OAuth account metadata in `~/.claude.json`). A failed write to either location triggers a full rollback.
 


### PR DESCRIPTION
## Why

`aisw use --all` previously applied matching tools one at a time. If a later
tool failed, the command exited non-zero but earlier tools and their live
credentials had already changed. That violated the same atomicity users get
from `context use` and could leave agents on a mixed account set.

## Decision

The command now resolves every matching switch before mutation, snapshots the
participating live states, applies them in `Tool::ALL` order, and activates the
profiles only after all live changes succeed. Any failure restores snapshots in
reverse order and preserves the existing non-zero failure behavior. The
snapshot/restore implementation is shared with `context use` so the two
cross-tool workflows cannot drift in their rollback rules.

Skipped tools remain successful, `--json` and `--emit-env` contracts remain
unchanged, and per-switch backups continue to be created according to the
existing setting. Parent-shell environment changes are still inherently
outside aisw's rollback boundary; shell exports are emitted only for the
successful path.

Closes #98

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked --test audit_regressions --test context_cmd --test use_cmd`
- `cargo test --locked`

The regression test exercises a successful Claude switch followed by a failed
Codex switch and verifies both live credential files and active-profile config
are unchanged after rollback.
