### PR TITLE
Make all-profile switches atomic

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -169,7 +169,7 @@ Activate a stored profile as the live account.
 Notes:
 - `--state-mode` applies to Claude Code and Codex CLI only. Gemini and Antigravity do not support it. With `--all`, it is applied only to the tools that support it rather than failing the whole switch.
 - Switching is atomic: the previous live state is snapshotted before any write. A failed write triggers a full rollback.
-- With `--all`, a tool that has no profile of that name is skipped and the command still succeeds. A tool that has the profile but fails to switch is reported and the command exits non-zero.
+- With `--all`, every matching tool is resolved before any live state changes. If a switch fails, all live states are restored and the command exits non-zero; a tool without the profile is skipped.
 - With shell hook active, `aisw use` also emits the environment variable exports into the current shell session.
 - `--emit-env` is used internally by the shell hook. You can use it directly to apply exports in a subshell: `eval "$(aisw use claude work --emit-env)"`.
 - Codex shared mode remains supported for API-key profiles.

--- a/src/auth/files.rs
+++ b/src/auth/files.rs
@@ -148,22 +148,30 @@ pub(crate) fn shell_single_quote(value: &str) -> String {
 /// We detect Fish by checking for `FISH_VERSION`, which Fish always exports into
 /// child-process environments.
 pub(crate) fn emit_export(key: &str, value: &str) {
+    println!("{}", export_line(key, value));
+}
+
+pub(crate) fn export_line(key: &str, value: &str) -> String {
     match std::env::var("AISW_SHELL").ok().as_deref() {
-        Some("pwsh") => println!("$env:{} = {}", key, powershell_single_quote(value)),
+        Some("pwsh") => format!("$env:{} = {}", key, powershell_single_quote(value)),
         _ if std::env::var_os("FISH_VERSION").is_some() => {
-            println!("set -gx {} {}", key, shell_single_quote(value));
+            format!("set -gx {} {}", key, shell_single_quote(value))
         }
-        _ => println!("export {}={}", key, shell_single_quote(value)),
+        _ => format!("export {}={}", key, shell_single_quote(value)),
     }
 }
 
 /// Emit a shell unset statement for `key`, choosing the correct syntax for the
 /// active shell.
 pub(crate) fn emit_unset(key: &str) {
+    println!("{}", unset_line(key));
+}
+
+pub(crate) fn unset_line(key: &str) -> String {
     match std::env::var("AISW_SHELL").ok().as_deref() {
-        Some("pwsh") => println!("Remove-Item Env:{} -ErrorAction SilentlyContinue", key),
-        _ if std::env::var_os("FISH_VERSION").is_some() => println!("set -e {}", key),
-        _ => println!("unset {}", key),
+        Some("pwsh") => format!("Remove-Item Env:{} -ErrorAction SilentlyContinue", key),
+        _ if std::env::var_os("FISH_VERSION").is_some() => format!("set -e {}", key),
+        _ => format!("unset {}", key),
     }
 }
 

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -528,7 +528,7 @@ fn resolve_context_switches(
 }
 
 #[derive(Debug, Clone)]
-enum LiveStateSnapshot {
+pub(crate) enum LiveStateSnapshot {
     Claude {
         credentials: Option<auth::claude::LiveCredentialSnapshot>,
         oauth_account_metadata: Option<Vec<u8>>,
@@ -546,18 +546,18 @@ enum LiveStateSnapshot {
 }
 
 #[derive(Debug, Clone)]
-struct FileSnapshot {
+pub(crate) struct FileSnapshot {
     path: std::path::PathBuf,
     bytes: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone)]
-struct NamedFileSnapshot {
+pub(crate) struct NamedFileSnapshot {
     file_name: OsString,
     bytes: Vec<u8>,
 }
 
-fn snapshot_live_state_for_context(
+pub(crate) fn snapshot_live_state_for_context(
     switches: &[ResolvedProfileSwitch],
     user_home: &Path,
 ) -> Result<HashMap<Tool, LiveStateSnapshot>> {
@@ -592,7 +592,7 @@ fn snapshot_live_state_for_context(
     Ok(snapshots)
 }
 
-fn restore_live_state_for_context(
+pub(crate) fn restore_live_state_for_context(
     snapshots: &HashMap<Tool, LiveStateSnapshot>,
     user_home: &Path,
 ) -> Result<()> {

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -65,10 +65,7 @@ pub(crate) fn run_all_in(
 ) -> Result<()> {
     let config_store = ConfigStore::new(home);
     let config = config_store.load()?;
-    let mut switched = 0usize;
-    let mut errors = Vec::new();
-    let before_backup_ids = backup_ids_for(home, None)?;
-    let mut affected_tools = Vec::new();
+    let mut switches = Vec::new();
 
     for tool in Tool::ALL {
         let profiles = config.profiles_for(tool);
@@ -84,43 +81,58 @@ pub(crate) fn run_all_in(
         // `--state-mode` only applies to tools that support it; passing it to
         // the others would make the whole `--all` switch fail.
         let tool_state_mode = state_mode_override.filter(|_| tool.supports_state_mode());
-        match run_for_tool(
+        switches.push(resolve_profile_switch_request(
             tool,
             Some(profile_name),
             tool_state_mode,
             emit_env,
-            false,
             home,
             user_home,
-        ) {
-            Ok(()) => {
-                switched += 1;
-                affected_tools.push(tool);
-            }
-            Err(e) => errors.push(format!("{}: {}", tool, e)),
-        }
+        )?);
     }
 
-    if switched == 0 && errors.is_empty() {
+    if switches.is_empty() {
         anyhow::bail!("no tool has a profile named '{}'", profile_name);
     }
 
-    // A tool without a matching profile is a *skip* and stays successful, but a
-    // tool that was attempted and failed must not exit 0 — scripts rely on the
-    // exit code to know whether the switch actually happened.
-    if !errors.is_empty() {
-        anyhow::bail!(
-            "{} of {} attempted tool switches failed:\n  {}",
-            errors.len(),
-            errors.len() + switched,
-            errors.join("\n  ")
-        );
+    let affected_tools = switches
+        .iter()
+        .map(|switch| switch.tool)
+        .collect::<Vec<_>>();
+    let before_backup_ids = backup_ids_for(home, None)?;
+
+    if emit_env {
+        let mut env_lines = Vec::new();
+        for switch in &switches {
+            let profile_store = prepare_profile_switch(switch, home, user_home)?;
+            env_lines.extend(shell_env_lines(switch, &profile_store, user_home)?);
+        }
+        config_store.activate_profiles(&activation_requests(&switches))?;
+        for line in env_lines {
+            println!("{line}");
+        }
+        return Ok(());
     }
 
-    // In --emit-env mode stdout is a shell script the caller evals; anything
-    // else written there would be executed as shell input.
-    if emit_env {
-        return Ok(());
+    let snapshots =
+        crate::commands::context::snapshot_live_state_for_context(&switches, user_home)?;
+    let apply_result = (|| -> Result<()> {
+        for switch in &switches {
+            apply_resolved_profile_switch(switch, false, home, user_home)?;
+        }
+        config_store.activate_profiles(&activation_requests(&switches))?;
+        Ok(())
+    })();
+
+    if let Err(err) = apply_result {
+        if let Err(rollback_err) =
+            crate::commands::context::restore_live_state_for_context(&snapshots, user_home)
+        {
+            return Err(err.context(format!(
+                "could not roll back the failed --all switch: {rollback_err:#}"
+            )));
+        }
+        return Err(err);
     }
 
     if json {
@@ -201,6 +213,24 @@ fn run_for_tool(
     }
 
     Ok(())
+}
+
+fn activation_requests(
+    switches: &[ResolvedProfileSwitch],
+) -> Vec<(Tool, String, Option<StateMode>)> {
+    switches
+        .iter()
+        .map(|switch| {
+            (
+                switch.tool,
+                switch.profile_name.clone(),
+                switch
+                    .tool
+                    .supports_state_mode()
+                    .then_some(switch.state_mode),
+            )
+        })
+        .collect()
 }
 
 pub(crate) fn resolve_profile_switch_request(
@@ -332,30 +362,7 @@ pub(crate) fn apply_resolved_profile_switch(
     home: &Path,
     user_home: &Path,
 ) -> Result<()> {
-    let profile_store = ProfileStore::new(home);
-    if resolved.backup_on_switch {
-        let backup_manager = BackupManager::new(home);
-        let profile_dir = profile_store.profile_dir(resolved.tool, &resolved.profile_name);
-        backup_manager.snapshot(
-            resolved.tool,
-            &resolved.profile_name,
-            &profile_dir,
-            &resolved.profile_meta,
-        )?;
-    }
-
-    if let Ok(config) = ConfigStore::new(home).load() {
-        if let Err(e) = maybe_sync_active_profile_before_switch(
-            &config,
-            &profile_store,
-            resolved.tool,
-            user_home,
-        ) {
-            output::print_warning_stderr(format!(
-                "Warning: could not sync active profile before switching: {e:#}"
-            ));
-        }
-    }
+    let profile_store = prepare_profile_switch(resolved, home, user_home)?;
 
     match resolved.tool {
         Tool::Claude => match resolved.profile_meta.auth_method {
@@ -491,6 +498,85 @@ pub(crate) fn apply_resolved_profile_switch(
     }
 
     Ok(())
+}
+
+fn prepare_profile_switch(
+    resolved: &ResolvedProfileSwitch,
+    home: &Path,
+    user_home: &Path,
+) -> Result<ProfileStore> {
+    let profile_store = ProfileStore::new(home);
+    if resolved.backup_on_switch {
+        let backup_manager = BackupManager::new(home);
+        let profile_dir = profile_store.profile_dir(resolved.tool, &resolved.profile_name);
+        backup_manager.snapshot(
+            resolved.tool,
+            &resolved.profile_name,
+            &profile_dir,
+            &resolved.profile_meta,
+        )?;
+    }
+
+    if let Ok(config) = ConfigStore::new(home).load() {
+        if let Err(e) = maybe_sync_active_profile_before_switch(
+            &config,
+            &profile_store,
+            resolved.tool,
+            user_home,
+        ) {
+            output::print_warning_stderr(format!(
+                "Warning: could not sync active profile before switching: {e:#}"
+            ));
+        }
+    }
+    Ok(profile_store)
+}
+
+fn shell_env_lines(
+    resolved: &ResolvedProfileSwitch,
+    profile_store: &ProfileStore,
+    user_home: &Path,
+) -> Result<Vec<String>> {
+    let lines = match resolved.tool {
+        Tool::Claude => {
+            let line = match resolved.state_mode {
+                StateMode::Isolated => crate::auth::files::export_line(
+                    "CLAUDE_CONFIG_DIR",
+                    &profile_store
+                        .profile_dir(Tool::Claude, &resolved.profile_name)
+                        .display()
+                        .to_string(),
+                ),
+                StateMode::Shared => crate::auth::files::unset_line("CLAUDE_CONFIG_DIR"),
+            };
+            vec![line]
+        }
+        Tool::Codex => {
+            let line = match resolved.state_mode {
+                StateMode::Isolated => crate::auth::files::export_line(
+                    "CODEX_HOME",
+                    &profile_store
+                        .profile_dir(Tool::Codex, &resolved.profile_name)
+                        .display()
+                        .to_string(),
+                ),
+                StateMode::Shared => crate::auth::files::unset_line("CODEX_HOME"),
+            };
+            vec![line]
+        }
+        Tool::Gemini => {
+            std::fs::create_dir_all(user_home.join(".gemini"))?;
+            match resolved.profile_meta.auth_method {
+                AuthMethod::ApiKey => vec![crate::auth::files::export_line(
+                    "GEMINI_API_KEY",
+                    &auth::gemini::read_api_key(profile_store, &resolved.profile_name)?,
+                )],
+                AuthMethod::OAuth => vec![crate::auth::files::unset_line("GEMINI_API_KEY")],
+            }
+        }
+        Tool::Antigravity => Vec::new(),
+    };
+    Ok(lines)
 }
 
 fn maybe_sync_active_profile_before_switch(
@@ -1534,6 +1620,50 @@ mod tests {
         assert_eq!(config.active_for(Tool::Claude), Some("work"));
         assert_eq!(config.active_for(Tool::Codex), Some("work"));
         assert_eq!(config.active_for(Tool::Gemini), Some("work"));
+    }
+
+    #[test]
+    fn all_flag_restores_live_state_when_a_later_tool_fails() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let user_home = tmp.path().join("uhome");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        auth::claude::add_api_key(
+            &ProfileStore::new(&home),
+            &ConfigStore::new(&home),
+            "old",
+            "sk-ant-api03-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            None,
+        )
+        .unwrap();
+        setup_claude_api_key_profile(&home, "work");
+        auth::codex::add_api_key(
+            &ProfileStore::new(&home),
+            &ConfigStore::new(&home),
+            "old",
+            "sk-codex-old-key-12345",
+            None,
+        )
+        .unwrap();
+        setup_codex_api_key_profile(&home, "work");
+        let config_store = ConfigStore::new(&home);
+        config_store.set_active(Tool::Claude, "old").unwrap();
+        config_store.set_active(Tool::Codex, "old").unwrap();
+        fs::remove_dir_all(ProfileStore::new(&home).profile_dir(Tool::Codex, "work")).unwrap();
+
+        let err = run_all_in("work", None, false, false, &home, &user_home).unwrap_err();
+
+        assert!(
+            err.to_string().contains("codex"),
+            "unexpected error: {err:#}"
+        );
+        assert!(!user_home.join(".claude").join(".credentials.json").exists());
+        let config = config_store.load().unwrap();
+        assert_eq!(config.active_for(Tool::Claude), Some("old"));
+        assert_eq!(config.active_for(Tool::Codex), Some("old"));
     }
 
     #[test]

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -186,7 +186,7 @@ Activate a stored profile as the live account.
 Notes:
 - `--state-mode` applies to Claude Code and Codex CLI only. Gemini and Antigravity do not support it. With `--all`, it is applied only to the tools that support it rather than failing the whole switch.
 - Switching is atomic: the previous live state is snapshotted before any write. A failed write triggers a full rollback.
-- With `--all`, a tool that has no profile of that name is skipped and the command still succeeds. A tool that has the profile but fails to switch is reported and the command exits non-zero.
+- With `--all`, every matching tool is resolved before any live state changes. If a switch fails, all live states are restored and the command exits non-zero; a tool without the profile is skipped.
 - With shell hook active, `aisw use` also emits the environment variable exports into the current shell session.
 - `--emit-env` is used internally by the shell hook. You can use it directly to apply exports in a subshell: `eval "$(aisw use claude work --emit-env)"`.
 - Codex shared mode remains supported for API-key profiles.


### PR DESCRIPTION
Closes #98

## Why
`use --all` previously called the single-tool command repeatedly. A later failure could therefore leave earlier tools switched and active-profile metadata updated, even though the overall command failed.

## What changed
- Resolve every matching profile before any mutation.
- Snapshot all affected live tool state once.
- Apply switches in deterministic `Tool::ALL` order and activate profiles once.
- Restore all live state when a switch or activation fails, including rollback diagnostics.
- Defer `--emit-env` output until the complete operation and config activation succeed.
- Add regression coverage for a later-tool failure and preserve existing docs/contracts.

## Trade-offs
This reuses the established context transaction snapshot/restore implementation and keeps the single-tool path unchanged. As with context switching, managed-profile synchronization and backup creation occur before live application and are not treated as a cross-system transaction; the rollback boundary covers live state and active-profile metadata.

## Verification
- `cargo fmt --all`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` — 576 passed, 1 ignored opt-in canary
- `cargo build --release --locked`
- `bash tests/completions_smoke.sh`
- Full commit hook passed.