### PR TITLE
Make single-profile switches rollback-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Backup restore now commits profile metadata only after its files and secure
   credentials have been restored successfully, and applies file writes as one
   rollback-capable transaction.
+- Failed profile switches now restore live agent state before returning, and
+  retain both the original switch error and any rollback failure details.
 - Failed backup snapshots now clean up partial files and secure-store backup
   entries instead of leaving incomplete recovery artifacts behind.
 - `aisw doctor` now fails clearly when `config.json` uses a schema newer than

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -376,8 +376,12 @@ fn use_context(_args: ContextUseArgs, _home: &Path) -> Result<()> {
     })();
 
     if let Err(err) = apply_result {
-        restore_live_state_for_context(&snapshots, &user_home)?;
-        return Err(err);
+        return match restore_live_state_for_context(&snapshots, &user_home) {
+            Ok(()) => Err(err),
+            Err(rollback_err) => Err(anyhow!(
+                "{err:#}\nAutomatic rollback also failed: {rollback_err:#}"
+            )),
+        };
     }
 
     if args.json {
@@ -528,7 +532,7 @@ fn resolve_context_switches(
 }
 
 #[derive(Debug, Clone)]
-enum LiveStateSnapshot {
+pub(crate) enum LiveStateSnapshot {
     Claude {
         credentials: Option<auth::claude::LiveCredentialSnapshot>,
         oauth_account_metadata: Option<Vec<u8>>,
@@ -546,18 +550,18 @@ enum LiveStateSnapshot {
 }
 
 #[derive(Debug, Clone)]
-struct FileSnapshot {
+pub(crate) struct FileSnapshot {
     path: std::path::PathBuf,
     bytes: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone)]
-struct NamedFileSnapshot {
+pub(crate) struct NamedFileSnapshot {
     file_name: OsString,
     bytes: Vec<u8>,
 }
 
-fn snapshot_live_state_for_context(
+pub(crate) fn snapshot_live_state_for_context(
     switches: &[ResolvedProfileSwitch],
     user_home: &Path,
 ) -> Result<HashMap<Tool, LiveStateSnapshot>> {
@@ -592,7 +596,7 @@ fn snapshot_live_state_for_context(
     Ok(snapshots)
 }
 
-fn restore_live_state_for_context(
+pub(crate) fn restore_live_state_for_context(
     snapshots: &HashMap<Tool, LiveStateSnapshot>,
     user_home: &Path,
 ) -> Result<()> {

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -1,12 +1,13 @@
 use std::io::IsTerminal;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use dialoguer::{theme::ColorfulTheme, Input, Select};
 
 use crate::auth;
 use crate::backup::BackupManager;
 use crate::cli::UseArgs;
+use crate::commands::context::{restore_live_state_for_context, snapshot_live_state_for_context};
 use crate::config::{AuthMethod, ConfigStore, ProfileMeta};
 use crate::error::AiswError;
 use crate::machine;
@@ -175,13 +176,14 @@ fn run_for_tool(
         home,
         user_home,
     )?;
-    apply_resolved_profile_switch(&resolved, emit_env, home, user_home)?;
-
-    ConfigStore::new(home).activate_profile(
-        tool,
-        &resolved.profile_name,
-        tool.supports_state_mode().then_some(resolved.state_mode),
-    )?;
+    apply_and_activate_profile_switch(&resolved, emit_env, home, user_home, || {
+        ConfigStore::new(home).activate_profile(
+            tool,
+            &resolved.profile_name,
+            tool.supports_state_mode().then_some(resolved.state_mode),
+        )?;
+        Ok(())
+    })?;
 
     if json {
         let after_backup_ids = backup_ids_for(home, Some(tool))?;
@@ -201,6 +203,45 @@ fn run_for_tool(
     }
 
     Ok(())
+}
+
+fn apply_and_activate_profile_switch<F>(
+    resolved: &ResolvedProfileSwitch,
+    emit_env: bool,
+    home: &Path,
+    user_home: &Path,
+    activate: F,
+) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    let snapshots = (!emit_env)
+        .then(|| snapshot_live_state_for_context(std::slice::from_ref(resolved), user_home))
+        .transpose()?;
+    let switch_result = (|| -> Result<()> {
+        apply_resolved_profile_switch(resolved, emit_env, home, user_home)?;
+        activate()?;
+        Ok(())
+    })();
+
+    if let Err(err) = switch_result {
+        if let Some(snapshots) = snapshots {
+            return match restore_live_state_for_context(&snapshots, user_home) {
+                Ok(()) => Err(err),
+                Err(rollback_err) => Err(switch_failure_with_rollback_error(err, rollback_err)),
+            };
+        }
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+fn switch_failure_with_rollback_error(
+    switch_error: anyhow::Error,
+    rollback_error: anyhow::Error,
+) -> anyhow::Error {
+    anyhow!("{switch_error:#}\nAutomatic rollback also failed: {rollback_error:#}")
 }
 
 pub(crate) fn resolve_profile_switch_request(
@@ -1194,6 +1235,45 @@ mod tests {
 
         let config = ConfigStore::new(&home).load().unwrap();
         assert_eq!(config.active_for(Tool::Claude), Some("work"));
+    }
+
+    #[test]
+    fn failed_activation_restores_live_profile_state() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _storage = EnvVarGuard::set("AISW_CLAUDE_AUTH_STORAGE", "file");
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let user_home = tmp.path().join("uhome");
+        fs::create_dir_all(&home).unwrap();
+        setup_claude_api_key_profile(&home, "work");
+
+        let resolved = resolve_profile_switch_request(
+            Tool::Claude,
+            Some("work"),
+            None,
+            false,
+            &home,
+            &user_home,
+        )
+        .unwrap();
+        let err = apply_and_activate_profile_switch(&resolved, false, &home, &user_home, || {
+            Err(anyhow!("config activation failed"))
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("config activation failed"));
+        assert!(!user_home.join(".claude/.credentials.json").exists());
+    }
+
+    #[test]
+    fn rollback_failure_keeps_original_switch_error() {
+        let err = switch_failure_with_rollback_error(
+            anyhow!("config activation failed"),
+            anyhow!("permission denied restoring credentials"),
+        );
+        let message = err.to_string();
+        assert!(message.contains("config activation failed"));
+        assert!(message.contains("permission denied restoring credentials"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #84

## Why

A single-tool switch could update live agent credentials and files, then fail while persisting the active profile. That left the agent using one profile while aisw reported another.

## What changed

- Snapshot the target tool's live state before a non-`--emit-env` single-tool switch.
- Restore that snapshot when live apply or config activation fails.
- Preserve the primary failure and append rollback diagnostics when compensation also fails.
- Apply the same error-preservation rule to multi-tool context rollback.
- Add regression coverage for failed activation cleanup and dual-error reporting.

## Trade-offs

The existing context snapshot/restore machinery is reused so credential and platform-specific state stay aligned. Environment-only output does not mutate live state, so it does not take a snapshot.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo build --release --locked`
- `cargo test --locked` — 577 passed, 1 ignored
- `bash tests/completions_smoke.sh`
- pre-push hook — tests and release build passed
