### PR TITLE
Harden Claude OAuth capture

### DIFF
--- a/docs/adding-profiles.md
+++ b/docs/adding-profiles.md
@@ -46,7 +46,7 @@ aisw add codex personal
 aisw add gemini personal
 ```
 
-- Claude: spawns `claude auth login`. When the installed Claude build supports profile-scoped auth, `aisw` runs login inside the profile-owned `CLAUDE_CONFIG_DIR`; otherwise it monitors the live credential file and Keychain for changes and captures the result there.
+- Claude: spawns `claude auth login`. When the installed Claude build supports profile-scoped auth, `aisw` runs login inside the profile-owned `CLAUDE_CONFIG_DIR`, waits for a non-empty credential payload, and captures account metadata from that directory; otherwise it monitors the live credential file and Keychain for changes and captures the result there.
 - Codex: sets `CODEX_HOME` to the profile directory and spawns `codex`. The device-auth flow writes credentials directly into that profile-owned isolated state. This is the durable ChatGPT-managed Codex path.
 - Gemini: sets `GEMINI_CLI_HOME` to a scratch directory, spawns `gemini`, then copies the resulting auth/state files into the profile. The scratch directory is removed after the flow regardless of outcome.
 - Antigravity: spawns `agy`, captures the resulting live keyring-backed OAuth session plus the documented `~/.gemini/antigravity-cli/` and `~/.gemini/config/` state, then restores the prior live state unless `--set-active` is requested.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -70,7 +70,7 @@ On Linux, if the Secret Service daemon is not available at runtime (e.g. headles
 **How `aisw` captures credentials:**
 - `--api-key`: stores the key directly.
 - `--from-live`: reads the current live credentials from file or Keychain.
-- Interactive OAuth: spawns `claude auth login`. When Claude's install supports profile-owned auth, `aisw` points login at the profile `CLAUDE_CONFIG_DIR`; otherwise it polls Claude's live credential file and Keychain for changes and captures the result there.
+- Interactive OAuth: spawns `claude auth login`. When Claude's install supports profile-owned auth, `aisw` points login at the profile `CLAUDE_CONFIG_DIR`, waits for a non-empty credential payload, and reads account metadata from that directory; otherwise it polls Claude's live credential file and Keychain for changes and captures the result there.
 
 **How `aisw use` applies credentials:**
 - Detects whether the live tool is reading from file or Keychain.

--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -890,7 +890,7 @@ mod tests {
              target=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"\n\
              mkdir -p \"$target\"\n\
              printf '%s' '{\"oauthToken\":\"tok\",\"account\":{\"email\":\"burak@example.com\"}}' > \"$target/.credentials.json\"\n\
-             printf '%s' '{\"oauthAccount\":{\"emailAddress\":\"burak@example.com\",\"organizationUuid\":\"org-b\"}}' > \"$HOME/.claude.json\"\n",
+             printf '%s' '{\"oauthAccount\":{\"emailAddress\":\"burak@example.com\",\"organizationUuid\":\"org-b\"}}' > \"$target/.claude.json\"\n",
         )
         .unwrap();
         fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();

--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -33,6 +33,7 @@ use paths::live_credentials_path;
 // ---- Constants ----
 
 pub(super) const CREDENTIALS_FILE: &str = ".credentials.json";
+pub(super) const ACCOUNT_METADATA_FILE: &str = ".claude.json";
 pub(super) const OAUTH_ACCOUNT_FILE: &str = "oauth-account.json";
 pub(super) const OAUTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 pub(super) const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
@@ -1263,6 +1264,100 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn oauth_waits_for_nonempty_credentials_before_capture() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("home");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&bin_dir).unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let bin = bin_dir.join("claude");
+        fs::write(
+            &bin,
+            "#!/bin/sh\n\
+             mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
+             echo '{}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             sleep 0.1\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (ps, cs) = stores(dir.path());
+        oauth::add_oauth_with(
+            &ps,
+            &cs,
+            "work",
+            None,
+            &bin,
+            CredentialBackend::File,
+            std::time::Duration::from_secs(2),
+            TEST_POLL,
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(ps.profile_dir(Tool::Claude, "work").join(CREDENTIALS_FILE))
+                .unwrap()
+                .trim(),
+            r#"{"oauthToken":"tok"}"#
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn oauth_persists_metadata_from_profile_config_dir() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("home");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(
+            home.join(ACCOUNT_METADATA_FILE),
+            r#"{"oauthAccount":{"emailAddress":"native@example.com"}}"#,
+        )
+        .unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let bin = bin_dir.join("claude");
+        fs::write(
+            &bin,
+            "#!/bin/sh\n\
+             mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             echo '{\"oauthAccount\":{\"emailAddress\":\"profile@example.com\"}}' > \"$CLAUDE_CONFIG_DIR/.claude.json\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (ps, cs) = stores(dir.path());
+        oauth::add_oauth_with(
+            &ps,
+            &cs,
+            "work",
+            None,
+            &bin,
+            CredentialBackend::File,
+            std::time::Duration::from_secs(2),
+            TEST_POLL,
+        )
+        .unwrap();
+
+        let metadata: serde_json::Value = serde_json::from_slice(
+            &ps.read_file(Tool::Claude, "work", OAUTH_ACCOUNT_FILE)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(metadata["emailAddress"], "profile@example.com");
+    }
+
+    #[test]
     #[cfg(target_os = "macos")]
     fn oauth_keychain_capture_persists_managed_credentials_file() {
         let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -1397,7 +1492,7 @@ mod tests {
              [ -n \"$CLAUDE_CONFIG_DIR\" ] || exit 7\n\
              printf '%s' \"$CLAUDE_CONFIG_DIR\" > \"$HOME/env_was_set\"\n\
              mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
-             echo '{}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
              exit 0\n",
         )
         .unwrap();
@@ -1516,7 +1611,7 @@ mod tests {
              [ -n \"$CLAUDE_CONFIG_DIR\" ] || exit 7\n\
              printf '%s %s' \"$1\" \"$2\" > \"$HOME/login_args\"\n\
              mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
-             echo '{}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
              exit 0\n",
         )
         .unwrap();
@@ -1618,7 +1713,7 @@ mod tests {
              printf '%s %s' \"$1\" \"$2\" > \"$HOME/login_args\"\n\
              printf '%s' \"$CLAUDE_CONFIG_DIR\" > \"$HOME/env_was_set\"\n\
              mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
-             echo '{}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
+             echo '{\"oauthToken\":\"tok\"}' > \"$CLAUDE_CONFIG_DIR/.credentials.json\"\n\
              exit 0\n",
         )
         .unwrap();

--- a/src/auth/claude/oauth.rs
+++ b/src/auth/claude/oauth.rs
@@ -91,13 +91,12 @@ pub fn live_credentials_snapshot_for_import(
 
 // ---- OAuth account metadata ----
 
-fn read_live_oauth_account_metadata(user_home: &Path) -> Result<Option<Vec<u8>>> {
-    let path = live_account_metadata_path(user_home);
+fn read_oauth_account_metadata(path: &Path) -> Result<Option<Vec<u8>>> {
     if !path.exists() {
         return Ok(None);
     }
 
-    let contents = fs::read(&path).with_context(|| format!("could not read {}", path.display()))?;
+    let contents = fs::read(path).with_context(|| format!("could not read {}", path.display()))?;
     let value: serde_json::Value = serde_json::from_slice(&contents)
         .with_context(|| format!("could not parse {}", path.display()))?;
     let Some(oauth_account) = value.get("oauthAccount") else {
@@ -107,6 +106,10 @@ fn read_live_oauth_account_metadata(user_home: &Path) -> Result<Option<Vec<u8>>>
     serde_json::to_vec(oauth_account)
         .map(Some)
         .context("could not serialize Claude oauthAccount metadata")
+}
+
+fn read_live_oauth_account_metadata(user_home: &Path) -> Result<Option<Vec<u8>>> {
+    read_oauth_account_metadata(&live_account_metadata_path(user_home))
 }
 
 /// Reads the live OAuth account metadata for profile import.
@@ -197,15 +200,23 @@ pub fn restore_live_state_after_oauth_add(
     restore_live_oauth_account_metadata_snapshot(oauth_account_metadata, user_home)
 }
 
+fn persist_oauth_account_metadata(
+    profile_store: &ProfileStore,
+    name: &str,
+    metadata_path: &Path,
+) -> Result<()> {
+    let Some(metadata) = read_oauth_account_metadata(metadata_path)? else {
+        return Ok(());
+    };
+    profile_store.write_file(Tool::Claude, name, super::OAUTH_ACCOUNT_FILE, &metadata)
+}
+
 fn persist_live_oauth_account_metadata(
     profile_store: &ProfileStore,
     name: &str,
     user_home: &Path,
 ) -> Result<()> {
-    let Some(metadata) = read_live_oauth_account_metadata(user_home)? else {
-        return Ok(());
-    };
-    profile_store.write_file(Tool::Claude, name, super::OAUTH_ACCOUNT_FILE, &metadata)
+    persist_oauth_account_metadata(profile_store, name, &live_account_metadata_path(user_home))
 }
 
 /// Captures the current live OAuth account metadata into the named profile.
@@ -340,14 +351,16 @@ pub(super) fn add_oauth_with(
         name,
     )?;
 
-    if let Some(user_home) = dirs::home_dir() {
-        files::cleanup_profile_on_error(
-            persist_live_oauth_account_metadata(profile_store, name, &user_home),
-            profile_store,
-            Tool::Claude,
-            name,
-        )?;
-    }
+    let metadata_path = target_config_dir
+        .as_deref()
+        .map(|config_dir| config_dir.join(super::ACCOUNT_METADATA_FILE))
+        .unwrap_or_else(|| live_account_metadata_path(&user_home));
+    files::cleanup_profile_on_error(
+        persist_oauth_account_metadata(profile_store, name, &metadata_path),
+        profile_store,
+        Tool::Claude,
+        name,
+    )?;
 
     files::cleanup_profile_on_error(
         identity::ensure_unique_oauth_identity(
@@ -478,7 +491,7 @@ If you need a different Claude account, fully sign out of claude.com first, then
                 .unwrap_or_else(read_keychain_credentials)?;
             if let Some(current) = current {
                 let changed = keychain_before.as_deref() != Some(current.as_slice());
-                if changed {
+                if changed && has_nonempty_credential_payload(&current) {
                     child.terminate();
                     return Ok(current);
                 }
@@ -489,7 +502,7 @@ If you need a different Claude account, fully sign out of claude.com first, then
             let current = fs::read(&credential_path)
                 .with_context(|| format!("could not read {}", credential_path.display()))?;
             let changed = file_before.as_deref() != Some(current.as_slice());
-            if changed {
+            if changed && has_nonempty_credential_payload(&current) {
                 child.terminate();
                 return Ok(current);
             }
@@ -500,7 +513,7 @@ If you need a different Claude account, fully sign out of claude.com first, then
                 let current = fs::read(fallback_path)
                     .with_context(|| format!("could not read {}", fallback_path.display()))?;
                 let changed = fallback_before.as_deref() != Some(current.as_slice());
-                if changed {
+                if changed && has_nonempty_credential_payload(&current) {
                     child.terminate();
                     return Ok(current);
                 }
@@ -518,21 +531,29 @@ If you need a different Claude account, fully sign out of claude.com first, then
                     .map(read_keychain_credentials_for_service)
                     .unwrap_or_else(read_keychain_credentials)?;
                 if let Some(current) = current {
-                    if status.success() || keychain_before.is_none() {
+                    if (status.success() || keychain_before.is_none())
+                        && has_nonempty_credential_payload(&current)
+                    {
                         return Ok(current);
                     }
                 }
             }
 
             if credential_path.exists() && status.success() {
-                return fs::read(&credential_path)
-                    .with_context(|| format!("could not read {}", credential_path.display()));
+                let current = fs::read(&credential_path)
+                    .with_context(|| format!("could not read {}", credential_path.display()))?;
+                if has_nonempty_credential_payload(&current) {
+                    return Ok(current);
+                }
             }
 
             if let Some(fallback_path) = fallback_live_path.as_ref() {
                 if fallback_path.exists() && status.success() {
-                    return fs::read(fallback_path)
-                        .with_context(|| format!("could not read {}", fallback_path.display()));
+                    let current = fs::read(fallback_path)
+                        .with_context(|| format!("could not read {}", fallback_path.display()))?;
+                    if has_nonempty_credential_payload(&current) {
+                        return Ok(current);
+                    }
                 }
             }
 
@@ -559,6 +580,13 @@ If you need a different Claude account, fully sign out of claude.com first, then
 
         std::thread::sleep(poll_interval);
     }
+}
+
+fn has_nonempty_credential_payload(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .ok()
+        .and_then(|value| value.as_object().map(|object| !object.is_empty()))
+        .unwrap_or(false)
 }
 
 // ---- Automatic synchronization ----
@@ -676,4 +704,21 @@ fn resolve_live_oauth_identity(
         return Ok(None);
     };
     identity::resolve_identity_from_json_bytes(&metadata)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_nonempty_credential_payload;
+
+    #[test]
+    fn empty_object_is_not_a_captured_credential() {
+        assert!(!has_nonempty_credential_payload(br#"{}"#));
+    }
+
+    #[test]
+    fn populated_object_is_a_captured_credential() {
+        assert!(has_nonempty_credential_payload(
+            br#"{"claudeAiOauth":{"accessToken":"token"}}"#
+        ));
+    }
 }

--- a/src/auth/claude/paths.rs
+++ b/src/auth/claude/paths.rs
@@ -36,7 +36,7 @@ pub(super) fn live_credentials_paths(user_home: &Path) -> [PathBuf; 2] {
 /// Returns the path to `~/.claude.json`, where Claude stores OAuth account
 /// metadata (`oauthAccount` field).
 pub(super) fn live_account_metadata_path(user_home: &Path) -> PathBuf {
-    user_home.join(".claude.json")
+    user_home.join(super::ACCOUNT_METADATA_FILE)
 }
 
 /// Returns the Claude local state directory if it exists. Returns `None` when

--- a/website/src/content/docs/adding-profiles.md
+++ b/website/src/content/docs/adding-profiles.md
@@ -63,7 +63,7 @@ aisw add codex personal
 aisw add gemini personal
 ```
 
-- Claude: spawns `claude auth login`. When the installed Claude build supports profile-scoped auth, `aisw` runs login inside the profile-owned `CLAUDE_CONFIG_DIR`; otherwise it monitors the live credential file and Keychain for changes and captures the result there.
+- Claude: spawns `claude auth login`. When the installed Claude build supports profile-scoped auth, `aisw` runs login inside the profile-owned `CLAUDE_CONFIG_DIR`, waits for a non-empty credential payload, and captures account metadata from that directory; otherwise it monitors the live credential file and Keychain for changes and captures the result there.
 - Codex: sets `CODEX_HOME` to the profile directory and spawns `codex`. The device-auth flow writes credentials directly into that profile-owned isolated state. This is the durable ChatGPT-managed Codex path.
 - Gemini: sets `GEMINI_CLI_HOME` to a scratch directory, spawns `gemini`, then copies the resulting auth/state files into the profile. The scratch directory is removed after the flow regardless of outcome.
 - Antigravity: spawns `agy`, captures the resulting live keyring-backed OAuth session plus the documented `~/.gemini/antigravity-cli/` and `~/.gemini/config/` state, then restores the prior live state unless `--set-active` is requested.

--- a/website/src/content/docs/how-it-works.md
+++ b/website/src/content/docs/how-it-works.md
@@ -87,7 +87,7 @@ On Linux, if the Secret Service daemon is not available at runtime (e.g. headles
 **How `aisw` captures credentials:**
 - `--api-key`: stores the key directly.
 - `--from-live`: reads the current live credentials from file or Keychain.
-- Interactive OAuth: spawns `claude auth login`. When Claude's install supports profile-owned auth, `aisw` points login at the profile `CLAUDE_CONFIG_DIR`; otherwise it polls Claude's live credential file and Keychain for changes and captures the result there.
+- Interactive OAuth: spawns `claude auth login`. When Claude's install supports profile-owned auth, `aisw` points login at the profile `CLAUDE_CONFIG_DIR`, waits for a non-empty credential payload, and reads account metadata from that directory; otherwise it polls Claude's live credential file and Keychain for changes and captures the result there.
 
 **How `aisw use` applies credentials:**
 - Detects whether the live tool is reading from file or Keychain.


### PR DESCRIPTION
Closes #63

## Why

Claude can create an empty credential placeholder before writing the real OAuth payload. Profile-scoped installs can also write account metadata inside `CLAUDE_CONFIG_DIR`. The old capture path treated the placeholder as success and read metadata only from the live home, producing incomplete or incorrect profiles. This replaces stale PR #51 with a current-main implementation.

## Decision

- require a non-empty JSON object before accepting changed OAuth credentials
- read account metadata from the profile-owned config root when Claude scopes auth, with the live-home path for shared installs
- add Unix regression coverage for both failure modes and update the workflow docs

The existing polling and shared-Keychain behavior stays unchanged; credential schema validation remains separate from capture completion.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` — 577 passed, 1 opt-in canary ignored
- `cargo +nightly llvm-cov --json --summary-only --branch` plus the repository coverage gate — passed
- pre-commit and pre-push hooks — passed
