### PR TITLE
Document machine interface versions

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -74,6 +74,18 @@ aisw doctor --json
 
 With `--json`, success and expected command failures are emitted as structured JSON on stdout. Human-oriented stdout/stderr output is suppressed. The process still exits non-zero on failure.
 
+### Machine interface versions
+
+Before integrating with a new binary, read `aisw version --json` or `aisw capabilities --json` and record these fields:
+
+| Field | Contract |
+|---|---|
+| `cli_api_version` | Command and flag contract used by automation |
+| `json_schema_version` | Payload shape for commands using `--json` |
+| `progress_schema_version` | Newline-delimited event shape from `--progress-json` |
+
+The current value for each is `1`. Within a version, existing fields and their meanings remain compatible; integrations should ignore unknown fields so additive changes do not break them. A removed field, incompatible type change, or changed meaning requires a schema-version increment. Treat an unknown version as unsupported and fail with an actionable message rather than guessing.
+
 For OAuth-based `add`, use `--progress-json` to stream newline-delimited JSON progress events:
 
 ```sh

--- a/tests/machine_interface_docs.rs
+++ b/tests/machine_interface_docs.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+fn read_repo_file(path: &str) -> String {
+    std::fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path))
+        .unwrap_or_else(|error| panic!("could not read {path}: {error}"))
+}
+
+#[test]
+fn automation_docs_publish_the_machine_interface_contract() {
+    let docs = read_repo_file("docs/automation.md");
+    let website = read_repo_file("website/src/content/docs/automation.md");
+
+    for content in [&docs, &website] {
+        for expected in [
+            "### Machine interface versions",
+            "`cli_api_version`",
+            "`json_schema_version`",
+            "`progress_schema_version`",
+            "The current value for each is `1`.",
+            "ignore unknown fields",
+            "Treat an unknown version as unsupported",
+        ] {
+            assert!(content.contains(expected), "missing {expected}");
+        }
+    }
+}

--- a/website/src/content/docs/automation.md
+++ b/website/src/content/docs/automation.md
@@ -91,6 +91,18 @@ aisw doctor --json
 
 With `--json`, success and expected command failures are emitted as structured JSON on stdout. Human-oriented stdout/stderr output is suppressed. The process still exits non-zero on failure.
 
+### Machine interface versions
+
+Before integrating with a new binary, read `aisw version --json` or `aisw capabilities --json` and record these fields:
+
+| Field | Contract |
+|---|---|
+| `cli_api_version` | Command and flag contract used by automation |
+| `json_schema_version` | Payload shape for commands using `--json` |
+| `progress_schema_version` | Newline-delimited event shape from `--progress-json` |
+
+The current value for each is `1`. Within a version, existing fields and their meanings remain compatible; integrations should ignore unknown fields so additive changes do not break them. A removed field, incompatible type change, or changed meaning requires a schema-version increment. Treat an unknown version as unsupported and fail with an actionable message rather than guessing.
+
 For OAuth-based `add`, use `--progress-json` to stream newline-delimited JSON progress events:
 
 ```sh


### PR DESCRIPTION
Closes #105

## Why

The CLI already publishes version fields for its machine-readable interfaces, but integrations had no documented way to discover or interpret them. That leaves GUI and CI clients relying on payload details without an explicit compatibility rule.

## Decision

Document `version --json` and `capabilities --json` as the discovery path, define the three version fields, and state the compatibility policy: existing fields remain compatible within a version, additive fields must be ignored, and unknown versions must fail closed. The OAuth progress stream is covered by the same contract. The website copy and a consistency test stay aligned with the canonical docs.

No payloads or schema versions change.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` — 576 passed, 1 opt-in canary ignored
- pre-commit and pre-push hooks — passed
