### PR TITLE
Clean up failed Gemini profile adds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `aisw doctor` no longer reports a false `credentials file missing` failure for every Gemini profile. It now checks the files a profile actually stores rather than one hardcoded name per tool, which also stopped `aisw verify` from inheriting the failure.
 - Antigravity is now guarded by the generated shell hooks and included in `workspace status --json` and `status --context --json`.
 - OAuth capture no longer leaves an orphaned interactive login process when a step inside the polling loop fails.
+- Failed Gemini API-key and OAuth registrations now remove the newly created profile when the config write fails.
 
 ### Performance
 

--- a/src/auth/gemini.rs
+++ b/src/auth/gemini.rs
@@ -196,15 +196,20 @@ pub fn add_api_key_with_backend(
         name,
     )?;
 
-    config_store.add_profile(
+    files::cleanup_profile_on_error(
+        config_store.add_profile(
+            Tool::Gemini,
+            name,
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method: AuthMethod::ApiKey,
+                credential_backend: backend,
+                label,
+            },
+        ),
+        profile_store,
         Tool::Gemini,
         name,
-        ProfileMeta {
-            added_at: Utc::now(),
-            auth_method: AuthMethod::ApiKey,
-            credential_backend: backend,
-            label,
-        },
     )?;
 
     Ok(())
@@ -344,15 +349,20 @@ fn add_oauth_with(
         name,
     )?;
 
-    config_store.add_profile(
+    files::cleanup_profile_on_error(
+        config_store.add_profile(
+            Tool::Gemini,
+            name,
+            ProfileMeta {
+                added_at: Utc::now(),
+                auth_method: AuthMethod::OAuth,
+                credential_backend: CredentialBackend::File,
+                label,
+            },
+        ),
+        profile_store,
         Tool::Gemini,
         name,
-        ProfileMeta {
-            added_at: Utc::now(),
-            auth_method: AuthMethod::OAuth,
-            credential_backend: CredentialBackend::File,
-            label,
-        },
     )?;
 
     // Best-effort identity display after capture
@@ -1055,6 +1065,24 @@ mod tests {
         assert!(!ps.exists(Tool::Gemini, "default"));
     }
 
+    #[test]
+    fn api_key_add_cleans_profile_when_config_save_fails() {
+        let dir = tempdir().unwrap();
+        let (ps, cs) = stores(dir.path());
+        cs.load().unwrap();
+        std::fs::create_dir(dir.path().join("config.json.tmp")).unwrap();
+
+        let err = add_api_key(&ps, &cs, "default", valid_key(), None).unwrap_err();
+
+        assert!(err.to_string().contains("config.json.tmp"));
+        assert!(!ps.exists(Tool::Gemini, "default"));
+        assert!(!cs
+            .load()
+            .unwrap()
+            .profiles_for(Tool::Gemini)
+            .contains_key("default"));
+    }
+
     // ---- OAuth tests ----
 
     // Poll interval used in all OAuth tests.
@@ -1125,6 +1153,38 @@ mod tests {
             .profile_dir(Tool::Gemini, "default")
             .join("oauth_creds.json")
             .exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn oauth_add_cleans_profile_when_config_save_fails() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempdir().unwrap();
+        let bin_dir = dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let bin = make_oauth_mock(&bin_dir, true, false);
+        let (ps, cs) = stores(dir.path());
+        cs.load().unwrap();
+        std::fs::create_dir(dir.path().join("config.json.tmp")).unwrap();
+
+        let err = add_oauth_with(
+            &ps,
+            &cs,
+            "default",
+            None,
+            &bin,
+            Duration::from_secs(2),
+            TEST_POLL,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("config.json.tmp"));
+        assert!(!ps.exists(Tool::Gemini, "default"));
+        assert!(!cs
+            .load()
+            .unwrap()
+            .profiles_for(Tool::Gemini)
+            .contains_key("default"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #74

## Why

Gemini add flows could create credential files before the final `config.json` registration. If registration failed, the command returned an error but left an orphaned managed profile behind, which could mislead later status and doctor checks.

## What changed

- Clean up Gemini API-key and OAuth profile state when config registration fails.
- Preserve the original registration error while keeping cleanup best-effort.
- Add regression coverage for API-key and OAuth rollback paths.
- Record the behavior in the changelog.

## Trade-offs

The cleanup helper is reused from the existing profile flows and does not replace the primary config error with a secondary cleanup error. This keeps the user-facing failure actionable while preventing orphaned credential state.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (578 library cases: 577 passed, 1 opt-in canary ignored; all integration suites passed)
- pre-push hook: full test and release build gates passed
