### PR TITLE
Serialize workspace configuration mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `aisw remove` no longer deletes credentials and profile files before checking whether a context still references the profile — the removal was rejected afterwards, leaving the data already destroyed.
 - Removing the active profile now clears `active` in the same locked config mutation, so config can no longer name a profile that does not exist.
 - `aisw status` no longer panics (`no entry found for key`) when `active` names a profile missing from the config; it reports the inconsistency instead.
+- Workspace configuration mutations now serialize their read-modify-write cycle, so concurrent `bind`, `unbind`, and `guard` commands cannot silently overwrite each other's changes.
 - `aisw status` now spells out when a Claude profile is stored in `~/.aisw` but the live upstream auth still comes from the macOS Keychain, avoiding the misleading "file-backed Claude" reading that surfaced in the OAuth switching bug report.
 - `aisw init --json` no longer aborts on a shell it has no hook for (for example `/bin/sh`, the default in many containers).
 - `aisw doctor` no longer reports a false `credentials file missing` failure for every Gemini profile. It now checks the files a profile actually stores rather than one hardcoded name per tool, which also stopped `aisw verify` from inheriting the failure.

--- a/src/commands/workspace.rs
+++ b/src/commands/workspace.rs
@@ -37,9 +37,10 @@ fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
 
     if args.default {
         let store = WorkspaceStore::new(home);
-        let mut workspace_config = store.load()?;
-        workspace_config.default_context = Some(args.context.clone());
-        store.save(&workspace_config)?;
+        store.update(|workspace_config| {
+            workspace_config.default_context = Some(args.context.clone());
+            Ok(())
+        })?;
 
         if args.json {
             machine::print_success(
@@ -64,10 +65,11 @@ fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
 
     if let Some(pattern) = args.git_remote.as_deref() {
         let store = WorkspaceStore::new(home);
-        let mut workspace_config = store.load()?;
         let normalized = normalize_remote_pattern(pattern);
-        upsert_git_remote_rule(&mut workspace_config, &normalized, &args.context);
-        store.save(&workspace_config)?;
+        store.update(|workspace_config| {
+            upsert_git_remote_rule(workspace_config, &normalized, &args.context);
+            Ok(())
+        })?;
 
         if args.json {
             machine::print_success(
@@ -126,13 +128,11 @@ fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
     }
 
     let store = WorkspaceStore::new(home);
-    let mut workspace_config = store.load()?;
-    upsert_path_rule(
-        &mut workspace_config,
-        &path.display().to_string(),
-        &args.context,
-    );
-    store.save(&workspace_config)?;
+    let path_text = path.display().to_string();
+    store.update(|workspace_config| {
+        upsert_path_rule(workspace_config, &path_text, &args.context);
+        Ok(())
+    })?;
 
     if args.json {
         machine::print_success(
@@ -140,7 +140,7 @@ fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
             json!({
                 "binding": {
                     "scope": "path",
-                    "path": path.display().to_string(),
+                    "path": path_text,
                     "context": args.context,
                 },
                 "project_bindings": project_bindings_snapshot(home, &cwd)?,
@@ -150,7 +150,7 @@ fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
     }
 
     output::print_title("Bound workspace path");
-    output::print_kv("Path", path.display().to_string());
+    output::print_kv("Path", &path_text);
     output::print_kv("Context", &args.context);
     output::print_effects_header();
     output::print_effect("User workspace path rule saved.");
@@ -162,12 +162,17 @@ fn unbind(args: WorkspaceUnbindArgs, home: &Path) -> Result<()> {
 
     if args.default {
         let store = WorkspaceStore::new(home);
-        let mut workspace_config = store.load()?;
-        let removed_context = workspace_config
-            .default_context
-            .take()
-            .context("default workspace context is not set")?;
-        store.save(&workspace_config)?;
+        let mut removed_context = None;
+        store.update(|workspace_config| {
+            removed_context = Some(
+                workspace_config
+                    .default_context
+                    .take()
+                    .context("default workspace context is not set")?,
+            );
+            Ok(())
+        })?;
+        let removed_context = removed_context.expect("workspace default removal result missing");
 
         if args.json {
             machine::print_success(
@@ -191,11 +196,16 @@ fn unbind(args: WorkspaceUnbindArgs, home: &Path) -> Result<()> {
 
     if let Some(pattern) = args.git_remote.as_deref() {
         let store = WorkspaceStore::new(home);
-        let mut workspace_config = store.load()?;
         let normalized = normalize_remote_pattern(pattern);
-        let removed_context = remove_git_remote_rule(&mut workspace_config, &normalized)
-            .with_context(|| format!("workspace remote rule '{}' not found", normalized))?;
-        store.save(&workspace_config)?;
+        let mut removed_context = None;
+        store.update(|workspace_config| {
+            removed_context = Some(
+                remove_git_remote_rule(workspace_config, &normalized)
+                    .with_context(|| format!("workspace remote rule '{}' not found", normalized))?,
+            );
+            Ok(())
+        })?;
+        let removed_context = removed_context.expect("workspace remote removal result missing");
 
         if args.json {
             machine::print_success(
@@ -257,11 +267,16 @@ fn unbind(args: WorkspaceUnbindArgs, home: &Path) -> Result<()> {
     }
 
     let store = WorkspaceStore::new(home);
-    let mut workspace_config = store.load()?;
     let path_text = path.display().to_string();
-    let removed_context = remove_path_rule(&mut workspace_config, &path_text)
-        .with_context(|| format!("workspace path rule '{}' not found", path_text))?;
-    store.save(&workspace_config)?;
+    let mut removed_context = None;
+    store.update(|workspace_config| {
+        removed_context = Some(
+            remove_path_rule(workspace_config, &path_text)
+                .with_context(|| format!("workspace path rule '{}' not found", path_text))?,
+        );
+        Ok(())
+    })?;
+    let removed_context = removed_context.expect("workspace path removal result missing");
 
     if args.json {
         machine::print_success(
@@ -451,9 +466,10 @@ fn doctor(args: WorkspaceDoctorArgs, home: &Path) -> Result<()> {
 
 fn guard(args: WorkspaceGuardArgs, home: &Path) -> Result<()> {
     let store = WorkspaceStore::new(home);
-    let mut config = store.load()?;
-    config.guard_mode = GuardMode::from(args.mode);
-    store.save(&config)?;
+    let config = store.update(|config| {
+        config.guard_mode = GuardMode::from(args.mode);
+        Ok(())
+    })?;
 
     if args.json {
         let cwd = std::env::current_dir().context("could not determine current directory")?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -719,6 +719,20 @@ mod tests {
     }
 
     #[test]
+    fn update_reports_workspace_lock_timeout() {
+        let temp = TempDir::new().unwrap();
+        let store = WorkspaceStore::new(temp.path());
+        let _lock = store.acquire_lock().unwrap();
+
+        let error = store.update(|_| Ok(())).unwrap_err();
+
+        let message = format!("{error:#}");
+        assert!(message.contains("timed out waiting for workspace config lock"));
+        assert!(message.contains("workspaces.json.lock"));
+        assert!(message.contains("retry after it finishes"));
+    }
+
+    #[test]
     fn normalize_remote_variants() {
         assert_eq!(
             normalize_remote("git@github.com:acme/api.git"),

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io::ErrorKind;
 use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
 use crate::commands::status::{
@@ -14,6 +17,8 @@ use crate::types::Tool;
 
 const WORKSPACES_VERSION: u32 = 1;
 const WORKSPACES_FILE: &str = "workspaces.json";
+const WORKSPACES_LOCK_FILE: &str = "workspaces.json.lock";
+const WORKSPACES_LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
 const REPO_LOCAL_FILE: &str = "aisw.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -130,12 +135,14 @@ fn workspace_version() -> u32 {
 
 pub struct WorkspaceStore {
     path: PathBuf,
+    lock_path: PathBuf,
 }
 
 impl WorkspaceStore {
     pub fn new(home: &Path) -> Self {
         Self {
             path: home.join(WORKSPACES_FILE),
+            lock_path: home.join(WORKSPACES_LOCK_FILE),
         }
     }
 
@@ -144,6 +151,21 @@ impl WorkspaceStore {
     }
 
     pub fn load(&self) -> Result<WorkspaceConfig> {
+        self.load_unlocked()
+    }
+
+    pub fn update<F>(&self, mutate: F) -> Result<WorkspaceConfig>
+    where
+        F: FnOnce(&mut WorkspaceConfig) -> Result<()>,
+    {
+        let _lock = self.acquire_lock()?;
+        let mut config = self.load_unlocked()?;
+        mutate(&mut config)?;
+        self.save_unlocked(&config)?;
+        Ok(config)
+    }
+
+    fn load_unlocked(&self) -> Result<WorkspaceConfig> {
         if !self.path.exists() {
             return Ok(WorkspaceConfig::default());
         }
@@ -158,6 +180,11 @@ impl WorkspaceStore {
     }
 
     pub fn save(&self, config: &WorkspaceConfig) -> Result<()> {
+        let _lock = self.acquire_lock()?;
+        self.save_unlocked(config)
+    }
+
+    fn save_unlocked(&self, config: &WorkspaceConfig) -> Result<()> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent)
                 .with_context(|| format!("could not create directory {}", parent.display()))?;
@@ -169,6 +196,52 @@ impl WorkspaceStore {
         fs::rename(&tmp, &self.path)
             .with_context(|| format!("could not move {}", self.path.display()))?;
         Ok(())
+    }
+
+    fn acquire_lock(&self) -> Result<WorkspaceLockGuard> {
+        if let Some(parent) = self.lock_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("could not create directory {}", parent.display()))?;
+        }
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&self.lock_path)
+            .with_context(|| format!("could not open {}", self.lock_path.display()))?;
+        set_file_permissions_600(&self.lock_path)?;
+
+        let started = Instant::now();
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => return Ok(WorkspaceLockGuard { file }),
+                Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                    if started.elapsed() >= WORKSPACES_LOCK_WAIT_TIMEOUT {
+                        anyhow::bail!(
+                            "timed out waiting for workspace config lock at {}.\n  \
+                             Another aisw workspace command may still be running; retry after it finishes.",
+                            self.lock_path.display()
+                        );
+                    }
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                Err(err) => {
+                    return Err(err)
+                        .with_context(|| format!("could not lock {}", self.lock_path.display()));
+                }
+            }
+        }
+    }
+}
+
+struct WorkspaceLockGuard {
+    file: fs::File,
+}
+
+impl Drop for WorkspaceLockGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
     }
 }
 
@@ -591,6 +664,54 @@ mod tests {
     use super::*;
     use crate::config::{ContextEntry, ContextProfiles};
     use tempfile::TempDir;
+
+    #[test]
+    fn concurrent_updates_preserve_both_changes() {
+        use std::sync::{mpsc, Arc, Barrier};
+        use std::time::Duration;
+
+        let temp = TempDir::new().unwrap();
+        let store = Arc::new(WorkspaceStore::new(temp.path()));
+        let first_entered = Arc::new(Barrier::new(2));
+        let (release_first_tx, release_first_rx) = mpsc::channel();
+        let (second_entered_tx, second_entered_rx) = mpsc::channel();
+
+        let first_store = Arc::clone(&store);
+        let first_entered_clone = Arc::clone(&first_entered);
+        let first = std::thread::spawn(move || {
+            first_store
+                .update(|config| {
+                    config.default_context = Some("first".to_owned());
+                    first_entered_clone.wait();
+                    release_first_rx.recv().unwrap();
+                    Ok(())
+                })
+                .unwrap();
+        });
+
+        first_entered.wait();
+        let second_store = Arc::clone(&store);
+        let second = std::thread::spawn(move || {
+            second_store
+                .update(|config| {
+                    second_entered_tx.send(()).unwrap();
+                    config.guard_mode = GuardMode::Strict;
+                    Ok(())
+                })
+                .unwrap();
+        });
+        assert!(second_entered_rx
+            .recv_timeout(Duration::from_millis(100))
+            .is_err());
+
+        release_first_tx.send(()).unwrap();
+        first.join().unwrap();
+        second.join().unwrap();
+
+        let config = store.load().unwrap();
+        assert_eq!(config.default_context.as_deref(), Some("first"));
+        assert_eq!(config.guard_mode, GuardMode::Strict);
+    }
 
     #[test]
     fn normalize_remote_variants() {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -220,7 +220,7 @@ impl WorkspaceStore {
                     if matches!(
                         err.kind(),
                         ErrorKind::WouldBlock | ErrorKind::PermissionDenied
-                    ) =>
+                    ) || err.raw_os_error() == Some(33) =>
                 {
                     if started.elapsed() >= WORKSPACES_LOCK_WAIT_TIMEOUT {
                         anyhow::bail!(

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -216,7 +216,12 @@ impl WorkspaceStore {
         loop {
             match file.try_lock_exclusive() {
                 Ok(()) => return Ok(WorkspaceLockGuard { file }),
-                Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                Err(err)
+                    if matches!(
+                        err.kind(),
+                        ErrorKind::WouldBlock | ErrorKind::PermissionDenied
+                    ) =>
+                {
                     if started.elapsed() >= WORKSPACES_LOCK_WAIT_TIMEOUT {
                         anyhow::bail!(
                             "timed out waiting for workspace config lock at {}.\n  \


### PR DESCRIPTION
Closes #82

## Why

Workspace bindings are often changed by shell hooks, IDE tasks, and parallel agent sessions. Previously, two commands could read the same `workspaces.json` and atomically replace it, silently discarding one successful update.

## What changed

- Add a sibling lock file and bounded cross-process wait for workspace mutations.
- Provide a locked read-modify-write operation and route user-level `bind`, `unbind`, and `guard` mutations through it.
- Preserve atomic replacement and restrictive file permissions.
- Treat Windows lock contention consistently with Unix contention and keep timeout guidance actionable.
- Add deterministic concurrent-writer and lock-timeout regressions.

## Trade-offs

The lock is file-backed rather than process-local, so separate aisw processes coordinate on macOS, Linux, and Windows. Read-only resolution remains unlocked. Repo-local binding files are independent single-record files and are outside this user-store lost-update boundary.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo build --release --locked`
- `cargo test --locked` — 577 passed, 1 ignored
- `bash tests/completions_smoke.sh`
- pre-commit and pre-push hooks passed
