### PR TITLE
Keep status usable after live inspection errors

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -469,6 +469,7 @@ the binary fields in JSON output.
 
 Notes:
 - "Live match" indicates whether the tool's current live credentials match the `aisw`-recorded active profile.
+- `live_state_diagnostic` is `inspection_failed` when live-state comparison could not be completed. In that case `active_profile_applied` is `null`; status still returns all tool rows without exposing the underlying error or credential contents.
 - `credential_state` is `present` when the known primary credential is stored,
   `missing` when no profile files or secure credential exist, and `unknown` when
   files exist but do not match a known credential layout. Unknown layouts are

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -45,6 +45,7 @@ pub(crate) struct ToolStatus {
     pub state_mode: Option<String>,
     pub active_profile_added_at: Option<chrono::DateTime<chrono::Utc>>,
     pub active_profile_applied: Option<bool>,
+    pub live_state_diagnostic: Option<&'static str>,
     pub credential_state: CredentialState,
     pub credentials_present: bool,
     pub permissions_ok: bool,
@@ -210,6 +211,7 @@ pub(crate) fn collect_status(
             state_mode,
             active_profile_added_at: active.added_at,
             active_profile_applied: active.applied,
+            live_state_diagnostic: active.live_state_diagnostic,
             credential_state: active.credential_state,
             credentials_present: active.credentials_present,
             permissions_ok: active.permissions_ok,
@@ -232,6 +234,7 @@ struct ActiveProfileStatus {
     antigravity_auth_classification: Option<String>,
     added_at: Option<chrono::DateTime<chrono::Utc>>,
     applied: Option<bool>,
+    live_state_diagnostic: Option<&'static str>,
     credential_state: CredentialState,
     credentials_present: bool,
     permissions_ok: bool,
@@ -249,6 +252,7 @@ impl Default for ActiveProfileStatus {
             antigravity_auth_classification: None,
             added_at: None,
             applied: None,
+            live_state_diagnostic: None,
             credential_state: CredentialState::Missing,
             credentials_present: false,
             permissions_ok: true,
@@ -326,22 +330,23 @@ fn collect_active_profile_status(
         Tool::Gemini => {}
     }
 
-    let applied = if !credentials_present {
-        Some(false)
+    let (applied, live_state_diagnostic) = if !credentials_present {
+        (Some(false), None)
     } else if should_skip_live_verification(tool, meta.credential_backend) {
-        None
+        (None, None)
     } else {
-        Some(
-            assess_live_state(
-                tool,
-                meta.auth_method,
-                meta.credential_backend,
-                config.state_mode_for(tool),
-                profile_store,
-                name,
-                user_home,
-            )? == LiveActivation::Applied,
-        )
+        match assess_live_state(
+            tool,
+            meta.auth_method,
+            meta.credential_backend,
+            config.state_mode_for(tool),
+            profile_store,
+            name,
+            user_home,
+        ) {
+            Ok(result) => (Some(result == LiveActivation::Applied), None),
+            Err(_) => (None, Some("inspection_failed")),
+        }
     };
 
     Ok(ActiveProfileStatus {
@@ -354,6 +359,7 @@ fn collect_active_profile_status(
         antigravity_auth_classification,
         added_at: Some(meta.added_at),
         applied,
+        live_state_diagnostic,
         credential_state,
         credentials_present,
         permissions_ok,
@@ -502,6 +508,9 @@ fn status_message(s: &ToolStatus) -> &'static str {
     if !s.permissions_ok {
         return "credentials present \u{2014} permissions too broad!";
     }
+    if s.live_state_diagnostic == Some("inspection_failed") {
+        return "credentials present, but live tool state could not be inspected";
+    }
     if s.tool == Tool::Claude
         && s.credential_backend.as_deref() == Some("file")
         && cfg!(target_os = "macos")
@@ -638,6 +647,7 @@ fn print_json(
                 "antigravity_auth_classification": s.antigravity_auth_classification,
                 "state_mode":           s.state_mode,
                 "active_profile_applied": s.active_profile_applied,
+                "live_state_diagnostic": s.live_state_diagnostic,
                 "credential_state":     s.credential_state,
                 "credentials_present":  s.credentials_present,
                 "permissions_ok":       s.permissions_ok,
@@ -1334,6 +1344,7 @@ mod tests {
                 state_mode: Some("isolated".to_owned()),
                 active_profile_added_at: Some(chrono::Utc::now()),
                 active_profile_applied: Some(true),
+                live_state_diagnostic: None,
                 credential_state: CredentialState::Present,
                 credentials_present: true,
                 permissions_ok: true,
@@ -1356,6 +1367,7 @@ mod tests {
                 state_mode: Some("isolated".to_owned()),
                 active_profile_added_at: None,
                 active_profile_applied: None,
+                live_state_diagnostic: None,
                 credential_state: CredentialState::Missing,
                 credentials_present: false,
                 permissions_ok: true,
@@ -1403,6 +1415,7 @@ mod tests {
                 state_mode: Some("isolated".to_owned()),
                 active_profile_added_at: Some(older),
                 active_profile_applied: Some(true),
+                live_state_diagnostic: None,
                 credential_state: CredentialState::Present,
                 credentials_present: true,
                 permissions_ok: true,
@@ -1425,6 +1438,7 @@ mod tests {
                 state_mode: Some("isolated".to_owned()),
                 active_profile_added_at: Some(newer),
                 active_profile_applied: Some(true),
+                live_state_diagnostic: None,
                 credential_state: CredentialState::Present,
                 credentials_present: true,
                 permissions_ok: true,

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -266,6 +266,7 @@ mod tests {
             state_mode: Some("isolated".to_owned()),
             active_profile_added_at: None,
             active_profile_applied: Some(true),
+            live_state_diagnostic: None,
             credential_state: status::CredentialState::Present,
             credentials_present: true,
             permissions_ok: true,

--- a/tests/json_output_contract.rs
+++ b/tests/json_output_contract.rs
@@ -113,6 +113,7 @@ fn status_json_contract_snapshot() {
             "antigravity_auth_classification": null,
             "state_mode": "isolated",
             "active_profile_applied": expected_claude_active_applied,
+            "live_state_diagnostic": null,
             "credential_state": "present",
             "credentials_present": true,
             "permissions_ok": true,
@@ -133,6 +134,7 @@ fn status_json_contract_snapshot() {
             "antigravity_auth_classification": null,
             "state_mode": "isolated",
             "active_profile_applied": true,
+            "live_state_diagnostic": null,
             "credential_state": "present",
             "credentials_present": true,
             "permissions_ok": true,
@@ -153,6 +155,7 @@ fn status_json_contract_snapshot() {
             "antigravity_auth_classification": null,
             "state_mode": null,
             "active_profile_applied": true,
+            "live_state_diagnostic": null,
             "credential_state": "present",
             "credentials_present": true,
             "permissions_ok": true,
@@ -173,6 +176,7 @@ fn status_json_contract_snapshot() {
             "antigravity_auth_classification": null,
             "state_mode": null,
             "active_profile_applied": null,
+            "live_state_diagnostic": null,
             "credential_state": "missing",
             "credentials_present": false,
             "permissions_ok": true,
@@ -314,6 +318,7 @@ fn status_json_contract_preserved_with_filter_and_sort_flags() {
         "antigravity_auth_classification",
         "state_mode",
         "active_profile_applied",
+        "live_state_diagnostic",
         "credential_state",
         "credentials_present",
         "permissions_ok",
@@ -324,7 +329,7 @@ fn status_json_contract_preserved_with_filter_and_sort_flags() {
             "missing key `{key}` in status entry"
         );
     }
-    assert_eq!(entry.len(), 18);
+    assert_eq!(entry.len(), 19);
 }
 
 #[test]

--- a/tests/status_cmd.rs
+++ b/tests/status_cmd.rs
@@ -248,6 +248,39 @@ fn status_json_has_expected_keys() {
     }
     assert_eq!(claude["credentials_present"], true);
     assert_eq!(claude["permissions_ok"], true);
+    assert!(claude["live_state_diagnostic"].is_null());
+}
+
+#[test]
+fn status_keeps_rows_when_live_state_cannot_be_inspected() {
+    let env = TestEnv::new();
+    add_and_activate_codex(&env, "work");
+    env.cmd()
+        .args(["use", "codex", "work", "--state-mode", "shared"])
+        .assert()
+        .success();
+    std::fs::write(env.fake_home.join(".codex").join("auth.json"), b"{").unwrap();
+
+    let output = env
+        .cmd()
+        .args(["status", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON");
+    let rows = json.as_array().unwrap();
+    let codex = rows.iter().find(|entry| entry["tool"] == "codex").unwrap();
+    assert_eq!(codex["active_profile_applied"], serde_json::Value::Null);
+    assert_eq!(codex["live_state_diagnostic"], "inspection_failed");
+    assert!(rows.iter().any(|entry| entry["tool"] == "claude"));
+
+    env.cmd()
+        .args(["status"])
+        .assert()
+        .success()
+        .stdout(contains("live tool state could not be inspected"));
 }
 
 #[test]

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -486,6 +486,7 @@ the binary fields in JSON output.
 
 Notes:
 - "Live match" indicates whether the tool's current live credentials match the `aisw`-recorded active profile.
+- `live_state_diagnostic` is `inspection_failed` when live-state comparison could not be completed. In that case `active_profile_applied` is `null`; status still returns all tool rows without exposing the underlying error or credential contents.
 - `credential_state` is `present` when the known primary credential is stored,
   `missing` when no profile files or secure credential exist, and `unknown` when
   files exist but do not match a known credential layout. Unknown layouts are


### PR DESCRIPTION
Closes #94

## Why
A malformed upstream live-state file or unavailable keyring currently aborts `aisw status`, hiding diagnostics for every tool.

## What
- preserve all status rows when live comparison fails
- leave `active_profile_applied` null and expose `live_state_diagnostic: inspection_failed`
- keep the diagnostic non-secret and document the JSON contract
- add malformed Codex live-state regression coverage

## Trade-offs
The command intentionally suppresses the underlying inspection error from machine output to avoid leaking paths or credential details. `verify` remains the stricter command for actionable failure handling.

## Verification
- `cargo fmt --all`
- `cargo check --all-targets --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`
