### PR TITLE
Preflight backup restores

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -560,7 +560,8 @@ aisw backup restore <backup_id> [--yes] [--json]
 ```
 
 Restore profile files and credentials from a backup. Profile metadata is saved
-only after restoration succeeds, and file writes are applied as one
+only after restoration succeeds. All backup entries are validated before any
+files are changed, and each profile's file writes are applied as one
 rollback-capable transaction. Does not activate the profile; run `aisw use`
 after restore.
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -31,6 +31,13 @@ struct BackupProfileMetadata {
     profile_meta: ProfileMeta,
 }
 
+struct RestorePlan {
+    tool: Tool,
+    profile_name: String,
+    profile_meta: ProfileMeta,
+    changes: Vec<crate::live_apply::LiveFileChange>,
+}
+
 impl BackupManager {
     pub fn new(home: &Path) -> Self {
         Self {
@@ -161,7 +168,7 @@ impl BackupManager {
             bail!("no backup found with id '{}'", backup_id);
         }
 
-        let mut restored = 0usize;
+        let mut plans = Vec::new();
 
         for tool in Tool::ALL {
             let tool_path = backup_root.join(tool.dir_name());
@@ -185,30 +192,43 @@ impl BackupManager {
                     continue;
                 }
 
-                let dest_dir = profile_store.profile_dir(tool, &profile_name);
                 let profile_meta =
                     restore_profile_meta(config_store, tool, &profile_name, &profile_path)?;
                 profile_meta.credential_backend.validate_for_tool(tool)?;
 
-                let restored_files = restore_profile_tree(&profile_path, &dest_dir)?;
-                restored += restored_files;
-
-                if profile_meta.credential_backend == CredentialBackend::SystemKeyring {
-                    secure_store::restore_profile_secret(tool, &profile_name, backup_id)?;
-                    if restored_files == 0 {
-                        fs::create_dir_all(&dest_dir).with_context(|| {
-                            format!("could not create profile dir {}", dest_dir.display())
-                        })?;
-                    }
-                    restored += 1;
-                } else if restored_files == 0 {
-                    continue;
-                }
-
-                // Register the profile only after all credential and file
-                // restoration for this entry has succeeded.
-                config_store.upsert_profile(tool, &profile_name, profile_meta)?;
+                let changes =
+                    prepare_profile_restore(&profile_path, profile_store, tool, &profile_name)?;
+                plans.push(RestorePlan {
+                    tool,
+                    profile_name,
+                    profile_meta,
+                    changes,
+                });
             }
+        }
+
+        let mut restored = 0usize;
+        for plan in plans {
+            let restored_files = plan.changes.len();
+            crate::live_apply::apply_transaction(plan.changes)?;
+            restored += restored_files;
+
+            if plan.profile_meta.credential_backend == CredentialBackend::SystemKeyring {
+                secure_store::restore_profile_secret(plan.tool, &plan.profile_name, backup_id)?;
+                if restored_files == 0 {
+                    let dest_dir = profile_store.profile_dir(plan.tool, &plan.profile_name);
+                    fs::create_dir_all(&dest_dir).with_context(|| {
+                        format!("could not create profile dir {}", dest_dir.display())
+                    })?;
+                }
+                restored += 1;
+            } else if restored_files == 0 {
+                continue;
+            }
+
+            // Register the profile only after all credential and file
+            // restoration for this entry has succeeded.
+            config_store.upsert_profile(plan.tool, &plan.profile_name, plan.profile_meta)?;
         }
 
         if restored == 0 {
@@ -285,21 +305,26 @@ fn copy_profile_tree(src_root: &Path, dest_root: &Path) -> Result<()> {
     Ok(())
 }
 
-fn restore_profile_tree(src_root: &Path, dest_root: &Path) -> Result<usize> {
+fn prepare_profile_restore(
+    src_root: &Path,
+    profile_store: &ProfileStore,
+    tool: Tool,
+    profile_name: &str,
+) -> Result<Vec<crate::live_apply::LiveFileChange>> {
     let mut changes = Vec::new();
     for file in crate::auth::files::list_regular_files_recursive(src_root)? {
         if file.file_name == METADATA_FILE {
             continue;
         }
         let relative = file.file_name.to_string_lossy().into_owned();
-        let dst = dest_root.join(&relative);
+        let dst = profile_store
+            .profile_dir(tool, profile_name)
+            .join(&relative);
         let contents = fs::read(&file.path)
             .with_context(|| format!("could not read backup file {}", file.path.display()))?;
         changes.push(crate::live_apply::LiveFileChange::write(dst, contents));
     }
-    let restored = changes.len();
-    crate::live_apply::apply_transaction(changes)?;
-    Ok(restored)
+    Ok(changes)
 }
 
 fn backup_id_now() -> String {
@@ -737,6 +762,62 @@ mod tests {
         assert!(err.to_string().contains("contains no files to restore"));
         assert!(cs.load().unwrap().profiles_for(Tool::Claude).is_empty());
         assert!(!ps.exists(Tool::Claude, "work"));
+    }
+
+    #[test]
+    fn restore_preflights_all_entries_before_mutating_any_profile() {
+        let dir = tempdir().unwrap();
+        let backup_id = "multi-entry-backup";
+        let claude_backup = write_legacy_backup(
+            dir.path(),
+            backup_id,
+            Tool::Claude,
+            "work",
+            &[("state.json", b"restored")],
+        );
+        write_metadata(
+            &claude_backup.join(METADATA_FILE),
+            &BackupProfileMetadata {
+                profile_meta: profile_meta(),
+            },
+        )
+        .unwrap();
+        let gemini_backup = dir
+            .path()
+            .join(BACKUPS_DIR)
+            .join(backup_id)
+            .join(Tool::Gemini.dir_name())
+            .join("broken");
+        fs::create_dir_all(&gemini_backup).unwrap();
+        write_metadata(
+            &gemini_backup.join(METADATA_FILE),
+            &BackupProfileMetadata {
+                profile_meta: ProfileMeta {
+                    credential_backend: CredentialBackend::SystemKeyring,
+                    ..profile_meta()
+                },
+            },
+        )
+        .unwrap();
+        fs::write(gemini_backup.join("state.json"), b"invalid backend").unwrap();
+
+        let m = manager(dir.path());
+        let ps = profile_store(dir.path());
+        ps.create(Tool::Claude, "work").unwrap();
+        ps.write_file(Tool::Claude, "work", "state.json", b"original")
+            .unwrap();
+        let cs = ConfigStore::new(dir.path());
+
+        let err = m.restore(backup_id, &ps, &cs).unwrap_err();
+
+        assert!(err.to_string().contains("system_keyring"), "{err:#}");
+        assert_eq!(
+            ps.read_file(Tool::Claude, "work", "state.json").unwrap(),
+            b"original"
+        );
+        assert!(cs.load().unwrap().profiles_for(Tool::Claude).is_empty());
+        assert!(!ps.exists(Tool::Gemini, "broken"));
+        assert!(claude_backup.join("state.json").exists());
     }
 
     #[test]

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -577,7 +577,8 @@ aisw backup restore <backup_id> [--yes] [--json]
 ```
 
 Restore profile files and credentials from a backup. Profile metadata is saved
-only after restoration succeeds, and file writes are applied as one
+only after restoration succeeds. All backup entries are validated before any
+files are changed, and each profile's file writes are applied as one
 rollback-capable transaction. Does not activate the profile; run `aisw use`
 after restore.
 


### PR DESCRIPTION
Closes #107

## Why
A backup ID can contain multiple profile entries. Previously, an invalid later entry could fail after earlier profiles had already been restored and registered, leaving a partial recovery.

## What changed
- Preflight all valid backup entries and read all file contents before mutation.
- Keep the existing per-profile rollback transaction for writes.
- Document the validation boundary in both command references.
- Add a regression test for an invalid later entry.

## Trade-offs
This removes deterministic partial restores from invalid metadata, unsupported backends, and unreadable backup files. It intentionally preserves the existing per-profile execution boundary for external secure-store and config-write failures rather than expanding this PR into a cross-system transaction.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked -- --test-threads=1` — 576 passed, 1 ignored opt-in canary
- `cargo build --release --locked`
- `bash tests/completions_smoke.sh`
- Full commit hook passed; hosted CI will cover Linux, macOS, and Windows.