### PR TITLE
Reject unknown Claude credential formats

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -85,6 +85,7 @@ Notes:
 - For Gemini, when both `~/.gemini/.env` and OAuth cache files are present, import uses the `.env` file first.
 - For Claude Code on macOS, `init` checks the Keychain before checking the credentials file.
 - `init` will not import a duplicate if the OAuth identity matches an already-stored profile.
+- Claude live payloads with an unknown credential shape are reported as unavailable and are not imported; this fail-closed behavior avoids creating profiles that cannot be applied after an upstream format change.
 
 ```sh
 aisw init
@@ -120,6 +121,7 @@ Notes:
 - In `--non-interactive` mode, interactive OAuth is not available and the command fails.
 - `--api-key-stdin` is intended for GUI and automation integrations that should not expose secrets in process arguments.
 - `--from-live` captures what the tool is currently using; it does not launch a browser or auth flow.
+- `--from-live` imports only credential shapes recognized for the selected tool. Unknown Claude payloads fail closed and must be re-authenticated or reviewed against the current upstream format.
 - `--from-live` always activates the profile because those credentials are already live.
 - `--from-live --yes` overwrites an existing profile in place; the existing entry is not removed until capture succeeds.
 - For Codex ChatGPT-managed auth, `--from-live` is a bootstrap import, not a durable interchangeable account bundle.

--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -117,6 +117,48 @@ pub use oauth::{
 };
 pub use paths::live_local_state_dir;
 
+/// Classifies credential payloads that aisw knows how to apply to Claude.
+///
+/// This deliberately recognizes a small set of observed upstream shapes so a
+/// future schema change cannot be mistaken for OAuth credentials.
+pub fn classify_live_credentials(bytes: &[u8]) -> Option<crate::config::AuthMethod> {
+    let normalized = normalize_credentials_bytes(bytes).unwrap_or_else(|| bytes.to_vec());
+    let value: serde_json::Value = serde_json::from_slice(&normalized).ok()?;
+    let object = value.as_object()?;
+
+    if nonempty_string(object.get("apiKey")) {
+        return Some(crate::config::AuthMethod::ApiKey);
+    }
+
+    let oauth = ["oauthToken", "token", "accessToken", "access_token"]
+        .into_iter()
+        .any(|field| nonempty_string(object.get(field)))
+        || object
+            .get("claudeAiOauth")
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|oauth| {
+                ["accessToken", "refreshToken", "token", "access_token"]
+                    .into_iter()
+                    .any(|field| nonempty_string(oauth.get(field)))
+            })
+        || object
+            .get("account")
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|account| {
+                ["email", "emailAddress", "email_address"]
+                    .into_iter()
+                    .any(|field| nonempty_string(account.get(field)))
+            });
+
+    oauth.then_some(crate::config::AuthMethod::OAuth)
+}
+
+fn nonempty_string(value: Option<&serde_json::Value>) -> bool {
+    value
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
 pub fn classify_profile(
     user_home: &Path,
     profile_store: &ProfileStore,
@@ -973,6 +1015,51 @@ mod tests {
         );
         // Profile dir cleaned up after the failed OAuth attempt.
         assert!(!ps.exists(Tool::Claude, "work"));
+    }
+
+    #[test]
+    fn classify_live_credentials_accepts_known_api_key_and_oauth_shapes() {
+        assert_eq!(
+            classify_live_credentials(br#"{"apiKey":"sk-ant-test"}"#),
+            Some(AuthMethod::ApiKey)
+        );
+        for payload in [
+            br#"{"oauthToken":"token"}"#.as_slice(),
+            br#"{"token":"token"}"#.as_slice(),
+            br#"{"claudeAiOauth":{"accessToken":"token"}}"#.as_slice(),
+        ] {
+            assert_eq!(classify_live_credentials(payload), Some(AuthMethod::OAuth));
+        }
+    }
+
+    #[test]
+    fn classify_live_credentials_rejects_unknown_or_empty_shapes() {
+        for payload in [
+            br#"{}"#.as_slice(),
+            br#"{"apiKey":""}"#.as_slice(),
+            br#"{"futureCredentialFormat":{"value":"token"}}"#.as_slice(),
+            b"not-json".as_slice(),
+        ] {
+            assert_eq!(classify_live_credentials(payload), None);
+        }
+    }
+
+    #[test]
+    fn live_snapshot_ignores_unknown_credential_payload() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("home");
+        fs::create_dir_all(user_home.join(".claude")).unwrap();
+        fs::write(
+            user_home.join(".claude").join(CREDENTIALS_FILE),
+            br#"{"futureCredentialFormat":{"value":"token"}}"#,
+        )
+        .unwrap();
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+
+        assert!(oauth::live_credentials_snapshot_for_import(&user_home)
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/src/auth/claude/oauth.rs
+++ b/src/auth/claude/oauth.rs
@@ -57,10 +57,12 @@ pub fn live_credentials_snapshot_for_import(
     match super::keychain::auth_storage(user_home) {
         ClaudeAuthStorage::Keychain => {
             if let Some(bytes) = read_live_keychain_credentials_for_import()? {
-                return Ok(Some(LiveCredentialSnapshot {
-                    bytes,
-                    source: LiveCredentialSource::Keychain,
-                }));
+                if super::classify_live_credentials(&bytes).is_some() {
+                    return Ok(Some(LiveCredentialSnapshot {
+                        bytes,
+                        source: LiveCredentialSource::Keychain,
+                    }));
+                }
             }
         }
         ClaudeAuthStorage::File => {}
@@ -69,10 +71,12 @@ pub fn live_credentials_snapshot_for_import(
     if live_path.exists() {
         let bytes = std::fs::read(&live_path)
             .with_context(|| format!("could not read {}", live_path.display()))?;
-        return Ok(Some(LiveCredentialSnapshot {
-            bytes,
-            source: LiveCredentialSource::File(live_path),
-        }));
+        if super::classify_live_credentials(&bytes).is_some() {
+            return Ok(Some(LiveCredentialSnapshot {
+                bytes,
+                source: LiveCredentialSource::File(live_path),
+            }));
+        }
     }
 
     if live_local_state_dir(user_home).is_none() {
@@ -82,6 +86,10 @@ pub fn live_credentials_snapshot_for_import(
     let Some(bytes) = read_live_keychain_credentials_for_import()? else {
         return Ok(None);
     };
+
+    if super::classify_live_credentials(&bytes).is_none() {
+        return Ok(None);
+    }
 
     Ok(Some(LiveCredentialSnapshot {
         bytes,

--- a/tests/init_cmd.rs
+++ b/tests/init_cmd.rs
@@ -254,6 +254,28 @@ fn init_imports_claude_profile_when_same_email_has_different_org() {
 }
 
 #[test]
+fn init_reports_unknown_claude_live_credentials_without_importing_them() {
+    let env = TestEnv::new();
+    let claude_dir = env.fake_home.join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join(".credentials.json"),
+        br#"{"futureCredentialFormat":{"value":"token"}}"#,
+    )
+    .unwrap();
+
+    run_init(&env).success().stdout(contains(
+        "Claude local state exists, but aisw could not find importable auth",
+    ));
+    assert!(!env
+        .aisw_home
+        .join("profiles")
+        .join("claude")
+        .join("default")
+        .exists());
+}
+
+#[test]
 fn init_is_idempotent_for_claude_oauth_import_without_identity_fields() {
     let env = TestEnv::new();
     let claude_dir = env.fake_home.join(".claude");

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -102,6 +102,7 @@ Notes:
 - For Gemini, when both `~/.gemini/.env` and OAuth cache files are present, import uses the `.env` file first.
 - For Claude Code on macOS, `init` checks the Keychain before checking the credentials file.
 - `init` will not import a duplicate if the OAuth identity matches an already-stored profile.
+- Claude live payloads with an unknown credential shape are reported as unavailable and are not imported; this fail-closed behavior avoids creating profiles that cannot be applied after an upstream format change.
 
 ```sh
 aisw init
@@ -137,6 +138,7 @@ Notes:
 - In `--non-interactive` mode, interactive OAuth is not available and the command fails.
 - `--api-key-stdin` is intended for GUI and automation integrations that should not expose secrets in process arguments.
 - `--from-live` captures what the tool is currently using; it does not launch a browser or auth flow.
+- `--from-live` imports only credential shapes recognized for the selected tool. Unknown Claude payloads fail closed and must be re-authenticated or reviewed against the current upstream format.
 - `--from-live` always activates the profile because those credentials are already live.
 - `--from-live --yes` overwrites an existing profile in place; the existing entry is not removed until capture succeeds.
 - For Codex ChatGPT-managed auth, `--from-live` is a bootstrap import, not a durable interchangeable account bundle.


### PR DESCRIPTION
Closes #92

## Why
Claude’s live credential payload is an upstream-owned format. Treating every JSON object without `apiKey` as OAuth can turn a future schema change into a profile that looks valid but cannot be applied safely.

## What
- recognize the supported Claude API-key and OAuth payload shapes
- make live import report unknown or structurally invalid payloads as unavailable
- retain legacy supported shapes and file/keychain source precedence
- cover `init` end-to-end so unsupported credentials do not create a default profile

## Trade-offs
The classifier is deliberately conservative: a new upstream shape remains unavailable until its semantics are verified. That avoids silently storing unusable credentials at the cost of requiring a follow-up compatibility patch when Claude changes its schema.

## Verification
- `cargo fmt --all`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`
