### PR TITLE
Refresh compatibility audit baseline

### DIFF
--- a/docs/acceptance-matrix.md
+++ b/docs/acceptance-matrix.md
@@ -4,7 +4,7 @@ This matrix records the current end-to-end acceptance status for supported `aisw
 
 ## Versioned compatibility baseline
 
-The baseline below records the upstream releases checked against `aisw` `0.3.8` at commit `f28aaf9`, verified on 2026-09-08. The release pins make the audit reproducible; they are not a guarantee that a future upstream release preserves the same storage contracts. Verification is based on the repository's unit and integration tests plus the documented upstream release and authentication behavior; it does not claim that each vendor binary was installed on every listed operating system in CI.
+The baseline below records the upstream releases checked against `aisw` `0.3.8` at commit `457b009`, verified on 2026-09-09. The release pins make the audit reproducible; they are not a guarantee that a future upstream release preserves the same storage contracts. Verification is based on the repository's unit and integration tests plus the documented upstream release and authentication behavior; it does not claim that each vendor binary was installed on every listed operating system in CI.
 
 | Agent | Upstream release | OS coverage | Compatibility basis | Result | Sources |
 | --- | --- | --- | --- | --- | --- |

--- a/tests/acceptance_matrix_consistency.rs
+++ b/tests/acceptance_matrix_consistency.rs
@@ -110,11 +110,11 @@ fn acceptance_matrix_records_current_versioned_agent_baseline() {
         "acceptance matrix should include a versioned compatibility section"
     );
     assert!(
-        matrix.contains("verified on 2026-09-08"),
+        matrix.contains("verified on 2026-09-09"),
         "versioned compatibility baseline should record its verification date"
     );
     assert!(
-        matrix.contains("against `aisw` `0.3.8` at commit `f28aaf9`"),
+        matrix.contains("against `aisw` `0.3.8` at commit `457b009`"),
         "versioned compatibility baseline should identify the aisw baseline"
     );
 


### PR DESCRIPTION
Closes #103

## Why

The acceptance matrix was still identifying an older mainline commit and audit date. That made the release evidence ambiguous: the upstream release pins were explicit, but the `aisw` code under test was not the current mainline.

## Decision

Refresh only the versioned baseline metadata and its consistency test to the current `main` commit, while preserving the existing upstream release pins and the documented limitation that vendor binaries are not installed on every CI operating system.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` — 575 passed, 1 opt-in canary ignored
- pre-commit and pre-push hooks — passed
