### PR TITLE
Support Antigravity API key profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ aisw context use acme
 - Codex: shared-mode ChatGPT auth switching is explicitly unsupported.
 - Gemini: upstream stopped serving Google AI Pro, Ultra, and free-tier individual accounts through Gemini CLI on June 18, 2026; those users should migrate to Antigravity. Gemini CLI enterprise and API-key / Vertex AI paths remain supported. See the [upstream transition announcement](https://github.com/google-gemini/gemini-cli/discussions/28017).
 - Gemini: `aisw init` and `aisw add gemini ...` can still capture the currently live Gemini state for supported upstream auth modes, but you should start a fresh process after switching.
-- Antigravity: OAuth only. `--api-key` and `--from-env` are rejected, because upstream documents keyring-backed sign-in rather than API-key profile auth.
+- Antigravity: OAuth uses shared keyring state; API-key profiles use `GEMINI_API_KEY` with `--emit-env` or shell integration, and aisw selects `modelProvider: gemini`.
 - Antigravity: no documented per-profile auth root exists, so switching replaces the shared live session and `--state-mode` does not apply.
 
 </details>
@@ -333,7 +333,7 @@ The practical value is simple: `aisw use --all --profile personal` works when na
 
 Credentials are stored in the native OS keyring where available (macOS Keychain, Linux Secret Service, Windows Credential Manager) and fall back to local files with `0600` permissions.
 
-Antigravity is OAuth-only: upstream documents keyring-backed sign-in rather than API-key profile auth, so `--api-key` and `--from-env` are rejected for it. It also has no documented per-profile auth root like `CODEX_HOME`, so `aisw` switches its shared live session rather than isolating it, and `--state-mode` does not apply.
+Antigravity supports shared OAuth keyring sign-in and Gemini API-key auth. API-key profiles use `GEMINI_API_KEY` with `--emit-env` or the shell hook; aisw selects the required `modelProvider: gemini` setting. It has no documented per-profile auth root like `CODEX_HOME`, so OAuth switching remains shared and `--state-mode` does not apply.
 
 \* Gemini CLI no longer serves Google AI Pro, Ultra, or free-tier individual accounts; those users should use Antigravity instead. Gemini CLI enterprise and API-key / Vertex AI users remain supported.
 

--- a/docs/acceptance-matrix.md
+++ b/docs/acceptance-matrix.md
@@ -11,7 +11,7 @@ The baseline below records the upstream releases checked against `aisw` `0.3.8` 
 | Claude Code | `v2.1.263` | macOS, Linux, Windows | `cargo test --locked`; file credentials and system-keyring paths in the status above | Pass for `aisw`-supported paths; macOS Keychain behavior remains acceptance-matrix-limited | [release](https://github.com/anthropics/claude-code/releases/tag/v2.1.263), [CLI usage](https://docs.anthropic.com/en/docs/claude-code/cli-usage) |
 | Codex CLI | `rust-v0.153.4` | macOS, Linux, Windows | `cargo test --locked`; isolated ChatGPT auth, file API keys, and shared-mode guard | Pass for `aisw`-supported paths | [release](https://github.com/openai/codex/releases/tag/rust-v0.153.4) |
 | Gemini CLI | `v0.58.0` | macOS, Linux, Windows | `cargo test --locked`; file/API-key/Vertex paths and the documented individual-tier sunset | Pass for supported paths; Google AI Pro, Ultra, and free-tier individual accounts are upstream-sunset | [release](https://github.com/google-gemini/gemini-cli/releases/tag/v0.58.0), [sunset announcement](https://github.com/google-gemini/gemini-cli/discussions/28017) |
-| Antigravity CLI | `1.1.27` | macOS, Linux, Windows | `cargo test --locked`; shared OAuth keyring and documented config-root paths | Pass for `aisw`-supported shared OAuth paths; upstream API-key mode is not yet managed by `aisw` | [release](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.27), [authentication docs](https://antigravity.google/docs/cli-install?app=antigravity) |
+| Antigravity CLI | `1.1.27` | macOS, Linux, Windows | `cargo test --locked`; shared OAuth keyring, Gemini API-key environment path, and documented config-root paths | Pass for `aisw`-supported OAuth and API-key paths; API-key switching requires `--emit-env` or shell integration | [release](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.27), [authentication docs](https://antigravity.google/docs/cli/install) |
 
 ## Status
 
@@ -29,6 +29,7 @@ The baseline below records the upstream releases checked against `aisw` `0.3.8` 
 | Gemini CLI | Google AI Pro, Ultra, or free-tier individual account | Upstream sunset | Not supported by upstream | Gemini CLI stopped serving these individual-account tiers on June 18, 2026; migrate to Antigravity | [upstream announcement](https://github.com/google-gemini/gemini-cli/discussions/28017) |
 | Gemini CLI | System keyring | Not supported | Not supported | Gemini remains file-managed in `aisw` because upstream behavior is file-centric | Product policy; see [supported-tools.md](./supported-tools.md) |
 | Antigravity CLI | Shared live OAuth keyring auth plus documented `~/.gemini` config roots | Supported via `add` / `--from-live` | Supported | Restores the shared live OS keyring session plus `~/.gemini/antigravity-cli/` and `~/.gemini/config/`; upstream does not currently document an isolated per-profile auth root | `src/auth/antigravity.rs`, `src/commands/add.rs`, `src/commands/use_.rs`, full `cargo test` |
+| Antigravity CLI | Gemini API-key environment auth | Supported via `--api-key` / `--from-env` | Supported with `--emit-env` or shell integration | Stores the key in the selected managed backend, selects `modelProvider: gemini`, and exports `GEMINI_API_KEY` for `agy` | `src/auth/antigravity.rs`, `src/commands/add.rs`, full `cargo test` |
 
 ## Notes
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -127,14 +127,14 @@ Notes:
 - `add` refuses to store the same account twice. For OAuth it compares the resolved account identity; for API keys it compares the key itself. The error names the existing profile, so re-running `add` with a key you already stored fails rather than creating a second name for it.
 - `--credential-backend` affects the managed `aisw` profile only. It does not force the upstream CLI's live auth backend.
 - Gemini supports only `file`. Claude, Codex, and Antigravity support `file` and `system-keyring`. Stored config and status output use `system_keyring`.
-- Antigravity is OAuth-only: `--api-key`, `--api-key-stdin`, and `--from-env` are rejected for it, because upstream documents keyring-backed sign-in rather than API-key profile auth. Use `aisw add antigravity <name>` or `--from-live`.
+- Antigravity supports shared OAuth keyring profiles and Gemini API-key profiles. API-key profiles use `GEMINI_API_KEY`; use `aisw use antigravity <name> --emit-env` (or the shell hook), and aisw selects `modelProvider: gemini` in Antigravity's settings.
 - API keys must be a single line. A key containing a newline or other control character is rejected  -  usually a stray newline from copy/paste or from piping a file into `--api-key`.
 
 Live credential locations by tool:
 - Claude: `~/.claude/.credentials.json` or the macOS Keychain
 - Codex: `~/.codex/auth.json` or the OS keyring
 - Gemini: `~/.gemini/.env` (API key) or OAuth files in `~/.gemini/`
-- Antigravity: live OS keyring auth plus config/state under `~/.gemini/antigravity-cli/` and `~/.gemini/config/`
+- Antigravity: OAuth uses the live OS keyring plus config/state under `~/.gemini/antigravity-cli/` and `~/.gemini/config/`; API-key profiles use `GEMINI_API_KEY` plus `modelProvider: gemini` in `~/.gemini/antigravity-cli/settings.json`.
 
 ```sh
 aisw add claude work --api-key "$ANTHROPIC_API_KEY"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -74,7 +74,7 @@ aisw add gemini personal
 aisw add antigravity work
 ```
 
-Antigravity is OAuth-only  -  it has no API-key path, so `--api-key` and `--from-env` are rejected for it.
+Antigravity supports shared OAuth and Gemini API-key profiles. API-key profiles use `GEMINI_API_KEY`; run `aisw use antigravity <profile> --emit-env` or use the shell hook so the key reaches `agy`.
 
 **Capture whatever is logged in right now** (no login flow is launched):
 

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -12,7 +12,7 @@ description: Claude Code, Codex CLI, Gemini CLI, and Antigravity CLI support mat
 | Claude Code | `claude` | OAuth, API key | Full | Full | Full |
 | Codex CLI | `codex` | OAuth, API key | Full | Full | Full |
 | Gemini CLI | `gemini` | Enterprise auth, Vertex AI, API key | Full* | Full* | Full* |
-| Antigravity CLI | `agy` | OAuth | Full | Full | Full |
+| Antigravity CLI | `agy` | OAuth, API key | Full | Full | Full |
 
 `aisw status` reports whether the detected release matches the audited
 compatibility baseline. A non-verified release is a warning, not an automatic
@@ -108,7 +108,7 @@ API key profiles store a `.env` file containing `GEMINI_API_KEY=<key>`. This is 
 - Live config/state: `~/.gemini/antigravity-cli/` and `~/.gemini/config/`
 - `--from-live`: captures the current live keyring-backed session plus both documented config roots.
 - Interactive OAuth: launches `agy`, captures the resulting live keyring/config state, and restores the prior live state unless `--set-active` is requested.
-- No API-key path in `aisw` because upstream Antigravity docs currently describe OAuth/keyring auth, not API-key profile auth.
+- API-key path: `GEMINI_API_KEY` with `modelProvider: gemini` in `~/.gemini/antigravity-cli/settings.json`; use the shell hook or `--emit-env` so the key reaches `agy`.
 - No `--state-mode` support because upstream does not currently document an isolated per-profile auth or data root.
 
 ## Auth backend support matrix
@@ -124,6 +124,7 @@ API key profiles store a `.env` file containing `GEMINI_API_KEY=<key>`. This is 
 | Gemini CLI | System keyring | Not supported | Not supported | Gemini does not use keyring for credentials |
 | Antigravity CLI | File-backed managed profile + live OS keyring apply | Supported | Supported | Stores captured secret in the profile, then restores it into the live keyring on switch |
 | Antigravity CLI | System keyring-backed managed profile | Supported | Supported | Stores the captured live keyring secret in `aisw`'s managed keyring backend |
+| Antigravity CLI | API-key profile via `GEMINI_API_KEY` | Supported | Supported with `--emit-env` or shell hook | Stores the key using the selected profile backend and selects the Gemini API-key provider |
 
 **Fail-closed** means `aisw` refuses the operation rather than guessing. This applies specifically to Codex when the keyring account identifier cannot be read from the live credential store.
 

--- a/src/auth/antigravity.rs
+++ b/src/auth/antigravity.rs
@@ -17,6 +17,7 @@ use crate::types::Tool;
 
 pub(crate) const KEYRING_METADATA_FILE: &str = "keyring.json";
 const SECRET_FILE: &str = "keyring-secret.json";
+const API_KEY_FILE: &str = "api-key.json";
 const APP_PREFIX: &str = "app";
 const SHARED_PREFIX: &str = "shared";
 const OAUTH_TIMEOUT: Duration = Duration::from_secs(180);
@@ -26,18 +27,21 @@ const KEYRING_ACCOUNT: &str = "antigravity";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AntigravityAuthClassification {
     OauthSharedLiveKeyring,
+    ApiKeyEnvironment,
 }
 
 impl AntigravityAuthClassification {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::OauthSharedLiveKeyring => "oauth_shared_live_keyring",
+            Self::ApiKeyEnvironment => "api_key_environment",
         }
     }
 
     pub fn human_label(self) -> &'static str {
         match self {
             Self::OauthSharedLiveKeyring => "OAuth shared live keyring",
+            Self::ApiKeyEnvironment => "API key via GEMINI_API_KEY",
         }
     }
 }
@@ -77,10 +81,96 @@ pub fn classify_profile(
     auth_method: AuthMethod,
     _credential_backend: CredentialBackend,
 ) -> Result<AntigravityAuthClassification> {
-    if auth_method != AuthMethod::OAuth {
-        bail!("Antigravity currently supports OAuth profiles only");
+    if auth_method == AuthMethod::OAuth {
+        return Ok(AntigravityAuthClassification::OauthSharedLiveKeyring);
     }
-    Ok(AntigravityAuthClassification::OauthSharedLiveKeyring)
+    Ok(AntigravityAuthClassification::ApiKeyEnvironment)
+}
+
+pub fn add_api_key_with_backend(
+    profile_store: &ProfileStore,
+    config_store: &ConfigStore,
+    profile_name: &str,
+    key: &str,
+    label: Option<String>,
+    backend: CredentialBackend,
+) -> Result<()> {
+    crate::auth::validate_api_key_charset(
+        key,
+        "Antigravity",
+        "Get your Gemini API key at aistudio.google.com → Get API Key.",
+    )?;
+
+    if let Some(existing_name) = identity::existing_api_key_profile_for_secret(
+        profile_store,
+        config_store,
+        Tool::Antigravity,
+        key,
+    )? {
+        bail!(
+            "Antigravity API key already exists as profile '{}'.\n  \
+             Use that profile or provide a different API key.",
+            existing_name
+        );
+    }
+
+    profile_store.create(Tool::Antigravity, profile_name)?;
+    let result = (|| {
+        let credentials = serde_json::to_vec(&serde_json::json!({ "apiKey": key }))
+            .context("could not serialize Antigravity API key credentials")?;
+        match backend {
+            CredentialBackend::File => profile_store.write_file(
+                Tool::Antigravity,
+                profile_name,
+                API_KEY_FILE,
+                &credentials,
+            )?,
+            CredentialBackend::SystemKeyring => {
+                secure_store::write_profile_secret(Tool::Antigravity, profile_name, &credentials)?;
+            }
+        }
+        config_store.add_profile(
+            Tool::Antigravity,
+            profile_name,
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method: AuthMethod::ApiKey,
+                credential_backend: backend,
+                label,
+            },
+        )?;
+        Ok::<(), anyhow::Error>(())
+    })();
+    if result.is_err() {
+        let _ = profile_store.delete(Tool::Antigravity, profile_name);
+        if backend == CredentialBackend::SystemKeyring {
+            let _ = secure_store::delete_profile_secret(Tool::Antigravity, profile_name);
+        }
+    }
+    result
+}
+
+pub fn read_api_key(
+    profile_store: &ProfileStore,
+    profile_name: &str,
+    backend: CredentialBackend,
+) -> Result<String> {
+    let bytes = match backend {
+        CredentialBackend::File => {
+            profile_store.read_file(Tool::Antigravity, profile_name, API_KEY_FILE)?
+        }
+        CredentialBackend::SystemKeyring => {
+            secure_store::read_profile_secret(Tool::Antigravity, profile_name)?
+                .context("managed Antigravity API key is missing")?
+        }
+    };
+    let value: serde_json::Value =
+        serde_json::from_slice(&bytes).context("could not parse managed Antigravity API key")?;
+    value
+        .get("apiKey")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .context("managed Antigravity API key is missing apiKey field")
 }
 
 pub fn read_managed_secret(
@@ -311,6 +401,25 @@ pub fn apply_live_credentials(
     )
 }
 
+pub fn apply_api_key_settings(user_home: &Path) -> Result<()> {
+    let path = live_app_dir(user_home).join("settings.json");
+    let mut settings = if path.exists() {
+        let bytes =
+            fs::read(&path).with_context(|| format!("could not read {}", path.display()))?;
+        serde_json::from_slice::<serde_json::Value>(&bytes)
+            .with_context(|| format!("could not parse {}", path.display()))?
+    } else {
+        serde_json::json!({})
+    };
+    let object = settings
+        .as_object_mut()
+        .context("Antigravity settings must be a JSON object")?;
+    object.insert("modelProvider".to_owned(), serde_json::json!("gemini"));
+    let bytes =
+        serde_json::to_vec_pretty(&settings).context("could not serialize Antigravity settings")?;
+    crate::live_apply::apply_transaction(vec![LiveFileChange::write(path, bytes)])
+}
+
 fn build_apply_transaction(
     profile_store: &ProfileStore,
     profile_name: &str,
@@ -379,9 +488,22 @@ fn profile_tree_map(
 pub fn live_state_matches(
     profile_store: &ProfileStore,
     profile_name: &str,
+    auth_method: AuthMethod,
     backend: CredentialBackend,
     user_home: &Path,
 ) -> Result<bool> {
+    if auth_method == AuthMethod::ApiKey {
+        let managed = read_api_key(profile_store, profile_name, backend)?;
+        let live = std::env::var("GEMINI_API_KEY").unwrap_or_default();
+        let settings_path = live_app_dir(user_home).join("settings.json");
+        let provider_is_gemini = settings_path.exists()
+            && serde_json::from_slice::<serde_json::Value>(&fs::read(&settings_path)?)
+                .ok()
+                .and_then(|value| value.get("modelProvider").cloned())
+                .and_then(|value| value.as_str().map(|value| value == "gemini"))
+                .unwrap_or(false);
+        return Ok(!live.is_empty() && managed == live && provider_is_gemini);
+    }
     let keyring_ref = read_profile_keyring_ref(profile_store, profile_name)?;
     let managed_secret = read_managed_secret(profile_store, profile_name, backend)?;
     let live_secret = super::system_keyring::read_generic_password(
@@ -526,7 +648,18 @@ pub fn restore_snapshot_to_live(snapshot: &LiveSnapshot, user_home: &Path) -> Re
     }
 }
 
-pub fn emit_shell_env() {}
+pub fn emit_shell_env(
+    profile_store: &ProfileStore,
+    profile_name: &str,
+    auth_method: AuthMethod,
+    backend: CredentialBackend,
+) -> Result<()> {
+    if auth_method == AuthMethod::ApiKey {
+        let key = read_api_key(profile_store, profile_name, backend)?;
+        files::emit_export("GEMINI_API_KEY", &key);
+    }
+    Ok(())
+}
 
 fn persist_profile_keyring_ref(
     profile_store: &ProfileStore,
@@ -626,6 +759,12 @@ mod tests {
             unsafe { std::env::set_var(key, value) };
             Self { key, previous }
         }
+
+        fn set_value(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
     }
 
     impl Drop for EnvVarGuard {
@@ -710,10 +849,14 @@ mod tests {
 
         apply_live_credentials(&profile_store, "work", CredentialBackend::File, &user_home)
             .unwrap();
-        assert!(
-            live_state_matches(&profile_store, "work", CredentialBackend::File, &user_home)
-                .unwrap()
-        );
+        assert!(live_state_matches(
+            &profile_store,
+            "work",
+            AuthMethod::OAuth,
+            CredentialBackend::File,
+            &user_home,
+        )
+        .unwrap());
     }
 
     #[test]
@@ -731,6 +874,48 @@ mod tests {
             classification,
             AntigravityAuthClassification::OauthSharedLiveKeyring
         );
+        assert_eq!(
+            classify_profile(
+                &profile_store,
+                "work",
+                AuthMethod::ApiKey,
+                CredentialBackend::File,
+            )
+            .unwrap(),
+            AntigravityAuthClassification::ApiKeyEnvironment
+        );
+    }
+
+    #[test]
+    fn api_key_profile_matches_provider_and_environment() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let temp = tempdir().unwrap();
+        let home = temp.path().join("home");
+        let user_home = temp.path().join("user");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        let profile_store = ProfileStore::new(&home);
+        let config_store = ConfigStore::new(&home);
+        add_api_key_with_backend(
+            &profile_store,
+            &config_store,
+            "work",
+            "AIza-antigravity-test",
+            None,
+            CredentialBackend::File,
+        )
+        .unwrap();
+        let _key = EnvVarGuard::set_value("GEMINI_API_KEY", "AIza-antigravity-test");
+        apply_api_key_settings(&user_home).unwrap();
+
+        assert!(live_state_matches(
+            &profile_store,
+            "work",
+            AuthMethod::ApiKey,
+            CredentialBackend::File,
+            &user_home,
+        )
+        .unwrap());
     }
 
     #[test]
@@ -915,10 +1100,14 @@ mod tests {
         )
         .unwrap();
 
-        assert!(
-            !live_state_matches(&profile_store, "work", CredentialBackend::File, &user_home)
-                .unwrap()
-        );
+        assert!(!live_state_matches(
+            &profile_store,
+            "work",
+            AuthMethod::OAuth,
+            CredentialBackend::File,
+            &user_home,
+        )
+        .unwrap());
     }
 
     #[test]

--- a/src/auth/identity.rs
+++ b/src/auth/identity.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use serde_json::Value;
 
-use super::{claude, codex, gemini, secure_store};
+use super::{antigravity, claude, codex, gemini, secure_store};
 use crate::config::{AuthMethod, Config, ConfigStore, CredentialBackend};
 use crate::profile::ProfileStore;
 use crate::types::Tool;
@@ -190,7 +190,7 @@ fn read_api_key_for_profile(
         Tool::Claude => claude::read_api_key_with_backend(profile_store, profile_name, backend),
         Tool::Codex => codex::read_api_key_with_backend(profile_store, profile_name, backend),
         Tool::Gemini => gemini::read_api_key(profile_store, profile_name),
-        Tool::Antigravity => bail!("Antigravity CLI does not support API key profiles"),
+        Tool::Antigravity => antigravity::read_api_key(profile_store, profile_name, backend),
     }
 }
 

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -90,7 +90,7 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
             Tool::Claude => CLAUDE_ENV_VAR,
             Tool::Codex => CODEX_ENV_VAR,
             Tool::Gemini => GEMINI_ENV_VAR,
-            Tool::Antigravity => unreachable!("validated above"),
+            Tool::Antigravity => GEMINI_ENV_VAR,
         };
         let key = std::env::var(env_var).unwrap_or_default();
         if key.is_empty() {
@@ -121,7 +121,14 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
                 args.label.clone(),
                 backend,
             )?,
-            Tool::Antigravity => unreachable!("validated above"),
+            Tool::Antigravity => auth::antigravity::add_api_key_with_backend(
+                &profile_store,
+                &config_store,
+                &args.profile_name,
+                &key,
+                args.label.clone(),
+                backend,
+            )?,
         }
         if args.set_active {
             config_store.set_active(args.tool, &args.profile_name)?;
@@ -162,7 +169,14 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
                 args.label.clone(),
                 backend,
             )?,
-            Tool::Antigravity => unreachable!("validated above"),
+            Tool::Antigravity => auth::antigravity::add_api_key_with_backend(
+                &profile_store,
+                &config_store,
+                &args.profile_name,
+                api_key,
+                args.label.clone(),
+                backend,
+            )?,
         }
         (backend, AuthMethod::ApiKey, None)
     } else {
@@ -1275,18 +1289,6 @@ fn validate_auth_source_support(args: &AddArgs) -> Result<()> {
     if args.tool != Tool::Antigravity {
         return Ok(());
     }
-    if args.from_env {
-        bail!(
-            "Antigravity CLI does not document API-key or environment-variable authentication.\n  \
-             Use interactive OAuth or --from-live instead."
-        );
-    }
-    if args.api_key.is_some() || args.api_key_stdin {
-        bail!(
-            "Antigravity CLI support in aisw is OAuth-only because upstream documents system-keyring-backed sign-in, not API-key profile auth.\n  \
-             Use 'aisw add antigravity <name>' or 'aisw add antigravity <name> --from-live'."
-        );
-    }
     Ok(())
 }
 
@@ -1343,12 +1345,18 @@ fn print_add_summary(
         output::print_effect("This is the durable ChatGPT-managed Codex path.");
     }
     if args.tool == Tool::Antigravity {
-        output::print_effect(
-            "Antigravity OAuth is restored through the shared live OS keyring entry and the documented ~/.gemini config roots.",
-        );
-        output::print_effect(
-            "Upstream does not currently document an isolated per-profile auth root or profile selector for Antigravity.",
-        );
+        if auth_method == AuthMethod::ApiKey {
+            output::print_effect(
+                "Antigravity API-key auth uses GEMINI_API_KEY; use the shell hook or --emit-env when running agy.",
+            );
+        } else {
+            output::print_effect(
+                "Antigravity OAuth is restored through the shared live OS keyring entry and the documented ~/.gemini config roots.",
+            );
+            output::print_effect(
+                "Upstream does not currently document an isolated per-profile auth root or profile selector for Antigravity.",
+            );
+        }
     }
     for warning in add_warnings(args.tool, auth_method, user_home) {
         output::print_effect(warning);
@@ -1438,8 +1446,13 @@ fn codex_add_classification(
 }
 
 fn antigravity_add_classification(tool: Tool, auth_method: AuthMethod) -> Option<&'static str> {
-    (tool == Tool::Antigravity && auth_method == AuthMethod::OAuth)
-        .then_some("oauth_shared_live_keyring")
+    if tool != Tool::Antigravity {
+        return None;
+    }
+    Some(match auth_method {
+        AuthMethod::OAuth => "oauth_shared_live_keyring",
+        AuthMethod::ApiKey => "api_key_environment",
+    })
 }
 
 fn claude_add_classification(
@@ -1475,6 +1488,11 @@ fn add_warnings(tool: Tool, auth_method: AuthMethod, user_home: Option<&Path>) -
     if tool == Tool::Antigravity && auth_method == AuthMethod::OAuth {
         return vec![
             "Antigravity currently documents shared live OS-keyring auth, not an isolated per-profile auth root. aisw switches the live keyring-backed session and Antigravity config roots transactionally.".to_owned(),
+        ];
+    }
+    if tool == Tool::Antigravity && auth_method == AuthMethod::ApiKey {
+        return vec![
+            "Antigravity API-key profiles use GEMINI_API_KEY and require --emit-env (or the shell hook); aisw also selects modelProvider=gemini in Antigravity settings.".to_owned(),
         ];
     }
     if tool == Tool::Gemini && auth_method == AuthMethod::OAuth {
@@ -1912,36 +1930,47 @@ mod tests {
     }
 
     #[test]
-    fn antigravity_from_env_is_rejected_before_tool_detection() {
+    fn antigravity_from_env_creates_api_key_profile() {
         with_env_lock(|| {
+            let _key = EnvVarGuard::set("GEMINI_API_KEY", "AIza-antigravity-test");
             let tmp = tempdir().unwrap();
             let home = tmp.path().join("home");
+            let bin_dir = tmp.path().join("bin");
             fs::create_dir_all(&home).unwrap();
+            fs::create_dir_all(&bin_dir).unwrap();
+            make_fake_binary(&bin_dir, "agy");
 
-            let err = run_in(
+            run_in(
                 from_env_args(Tool::Antigravity, "work"),
                 &home,
-                OsString::new(),
+                path_of(&bin_dir),
             )
-            .unwrap_err();
-            assert!(
-                err.to_string()
-                    .contains("does not document API-key or environment-variable authentication"),
-                "unexpected: {err}"
+            .unwrap();
+            let config = ConfigStore::new(&home).load().unwrap();
+            assert_eq!(config.active_for(Tool::Antigravity), None);
+            assert_eq!(
+                config.profiles_for(Tool::Antigravity)["work"].auth_method,
+                AuthMethod::ApiKey
             );
         });
     }
 
     #[test]
-    fn antigravity_api_key_auth_is_rejected_before_tool_detection() {
+    fn antigravity_api_key_auth_creates_profile() {
         with_env_lock(|| {
             let tmp = tempdir().unwrap();
             let home = tmp.path().join("home");
+            let bin_dir = tmp.path().join("bin");
             fs::create_dir_all(&home).unwrap();
+            fs::create_dir_all(&bin_dir).unwrap();
+            make_fake_binary(&bin_dir, "agy");
 
-            let args = add_args_api_key(Tool::Antigravity, "work", "AIza-not-supported");
-            let err = run_in(args, &home, OsString::new()).unwrap_err();
-            assert!(err.to_string().contains("OAuth-only"), "unexpected: {err}");
+            let args = add_args_api_key(Tool::Antigravity, "work", "AIza-antigravity-test");
+            run_in(args, &home, path_of(&bin_dir)).unwrap();
+            let profile = ProfileStore::new(&home);
+            assert!(profile
+                .read_file(Tool::Antigravity, "work", "api-key.json")
+                .is_ok());
         });
     }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -137,6 +137,7 @@ fn assess_live_state(
         Tool::Antigravity => auth::antigravity::live_state_matches(
             profile_store,
             profile_name,
+            auth_method,
             credential_backend,
             user_home,
         )?,
@@ -455,7 +456,8 @@ fn check_profile_storage(
                 (Tool::Codex, _) => "auth.json",
                 (Tool::Gemini, AuthMethod::ApiKey) => ".env",
                 (Tool::Gemini, AuthMethod::OAuth) => "oauth_creds.json",
-                (Tool::Antigravity, _) => "keyring-secret.json",
+                (Tool::Antigravity, AuthMethod::OAuth) => "keyring-secret.json",
+                (Tool::Antigravity, AuthMethod::ApiKey) => "api-key.json",
             };
             if files.iter().any(|file| file.file_name == primary) {
                 CredentialState::Present

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -478,7 +478,14 @@ pub(crate) fn apply_resolved_profile_switch(
         }
         Tool::Antigravity => {
             if emit_env {
-                auth::antigravity::emit_shell_env();
+                auth::antigravity::emit_shell_env(
+                    &profile_store,
+                    &resolved.profile_name,
+                    resolved.profile_meta.auth_method,
+                    resolved.profile_meta.credential_backend,
+                )?;
+            } else if resolved.profile_meta.auth_method == AuthMethod::ApiKey {
+                auth::antigravity::apply_api_key_settings(user_home)?;
             } else {
                 auth::antigravity::apply_live_credentials(
                     &profile_store,
@@ -671,12 +678,18 @@ fn print_switch_summary(resolved: &ResolvedProfileSwitch, home: &Path, user_home
             }
         }
     } else if resolved.tool == Tool::Antigravity {
-        output::print_effect(
-            "Antigravity switching restores the shared live OS keyring credential and the documented ~/.gemini config roots for this profile.",
-        );
-        output::print_effect(
-            "Upstream does not currently document an isolated per-profile auth root or profile selector for Antigravity.",
-        );
+        if resolved.profile_meta.auth_method == AuthMethod::ApiKey {
+            output::print_effect(
+                "Antigravity selected modelProvider=gemini; use the shell hook or --emit-env so GEMINI_API_KEY is available to agy.",
+            );
+        } else {
+            output::print_effect(
+                "Antigravity switching restores the shared live OS keyring credential and the documented ~/.gemini config roots for this profile.",
+            );
+            output::print_effect(
+                "Upstream does not currently document an isolated per-profile auth root or profile selector for Antigravity.",
+            );
+        }
     }
     output::print_blank_line();
     output::print_next_step(output::next_step_after_use());

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -138,11 +138,19 @@ fn tool_verification(tool: &status::ToolStatus) -> ToolVerification {
         VerifyStatus::Fail
     } else if tool.active_profile_applied == Some(false) {
         issues.push("live tool credentials do not match the recorded active profile".to_owned());
-        remediation.push(format!(
-            "Run 'aisw use {} {}' to reapply the active profile",
-            tool.tool.binary_name(),
-            tool.active_profile.as_deref().unwrap_or("<profile>")
-        ));
+        if tool.antigravity_auth_classification.as_deref() == Some("api_key_environment") {
+            remediation.push(format!(
+                "Run 'aisw use {} {} --emit-env' through the aisw shell hook so GEMINI_API_KEY reaches agy",
+                tool.tool.binary_name(),
+                tool.active_profile.as_deref().unwrap_or("<profile>")
+            ));
+        } else {
+            remediation.push(format!(
+                "Run 'aisw use {} {}' to reapply the active profile",
+                tool.tool.binary_name(),
+                tool.active_profile.as_deref().unwrap_or("<profile>")
+            ));
+        }
         VerifyStatus::Fail
     } else if tool.tool == Tool::Claude
         && tool.credential_backend.as_deref() == Some("file")

--- a/tests/add_cmd.rs
+++ b/tests/add_cmd.rs
@@ -965,24 +965,22 @@ fn add_antigravity_from_live_fails_without_live_credentials() {
 }
 
 #[test]
-fn add_antigravity_rejects_api_key_auth_paths() {
+fn add_antigravity_accepts_api_key_auth_paths() {
     let env = TestEnv::new();
     env.add_fake_tool("agy", "agy 1.0.0");
 
     env.cmd()
         .args(["add", "antigravity", "work", "--api-key", VALID_GEMINI_KEY])
         .assert()
-        .failure()
-        .stderr(contains("OAuth-only"))
-        .stderr(contains("Use 'aisw add antigravity <name>'"));
+        .success()
+        .stdout(contains("api_key_environment"));
 
     env.cmd()
-        .args(["add", "antigravity", "work", "--from-env"])
+        .env("GEMINI_API_KEY", "AIza-antigravity-env-key")
+        .args(["add", "antigravity", "env", "--from-env"])
         .assert()
-        .failure()
-        .stderr(contains(
-            "does not document API-key or environment-variable authentication",
-        ));
+        .success()
+        .stdout(contains("api_key_environment"));
 }
 
 #[test]

--- a/tests/status_cmd.rs
+++ b/tests/status_cmd.rs
@@ -308,6 +308,44 @@ fn status_json_reports_antigravity_classification_and_live_state() {
 }
 
 #[test]
+fn status_json_reports_antigravity_api_key_provider_state() {
+    let env = TestEnv::new();
+    env.add_fake_tool("agy", "agy 1.1.25");
+    env.cmd()
+        .args(["add", "antigravity", "work", "--api-key", VALID_GEMINI_KEY])
+        .assert()
+        .success();
+    env.cmd()
+        .env("GEMINI_API_KEY", VALID_GEMINI_KEY)
+        .args(["use", "antigravity", "work"])
+        .assert()
+        .success();
+
+    let output = env
+        .cmd()
+        .env("GEMINI_API_KEY", VALID_GEMINI_KEY)
+        .args(["status", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON");
+    let antigravity = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["tool"] == "agy")
+        .unwrap();
+    assert_eq!(antigravity["auth_method"], "api_key");
+    assert_eq!(
+        antigravity["antigravity_auth_classification"],
+        "api_key_environment"
+    );
+    assert_eq!(antigravity["active_profile_applied"], true);
+}
+
+#[test]
 fn status_context_json_wraps_tools_and_context_summary() {
     let env = TestEnv::new();
     add_and_activate_claude(&env, "acme-claude");

--- a/tests/use_cmd.rs
+++ b/tests/use_cmd.rs
@@ -39,6 +39,14 @@ fn add_codex_profile(env: &TestEnv, name: &str) {
         .success();
 }
 
+fn add_antigravity_api_key_profile(env: &TestEnv, name: &str) {
+    env.add_fake_tool("agy", "agy 1.1.25");
+    env.cmd()
+        .args(["add", "antigravity", name, "--api-key", VALID_GEMINI_KEY])
+        .assert()
+        .success();
+}
+
 fn antigravity_live_keyring_secret_path(env: &TestEnv) -> std::path::PathBuf {
     env.fake_home
         .join("keychain")
@@ -494,6 +502,33 @@ fn use_gemini_api_key_emit_env_prints_gemini_key() {
         .assert()
         .success()
         .stdout(contains("export GEMINI_API_KEY='"));
+}
+
+#[test]
+fn use_antigravity_api_key_selects_provider_and_emits_key() {
+    let env = TestEnv::new();
+    add_antigravity_api_key_profile(&env, "work");
+
+    env.cmd()
+        .args(["use", "antigravity", "work", "--emit-env"])
+        .assert()
+        .success()
+        .stdout(contains("export GEMINI_API_KEY='"));
+
+    env.cmd()
+        .env("GEMINI_API_KEY", VALID_GEMINI_KEY)
+        .args(["use", "antigravity", "work"])
+        .assert()
+        .success();
+    let settings = std::fs::read_to_string(
+        env.fake_home
+            .join(".gemini")
+            .join("antigravity-cli")
+            .join("settings.json"),
+    )
+    .unwrap();
+    let settings: serde_json::Value = serde_json::from_str(&settings).unwrap();
+    assert_eq!(settings["modelProvider"], "gemini");
 }
 
 #[test]

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -144,14 +144,14 @@ Notes:
 - `add` refuses to store the same account twice. For OAuth it compares the resolved account identity; for API keys it compares the key itself. The error names the existing profile, so re-running `add` with a key you already stored fails rather than creating a second name for it.
 - `--credential-backend` affects the managed `aisw` profile only. It does not force the upstream CLI's live auth backend.
 - Gemini supports only `file`. Claude, Codex, and Antigravity support `file` and `system-keyring`. Stored config and status output use `system_keyring`.
-- Antigravity is OAuth-only: `--api-key`, `--api-key-stdin`, and `--from-env` are rejected for it, because upstream documents keyring-backed sign-in rather than API-key profile auth. Use `aisw add antigravity <name>` or `--from-live`.
+- Antigravity supports shared OAuth keyring profiles and Gemini API-key profiles. API-key profiles use `GEMINI_API_KEY`; use `aisw use antigravity <name> --emit-env` (or the shell hook), and aisw selects `modelProvider: gemini` in Antigravity's settings.
 - API keys must be a single line. A key containing a newline or other control character is rejected  -  usually a stray newline from copy/paste or from piping a file into `--api-key`.
 
 Live credential locations by tool:
 - Claude: `~/.claude/.credentials.json` or the macOS Keychain
 - Codex: `~/.codex/auth.json` or the OS keyring
 - Gemini: `~/.gemini/.env` (API key) or OAuth files in `~/.gemini/`
-- Antigravity: live OS keyring auth plus config/state under `~/.gemini/antigravity-cli/` and `~/.gemini/config/`
+- Antigravity: OAuth uses the live OS keyring plus config/state under `~/.gemini/antigravity-cli/` and `~/.gemini/config/`; API-key profiles use `GEMINI_API_KEY` plus `modelProvider: gemini` in `~/.gemini/antigravity-cli/settings.json`.
 
 ```sh
 aisw add claude work --api-key "$ANTHROPIC_API_KEY"

--- a/website/src/content/docs/quickstart.md
+++ b/website/src/content/docs/quickstart.md
@@ -91,7 +91,7 @@ aisw add gemini personal
 aisw add antigravity work
 ```
 
-Antigravity is OAuth-only  -  it has no API-key path, so `--api-key` and `--from-env` are rejected for it.
+Antigravity supports shared OAuth and Gemini API-key profiles. API-key profiles use `GEMINI_API_KEY`; run `aisw use antigravity <profile> --emit-env` or use the shell hook so the key reaches `agy`.
 
 **Capture whatever is logged in right now** (no login flow is launched):
 

--- a/website/src/content/docs/supported-tools.md
+++ b/website/src/content/docs/supported-tools.md
@@ -29,7 +29,7 @@ head:
 | Claude Code | `claude` | OAuth, API key | Full | Full | Full |
 | Codex CLI | `codex` | OAuth, API key | Full | Full | Full |
 | Gemini CLI | `gemini` | Enterprise auth, Vertex AI, API key | Full* | Full* | Full* |
-| Antigravity CLI | `agy` | OAuth | Full | Full | Full |
+| Antigravity CLI | `agy` | OAuth, API key | Full | Full | Full |
 
 `aisw status` reports whether the detected release matches the audited
 compatibility baseline. A non-verified release is a warning, not an automatic
@@ -125,7 +125,7 @@ API key profiles store a `.env` file containing `GEMINI_API_KEY=<key>`. This is 
 - Live config/state: `~/.gemini/antigravity-cli/` and `~/.gemini/config/`
 - `--from-live`: captures the current live keyring-backed session plus both documented config roots.
 - Interactive OAuth: launches `agy`, captures the resulting live keyring/config state, and restores the prior live state unless `--set-active` is requested.
-- No API-key path in `aisw` because upstream Antigravity docs currently describe OAuth/keyring auth, not API-key profile auth.
+- API-key path: `GEMINI_API_KEY` with `modelProvider: gemini` in `~/.gemini/antigravity-cli/settings.json`; use the shell hook or `--emit-env` so the key reaches `agy`.
 - No `--state-mode` support because upstream does not currently document an isolated per-profile auth or data root.
 
 ## Auth backend support matrix
@@ -141,6 +141,7 @@ API key profiles store a `.env` file containing `GEMINI_API_KEY=<key>`. This is 
 | Gemini CLI | System keyring | Not supported | Not supported | Gemini does not use keyring for credentials |
 | Antigravity CLI | File-backed managed profile + live OS keyring apply | Supported | Supported | Stores captured secret in the profile, then restores it into the live keyring on switch |
 | Antigravity CLI | System keyring-backed managed profile | Supported | Supported | Stores the captured live keyring secret in `aisw`'s managed keyring backend |
+| Antigravity CLI | API-key profile via `GEMINI_API_KEY` | Supported | Supported with `--emit-env` or shell hook | Stores the key using the selected profile backend and selects the Gemini API-key provider |
 
 **Fail-closed** means `aisw` refuses the operation rather than guessing. This applies specifically to Codex when the keyring account identifier cannot be read from the live credential store.
 


### PR DESCRIPTION
Closes #96

## Why

The current Antigravity CLI supports headless/API-key authentication through `GEMINI_API_KEY` and `modelProvider: "gemini"`, but aisw treated Antigravity as OAuth-only. That left the documented non-interactive path unmanaged and made provider selection implicit.

## What changed

- Add explicit Antigravity API-key profiles through `--api-key` and `--from-env`.
- Store keys with the existing file or system-keyring profile backends.
- Select Gemini provider mode when applying an API-key profile.
- Export `GEMINI_API_KEY` through `--emit-env` and shell integration.
- Report API-key classification and live-state mismatches in status and verify.
- Preserve shared OAuth keyring behavior.
- Add unit, integration, and contract coverage plus compatibility/user docs.

## Trade-offs

A normal child `use` process cannot mutate its parent shell environment, so API-key profiles require `--emit-env` or the installed shell hook. Antigravity OAuth continues using the shared live keyring because the upstream CLI does not expose a documented isolated auth/data root.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (577 library tests plus all integration suites; one opt-in real credential-store canary ignored)
- `cargo build --release --locked`
- `bash tests/completions_smoke.sh`
- pre-push hook passed with full test and release build gates
