### PR TITLE
Expose doctor JSON result

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -72,6 +72,11 @@ aisw backup list --json
 aisw doctor --json
 ```
 
+The machine-readable doctor result keeps its existing `checks` array and adds
+an additive top-level `ok` boolean. Use it when a caller needs the diagnostic
+result in the same JSON document rather than deriving it from individual
+checks; the command still exits non-zero when `ok` is `false`.
+
 With `--json`, success and expected command failures are emitted as structured JSON on stdout. Human-oriented stdout/stderr output is suppressed. The process still exits non-zero on failure.
 
 For OAuth-based `add`, use `--progress-json` to stream newline-delimited JSON progress events:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -641,6 +641,10 @@ aisw doctor
 aisw doctor --json
 ```
 
+`doctor --json` preserves the `checks` array and adds an additive top-level
+`ok` boolean. It is `true` when no check has status `fail`; the process still
+uses a non-zero exit code when `ok` is `false`.
+
 ---
 
 ## `aisw verify`

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -389,12 +389,15 @@ fn print_text(report: &DoctorReport) {
     }
 }
 
+#[derive(Serialize)]
+struct DoctorJsonOutput<'a> {
+    ok: bool,
+    checks: &'a [CheckResult],
+}
+
 fn print_json(report: &DoctorReport) -> Result<()> {
-    #[derive(Serialize)]
-    struct Output<'a> {
-        checks: &'a [CheckResult],
-    }
-    let out = serde_json::to_string_pretty(&Output {
+    let out = serde_json::to_string_pretty(&DoctorJsonOutput {
+        ok: !report.any_failed(),
         checks: &report.checks,
     })?;
     println!("{out}");
@@ -744,5 +747,30 @@ mod tests {
         let args = DoctorArgs { json: true };
         // Should not panic or error.
         let _ = run_in(args, &home, &user_home, std::ffi::OsStr::new(""));
+    }
+
+    #[test]
+    fn doctor_json_includes_overall_result_without_changing_checks() {
+        let report = DoctorReport {
+            checks: vec![CheckResult::pass("config/json", "valid")],
+        };
+        let output = serde_json::to_value(DoctorJsonOutput {
+            ok: !report.any_failed(),
+            checks: &report.checks,
+        })
+        .unwrap();
+
+        assert_eq!(output["ok"], true);
+        assert_eq!(output["checks"].as_array().unwrap().len(), 1);
+
+        let failed_report = DoctorReport {
+            checks: vec![CheckResult::fail("config/json", "invalid")],
+        };
+        let failed_output = serde_json::to_value(DoctorJsonOutput {
+            ok: !failed_report.any_failed(),
+            checks: &failed_report.checks,
+        })
+        .unwrap();
+        assert_eq!(failed_output["ok"], false);
     }
 }

--- a/tests/all_commands_smoke.rs
+++ b/tests/all_commands_smoke.rs
@@ -281,6 +281,7 @@ fn doctor_verify_repair() {
     // After a repair --apply, the installation is healthy.
     let doctor_after = env.output(&["doctor", "--json"]);
     let json: serde_json::Value = serde_json::from_slice(&doctor_after.stdout).unwrap();
+    assert_eq!(json["ok"], true, "healthy doctor report should be ok");
     let failures: Vec<_> = json["checks"]
         .as_array()
         .unwrap()

--- a/tests/audit_regressions.rs
+++ b/tests/audit_regressions.rs
@@ -419,6 +419,7 @@ fn doctor_reports_future_config_schema_in_json() {
         .expect("config check");
 
     assert_eq!(config_check["status"], "fail");
+    assert_eq!(json["ok"], false, "failed doctor report should not be ok");
     assert!(config_check["detail"]
         .as_str()
         .expect("config detail")

--- a/website/src/content/docs/automation.md
+++ b/website/src/content/docs/automation.md
@@ -89,6 +89,11 @@ aisw backup list --json
 aisw doctor --json
 ```
 
+The machine-readable doctor result keeps its existing `checks` array and adds
+an additive top-level `ok` boolean. Use it when a caller needs the diagnostic
+result in the same JSON document rather than deriving it from individual
+checks; the command still exits non-zero when `ok` is `false`.
+
 With `--json`, success and expected command failures are emitted as structured JSON on stdout. Human-oriented stdout/stderr output is suppressed. The process still exits non-zero on failure.
 
 For OAuth-based `add`, use `--progress-json` to stream newline-delimited JSON progress events:

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -658,6 +658,10 @@ aisw doctor
 aisw doctor --json
 ```
 
+`doctor --json` preserves the `checks` array and adds an additive top-level
+`ok` boolean. It is `true` when no check has status `fail`; the process still
+uses a non-zero exit code when `ok` is `false`.
+
 ---
 
 ## `aisw verify`


### PR DESCRIPTION
Closes #86

## Why
`aisw doctor --json` reports individual checks but not the overall health result. GUI and CI callers must otherwise duplicate the reduction logic or infer success from a piped process exit.

## Decision
Add an additive top-level `ok` boolean while preserving the existing `checks` array and exit-code behavior. `ok` is derived from the same check set the command already uses, so this improves machine ergonomics without changing diagnostic policy.

The integration assertions cover both healthy and future-schema failure reports.

## Verification
- `cargo fmt --all`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`
