### PR TITLE
Serialize live profile switches

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -212,7 +212,7 @@ eval "$(aisw context use acme --emit-env)"
 
 ## Concurrency
 
-Commands that write `~/.aisw/config.json` take an exclusive file lock. If two `aisw` commands run concurrently, the second will wait briefly then fail with a lock error. This prevents partial writes in parallel CI matrix jobs. Design your CI steps so profile setup runs before parallel job steps that invoke the tools.
+Commands that write `~/.aisw/config.json` take an exclusive file lock. `aisw use` and `aisw context use` also take an operation lock across the complete live profile switch, including active-profile metadata. If two switching commands run concurrently, the second waits briefly then fails with a lock error. Design your CI steps so profile setup and switching run before parallel job steps that invoke the tools.
 
 ## Common CI patterns
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -113,7 +113,8 @@ A repo can also carry its own binding at `<repo>/.git/info/aisw.json`, which tak
 ```text
 ~/.aisw/
 ├── config.json                        # profile registry and settings (0600)
-├── config.json.lock                   # advisory write lock
+├── config.json.lock                   # advisory config write lock
+├── switch.lock                        # advisory live-switch operation lock
 ├── workspaces.json                    # workspace binding rules (0600)
 ├── profiles/
 │   ├── claude/

--- a/docs/security.md
+++ b/docs/security.md
@@ -80,6 +80,8 @@ Backups are also created before profile switching when `backup_on_switch` is ena
 
 All commands that modify `~/.aisw/config.json` take an exclusive lock on the file before writing. If two `aisw` commands run concurrently, the second will wait briefly and then fail with a clear error rather than producing a partial write. This prevents config corruption in parallel CI environments.
 
+Live profile switches take a separate operation lock for their full multi-file transaction. This prevents concurrent `use` and `context use` commands from interleaving credential-file writes with active-profile metadata updates.
+
 ### Input validation
 
 Profile names are restricted to `a-z`, `A-Z`, `0-9`, `-`, and `_`, and every read and write resolves inside the profile directory, so a name can never reach a path outside `~/.aisw/profiles/`. `aisw` refuses to read or write through a symlink at a credential path.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -330,7 +330,9 @@ If a desktop app, remote sidecar, or long-lived shell already had the old accoun
 
 **Fix:**
 - Wait for the other command to complete.
-- If no `aisw` process is running, a stale lock may remain. Check for lock files under `~/.aisw/` and remove any that have a modification time older than a minute.
+- If no `aisw` process is running, retry the command. Lock files under `~/.aisw/` may remain after a process exits; their presence alone does not indicate a held lock, and deleting one while another process holds it can defeat coordination.
+
+The same guidance applies to live-switch lock timeouts: wait for the active switch to finish, then retry. The lock is released automatically when its process exits.
 
 ---
 

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -319,6 +319,7 @@ fn use_context(_args: ContextUseArgs, _home: &Path) -> Result<()> {
     let home = _home;
     let user_home = dirs::home_dir().context("could not determine home directory")?;
     let store = ConfigStore::new(home);
+    let _switch_lock = store.acquire_switch_lock()?;
     let config = store.load()?;
     let context = config
         .context(&args.context_name)

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -43,7 +43,8 @@ pub fn run(args: UseArgs, home: &Path) -> Result<()> {
         let tool = args
             .tool
             .context("use requires <tool> unless --all is provided")?;
-        run_for_tool(
+        let _switch_lock = ConfigStore::new(home).acquire_switch_lock()?;
+        run_for_tool_unlocked(
             tool,
             args.profile_name.as_deref(),
             args.state_mode,
@@ -64,6 +65,7 @@ pub(crate) fn run_all_in(
     user_home: &Path,
 ) -> Result<()> {
     let config_store = ConfigStore::new(home);
+    let _switch_lock = config_store.acquire_switch_lock()?;
     let config = config_store.load()?;
     let mut switched = 0usize;
     let mut errors = Vec::new();
@@ -84,7 +86,7 @@ pub(crate) fn run_all_in(
         // `--state-mode` only applies to tools that support it; passing it to
         // the others would make the whole `--all` switch fail.
         let tool_state_mode = state_mode_override.filter(|_| tool.supports_state_mode());
-        match run_for_tool(
+        match run_for_tool_unlocked(
             tool,
             Some(profile_name),
             tool_state_mode,
@@ -146,7 +148,8 @@ pub(crate) fn run_in(args: UseArgs, home: &Path, user_home: &Path) -> Result<()>
     let tool = args
         .tool
         .context("run_in requires tool when --all is not set")?;
-    run_for_tool(
+    let _switch_lock = ConfigStore::new(home).acquire_switch_lock()?;
+    run_for_tool_unlocked(
         tool,
         args.profile_name.as_deref(),
         args.state_mode,
@@ -157,7 +160,7 @@ pub(crate) fn run_in(args: UseArgs, home: &Path, user_home: &Path) -> Result<()>
     )
 }
 
-fn run_for_tool(
+fn run_for_tool_unlocked(
     tool: Tool,
     requested_profile_name: Option<&str>,
     state_mode_override: Option<StateMode>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ use crate::types::{StateMode, Tool};
 pub(crate) const CURRENT_VERSION: u32 = 2;
 const CONFIG_FILE: &str = "config.json";
 const CONFIG_LOCK_FILE: &str = "config.json.lock";
+const SWITCH_LOCK_FILE: &str = "switch.lock";
 const AISW_HOME_ENV: &str = "AISW_HOME";
 const CONFIG_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(25);
 const CONFIG_LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -183,6 +184,7 @@ impl Config {
 pub struct ConfigStore {
     path: PathBuf,
     lock_path: PathBuf,
+    switch_lock_path: PathBuf,
 }
 
 impl ConfigStore {
@@ -190,7 +192,16 @@ impl ConfigStore {
         Self {
             path: home.join(CONFIG_FILE),
             lock_path: home.join(CONFIG_LOCK_FILE),
+            switch_lock_path: home.join(SWITCH_LOCK_FILE),
         }
+    }
+
+    pub(crate) fn acquire_switch_lock(&self) -> Result<SwitchLockGuard> {
+        acquire_file_lock(
+            &self.switch_lock_path,
+            "switch lock",
+            "Another aisw command is switching profiles. Wait for it to finish, then retry.",
+        )
     }
 
     /// Resolve the aisw home directory from AISW_HOME env var or ~/.aisw/.
@@ -538,40 +549,62 @@ impl ConfigStore {
     }
 
     fn acquire_lock_with_timeout(&self, timeout: Duration) -> Result<ConfigLockGuard> {
-        if let Some(parent) = self.lock_path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("could not create directory {}", parent.display()))?;
-        }
+        let file = acquire_file_lock_with_timeout(
+            &self.lock_path,
+            "config lock",
+            "Another aisw command is updating configuration. Wait for it to finish, then retry.",
+            timeout,
+        )?;
+        Ok(ConfigLockGuard { file })
+    }
+}
 
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&self.lock_path)
-            .with_context(|| format!("could not open {}", self.lock_path.display()))?;
+fn acquire_file_lock(
+    path: &Path,
+    lock_name: &str,
+    timeout_message: &str,
+) -> Result<SwitchLockGuard> {
+    let file =
+        acquire_file_lock_with_timeout(path, lock_name, timeout_message, CONFIG_LOCK_WAIT_TIMEOUT)?;
+    Ok(SwitchLockGuard { file })
+}
 
-        set_file_permissions_600(&self.lock_path)?;
+fn acquire_file_lock_with_timeout(
+    path: &Path,
+    lock_name: &str,
+    timeout_message: &str,
+    timeout: Duration,
+) -> Result<fs::File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("could not create directory {}", parent.display()))?;
+    }
 
-        let started_at = Instant::now();
-        loop {
-            match file.try_lock_exclusive() {
-                Ok(()) => return Ok(ConfigLockGuard { file }),
-                Err(err) if err.kind() == ErrorKind::WouldBlock => {
-                    if started_at.elapsed() >= timeout {
-                        bail!(
-                            "timed out waiting for config lock at {}.\n  \
-                             Another aisw command is updating configuration. Wait for it to \
-                             finish, then retry.",
-                            self.lock_path.display()
-                        );
-                    }
-                    thread::sleep(CONFIG_LOCK_RETRY_INTERVAL);
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .with_context(|| format!("could not open {}", path.display()))?;
+
+    set_file_permissions_600(path)?;
+
+    let started_at = Instant::now();
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(file),
+            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                if started_at.elapsed() >= timeout {
+                    bail!(
+                        "timed out waiting for {lock_name} at {}.\n  {timeout_message}",
+                        path.display()
+                    );
                 }
-                Err(err) => {
-                    return Err(err)
-                        .with_context(|| format!("could not lock {}", self.lock_path.display()));
-                }
+                thread::sleep(CONFIG_LOCK_RETRY_INTERVAL);
+            }
+            Err(err) => {
+                return Err(err).with_context(|| format!("could not lock {}", path.display()));
             }
         }
     }
@@ -933,6 +966,16 @@ struct ConfigLockGuard {
 }
 
 impl Drop for ConfigLockGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+pub(crate) struct SwitchLockGuard {
+    file: fs::File,
+}
+
+impl Drop for SwitchLockGuard {
     fn drop(&mut self) {
         let _ = FileExt::unlock(&self.file);
     }
@@ -1568,6 +1611,32 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
+    fn switch_lock_contention_has_clear_error() {
+        let dir = tempdir().unwrap();
+        let signal_path = dir.path().join("switch-lock-timeout.signal");
+        let mut child = spawn_switch_lock_helper(dir.path(), &signal_path, 500);
+
+        wait_for_file(&signal_path);
+        let err = acquire_file_lock_with_timeout(
+            &dir.path().join(SWITCH_LOCK_FILE),
+            "switch lock",
+            "Another aisw command is switching profiles. Wait for it to finish, then retry.",
+            Duration::from_millis(100),
+        )
+        .unwrap_err();
+
+        let status = child.wait().unwrap();
+        assert!(status.success(), "lock helper exited with {status}");
+        assert!(err
+            .to_string()
+            .contains("timed out waiting for switch lock"));
+        assert!(err
+            .to_string()
+            .contains("Another aisw command is switching profiles"));
+    }
+
+    #[test]
     fn lock_helper_process() {
         let Some(home) = std::env::var_os("AISW_CONFIG_LOCK_HELPER_HOME") else {
             return;
@@ -1582,7 +1651,23 @@ mod tests {
         let profile_name = std::env::var("AISW_CONFIG_LOCK_HELPER_PROFILE").unwrap();
 
         let store = store(Path::new(&home));
-        let _lock = store.acquire_lock().unwrap();
+        let home = Path::new(&home);
+        let _lock = if std::env::var_os("AISW_SWITCH_LOCK_HELPER_KIND").is_some() {
+            acquire_file_lock_with_timeout(
+                &home.join(SWITCH_LOCK_FILE),
+                "switch lock",
+                "Another aisw command is switching profiles. Wait for it to finish, then retry.",
+                CONFIG_LOCK_WAIT_TIMEOUT,
+            )
+        } else {
+            acquire_file_lock_with_timeout(
+                &home.join(CONFIG_LOCK_FILE),
+                "config lock",
+                "Another aisw command is updating configuration. Wait for it to finish, then retry.",
+                CONFIG_LOCK_WAIT_TIMEOUT,
+            )
+        }
+        .unwrap();
         fs::write(&signal_path, b"locked").unwrap();
         thread::sleep(Duration::from_millis(hold_ms));
 
@@ -1605,6 +1690,24 @@ mod tests {
             .env("AISW_CONFIG_LOCK_HELPER_SIGNAL", signal_path)
             .env("AISW_CONFIG_LOCK_HELPER_HOLD_MS", hold_ms.to_string())
             .env("AISW_CONFIG_LOCK_HELPER_PROFILE", profile_name)
+            .spawn()
+            .unwrap()
+    }
+
+    fn spawn_switch_lock_helper(
+        home: &Path,
+        signal_path: &Path,
+        hold_ms: u64,
+    ) -> std::process::Child {
+        Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("config::tests::lock_helper_process")
+            .arg("--nocapture")
+            .env("AISW_CONFIG_LOCK_HELPER_HOME", home)
+            .env("AISW_CONFIG_LOCK_HELPER_SIGNAL", signal_path)
+            .env("AISW_CONFIG_LOCK_HELPER_HOLD_MS", hold_ms.to_string())
+            .env("AISW_CONFIG_LOCK_HELPER_PROFILE", "switch-helper")
+            .env("AISW_SWITCH_LOCK_HELPER_KIND", "switch")
             .spawn()
             .unwrap()
     }

--- a/website/src/content/docs/automation.md
+++ b/website/src/content/docs/automation.md
@@ -229,7 +229,7 @@ eval "$(aisw context use acme --emit-env)"
 
 ## Concurrency
 
-Commands that write `~/.aisw/config.json` take an exclusive file lock. If two `aisw` commands run concurrently, the second will wait briefly then fail with a lock error. This prevents partial writes in parallel CI matrix jobs. Design your CI steps so profile setup runs before parallel job steps that invoke the tools.
+Commands that write `~/.aisw/config.json` take an exclusive file lock. `aisw use` and `aisw context use` also take an operation lock across the complete live profile switch, including active-profile metadata. If two switching commands run concurrently, the second waits briefly then fails with a lock error. Design your CI steps so profile setup and switching run before parallel job steps that invoke the tools.
 
 ## Common CI patterns
 

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -130,7 +130,8 @@ A repo can also carry its own binding at `<repo>/.git/info/aisw.json`, which tak
 ```text
 ~/.aisw/
 ├── config.json                        # profile registry and settings (0600)
-├── config.json.lock                   # advisory write lock
+├── config.json.lock                   # advisory config write lock
+├── switch.lock                        # advisory live-switch operation lock
 ├── workspaces.json                    # workspace binding rules (0600)
 ├── profiles/
 │   ├── claude/

--- a/website/src/content/docs/security.md
+++ b/website/src/content/docs/security.md
@@ -97,6 +97,8 @@ Backups are also created before profile switching when `backup_on_switch` is ena
 
 All commands that modify `~/.aisw/config.json` take an exclusive lock on the file before writing. If two `aisw` commands run concurrently, the second will wait briefly and then fail with a clear error rather than producing a partial write. This prevents config corruption in parallel CI environments.
 
+Live profile switches take a separate operation lock for their full multi-file transaction. This prevents concurrent `use` and `context use` commands from interleaving credential-file writes with active-profile metadata updates.
+
 ### Input validation
 
 Profile names are restricted to `a-z`, `A-Z`, `0-9`, `-`, and `_`, and every read and write resolves inside the profile directory, so a name can never reach a path outside `~/.aisw/profiles/`. `aisw` refuses to read or write through a symlink at a credential path.

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -347,7 +347,9 @@ If a desktop app, remote sidecar, or long-lived shell already had the old accoun
 
 **Fix:**
 - Wait for the other command to complete.
-- If no `aisw` process is running, a stale lock may remain. Check for lock files under `~/.aisw/` and remove any that have a modification time older than a minute.
+- If no `aisw` process is running, retry the command. Lock files under `~/.aisw/` may remain after a process exits; their presence alone does not indicate a held lock, and deleting one while another process holds it can defeat coordination.
+
+The same guidance applies to live-switch lock timeouts: wait for the active switch to finish, then retry. The lock is released automatically when its process exits.
 
 ---
 


### PR DESCRIPTION
## Why

`ConfigStore` already serialized individual config writes, but a live profile switch spans multiple credential files and an active-profile metadata update. Concurrent `use` and `context use` processes could interleave those operations and leave the live profile set inconsistent.

## What changed

- Add a bounded cross-process `switch.lock` for the complete `use` and `context use` operation.
- Keep single-tool and multi-tool switches on one lock without nested acquisition.
- Preserve the existing config lock for ordinary config mutations.
- Add a real child-process contention regression test and document both locks.

## Trade-offs

- Switching commands serialize per AISW home, which favors consistency over parallel switch throughput.
- `--emit-env` also takes the lock because it updates active metadata, while shell environment changes remain the caller's responsibility.
- Read-only commands do not take the switch lock.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- repository commit hook: format, clippy, release build, full tests, completions smoke, pre-commit
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`

Closes #100
