### PR TITLE
Roll back failed profile removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `aisw doctor` no longer reports a false `credentials file missing` failure for every Gemini profile. It now checks the files a profile actually stores rather than one hardcoded name per tool, which also stopped `aisw verify` from inheriting the failure.
 - Antigravity is now guarded by the generated shell hooks and included in `workspace status --json` and `status --context --json`.
 - OAuth capture no longer leaves an orphaned interactive login process when a step inside the polling loop fails.
+- Failed profile removals now attempt to restore the fresh backup and report when automatic recovery is incomplete.
 
 ### Performance
 

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -525,6 +525,10 @@ mod tests {
             None,
         )
         .unwrap();
+        let profile_file = ps
+            .profile_dir(Tool::Claude, "work")
+            .join(".credentials.json");
+        let expected_profile_file = fs::read(&profile_file).unwrap();
         fs::create_dir(tmp.path().join("config.json.tmp")).unwrap();
 
         let err = run_inner(
@@ -542,6 +546,7 @@ mod tests {
 
         assert!(format!("{err:#}").contains("profile removal failed"));
         assert!(ps.exists(Tool::Claude, "work"));
+        assert_eq!(fs::read(profile_file).unwrap(), expected_profile_file);
         assert!(cs
             .load()
             .unwrap()

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -120,15 +120,30 @@ pub(crate) fn run_inner(args: RemoveArgs, home: &Path, confirmed: bool) -> Resul
         .nth(2)
         .and_then(|path| path.file_name())
         .and_then(|name| name.to_str())
-        .map(str::to_owned);
+        .map(str::to_owned)
+        .context("could not determine backup id after creating removal backup")?;
 
-    if profile_meta.credential_backend == crate::config::CredentialBackend::SystemKeyring {
-        auth::secure_store::delete_profile_secret(args.tool, profile_name)?;
+    let removal_result = (|| -> Result<()> {
+        if profile_meta.credential_backend == crate::config::CredentialBackend::SystemKeyring {
+            auth::secure_store::delete_profile_secret(args.tool, profile_name)?;
+        }
+        profile_store.delete(args.tool, profile_name)?;
+        // `remove_profile` also clears `active` in the same locked mutation, so
+        // there is no window where `active` names a profile that no longer exists.
+        config_store.remove_profile(args.tool, profile_name)?;
+        Ok(())
+    })();
+
+    if let Err(err) = removal_result {
+        let rollback_result =
+            BackupManager::new(home).restore(&backup_id, &profile_store, &config_store);
+        return Err(match rollback_result {
+            Ok(()) => err.context("profile removal failed; restored the profile from its backup"),
+            Err(rollback_err) => err
+                .context("profile removal failed and automatic restoration was incomplete")
+                .context(format!("could not restore removal backup: {rollback_err}")),
+        });
     }
-    profile_store.delete(args.tool, profile_name)?;
-    // `remove_profile` also clears `active` in the same locked mutation, so
-    // there is no window where `active` names a profile that no longer exists.
-    config_store.remove_profile(args.tool, profile_name)?;
 
     if args.json {
         machine::print_success(
@@ -137,7 +152,7 @@ pub(crate) fn run_inner(args: RemoveArgs, home: &Path, confirmed: bool) -> Resul
                 "tool": args.tool.binary_name(),
                 "removed_profile": profile_name,
                 "was_active": is_active,
-                "backup_ids": backup_id.into_iter().collect::<Vec<_>>(),
+                "backup_ids": vec![backup_id],
                 "remaining_profiles": remaining_profiles(home, args.tool)?,
             }),
         )?;
@@ -495,6 +510,44 @@ mod tests {
         assert!(backups_dir.exists());
         let entries: Vec<_> = fs::read_dir(&backups_dir).unwrap().collect();
         assert!(!entries.is_empty());
+    }
+
+    #[test]
+    fn config_save_failure_restores_profile_from_removal_backup() {
+        let tmp = tempdir().unwrap();
+        let ps = ProfileStore::new(tmp.path());
+        let cs = ConfigStore::new(tmp.path());
+        auth::claude::add_api_key(
+            &ps,
+            &cs,
+            "work",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            None,
+        )
+        .unwrap();
+        fs::create_dir(tmp.path().join("config.json.tmp")).unwrap();
+
+        let err = run_inner(
+            RemoveArgs {
+                tool: Tool::Claude,
+                profile_name: Some("work".to_owned()),
+                yes: true,
+                force: true,
+                json: false,
+            },
+            tmp.path(),
+            true,
+        )
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("profile removal failed"));
+        assert!(ps.exists(Tool::Claude, "work"));
+        assert!(cs
+            .load()
+            .unwrap()
+            .profiles_for(Tool::Claude)
+            .contains_key("work"));
+        assert!(!BackupManager::new(tmp.path()).list().unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #80

## Why

`aisw remove` creates a recovery snapshot, but previously a failure after secure-credential or profile-file deletion could leave a partial removal behind. The backup existed, but the command did not use it as a rollback boundary.

## What changed

- Treat secure credential deletion, profile deletion, and locked metadata removal as one compensating operation.
- Restore the fresh backup when any destructive step fails.
- Preserve the original removal error and report incomplete automatic recovery separately.
- Keep the successful JSON backup-id shape as a string array.
- Verify that a real deleted profile file is restored when metadata persistence fails.

## Trade-offs

Recovery uses the already-created backup, keeping the change local to the removal workflow and preserving the existing explicit backup for user recovery. If restoration itself fails, the command reports both failures so the user can use the backup manually.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked`
- pre-commit hook: clippy, release build, 576 unit tests, integration suite, completion smoke
- pre-push hook: full test suite and release build
