### PR TITLE
Sandbox Windows credential canary

### DIFF
--- a/src/auth/antigravity.rs
+++ b/src/auth/antigravity.rs
@@ -439,7 +439,7 @@ pub fn add_oauth_with_backend(
     agy_bin: &Path,
     backend: CredentialBackend,
 ) -> Result<()> {
-    let user_home = dirs::home_dir().context("could not determine home directory")?;
+    let user_home = crate::runtime::user_home().context("could not determine home directory")?;
     let before = capture_live_snapshot(&user_home)?;
     let mut child = Command::new(agy_bin)
         .spawn()

--- a/src/auth/claude/oauth.rs
+++ b/src/auth/claude/oauth.rs
@@ -315,7 +315,7 @@ pub(super) fn add_oauth_with(
 ) -> Result<()> {
     profile_store.create(Tool::Claude, name)?;
 
-    let user_home = dirs::home_dir().context("could not determine home directory")?;
+    let user_home = crate::runtime::user_home().context("could not determine home directory")?;
     let login_targets_profile_state = super::login_targets_profile_state(&user_home);
     let target_config_dir =
         login_targets_profile_state.then(|| profile_store.profile_dir(Tool::Claude, name));
@@ -340,7 +340,7 @@ pub(super) fn add_oauth_with(
         name,
     )?;
 
-    if let Some(user_home) = dirs::home_dir() {
+    if let Some(user_home) = crate::runtime::user_home() {
         files::cleanup_profile_on_error(
             persist_live_oauth_account_metadata(profile_store, name, &user_home),
             profile_store,

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -44,7 +44,8 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
     // Tool detection is intentionally skipped: the tool is already installed
     // and logged in, which is the prerequisite for --from-live to succeed.
     if args.from_live {
-        let user_home = dirs::home_dir().context("could not determine home directory")?;
+        let user_home =
+            crate::runtime::user_home().context("could not determine home directory")?;
         return from_live(args, home, &user_home);
     }
 
@@ -189,14 +190,14 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
                     Option<Vec<u8>>,
                     Option<std::path::PathBuf>,
                 ) = if args.set_active
-                    || dirs::home_dir()
+                    || crate::runtime::user_home()
                         .as_deref()
                         .is_some_and(auth::claude::login_targets_profile_state)
                 {
                     (None, None, None)
                 } else {
-                    let user_home =
-                        dirs::home_dir().context("could not determine home directory")?;
+                    let user_home = crate::runtime::user_home()
+                        .context("could not determine home directory")?;
                     (
                         auth::claude::live_credentials_snapshot_for_import(&user_home)?,
                         auth::claude::read_live_oauth_account_metadata_for_import(&user_home)?,
@@ -258,7 +259,8 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
             }
             Tool::Antigravity => {
                 let backend = requested_backend.unwrap_or(CredentialBackend::File);
-                let user_home = dirs::home_dir().context("could not determine home directory")?;
+                let user_home =
+                    crate::runtime::user_home().context("could not determine home directory")?;
                 let live_snapshot = (!args.set_active)
                     .then(|| auth::antigravity::capture_live_snapshot(&user_home))
                     .transpose()?;
@@ -300,7 +302,7 @@ pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<
         config_store.set_active(args.tool, &args.profile_name)?;
     }
 
-    let user_home = dirs::home_dir();
+    let user_home = crate::runtime::user_home();
     emit_add_result(
         &args,
         backend,

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -317,7 +317,7 @@ fn rename(args: ContextRenameArgs, home: &Path) -> Result<()> {
 fn use_context(_args: ContextUseArgs, _home: &Path) -> Result<()> {
     let args = _args;
     let home = _home;
-    let user_home = dirs::home_dir().context("could not determine home directory")?;
+    let user_home = crate::runtime::user_home().context("could not determine home directory")?;
     let store = ConfigStore::new(home);
     let config = store.load()?;
     let context = config

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -404,7 +404,7 @@ fn print_json(report: &DoctorReport) -> Result<()> {
 // ---- Entry point ----
 
 pub fn run(args: DoctorArgs, home: &Path) -> Result<bool> {
-    let user_home = dirs::home_dir().unwrap_or_else(|| Path::new(".").to_path_buf());
+    let user_home = crate::runtime::user_home().unwrap_or_else(|| Path::new(".").to_path_buf());
     let path_var = std::env::var_os("PATH").unwrap_or_default();
     run_in(args, home, &user_home, &path_var)
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -38,7 +38,7 @@ pub(crate) fn collect_rows(args: &ListArgs, home: &Path) -> Result<Vec<Row>> {
     let config_store = ConfigStore::new(home);
     let config = config_store.load()?;
     let profile_store = ProfileStore::new(home);
-    let user_home = dirs::home_dir().unwrap_or_else(|| Path::new(".").to_path_buf());
+    let user_home = crate::runtime::user_home().unwrap_or_else(|| Path::new(".").to_path_buf());
 
     let selected_tool = args.tool.or(args.tool_filter);
     let tools: Vec<Tool> = match selected_tool {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -35,7 +35,8 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Command::Rename(args) => rename::run(args, &home)?,
         Command::Status(args) => status::run(args, &home)?,
         Command::Init(args) => {
-            let user_home = dirs::home_dir().context("could not determine home directory")?;
+            let user_home =
+                crate::runtime::user_home().context("could not determine home directory")?;
             let shell_env = std::env::var("SHELL").ok().or_else(|| {
                 std::env::var("PSModulePath")
                     .ok()
@@ -54,7 +55,8 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             init::run_inner(&home, &user_home, shell_env.as_deref(), args.yes)?;
         }
         Command::Uninstall(args) => {
-            let user_home = dirs::home_dir().context("could not determine home directory")?;
+            let user_home =
+                crate::runtime::user_home().context("could not determine home directory")?;
             uninstall::run(args, &home, &user_home)?;
         }
         Command::ShellHook(args) => shell_hook::run(args)?,

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -67,7 +67,7 @@ impl DerivedContextStatus {
 }
 
 pub fn run(args: StatusArgs, home: &Path) -> Result<()> {
-    let user_home = dirs::home_dir().unwrap_or_else(|| Path::new(".").to_path_buf());
+    let user_home = crate::runtime::user_home().unwrap_or_else(|| Path::new(".").to_path_buf());
     run_in(
         args,
         home,

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -25,7 +25,7 @@ pub(crate) struct ResolvedProfileSwitch {
 }
 
 pub fn run(args: UseArgs, home: &Path) -> Result<()> {
-    let user_home = dirs::home_dir().context("could not determine home directory")?;
+    let user_home = crate::runtime::user_home().context("could not determine home directory")?;
     if args.all {
         let profile_name = args.all_profile.as_deref().unwrap_or_default();
         if profile_name.is_empty() {

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -49,7 +49,7 @@ struct VerifyReport {
 }
 
 pub fn run(args: VerifyArgs, home: &Path) -> Result<bool> {
-    let user_home = dirs::home_dir().unwrap_or_else(|| Path::new(".").to_path_buf());
+    let user_home = crate::runtime::user_home().unwrap_or_else(|| Path::new(".").to_path_buf());
     let path_var = std::env::var_os("PATH").unwrap_or_default();
     run_in(args, home, &user_home, path_var.as_os_str())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -198,7 +198,7 @@ impl ConfigStore {
         if let Ok(val) = std::env::var(AISW_HOME_ENV) {
             return Ok(PathBuf::from(val));
         }
-        let home = dirs::home_dir().context("could not determine home directory")?;
+        let home = crate::runtime::user_home().context("could not determine home directory")?;
         Ok(home.join(".aisw"))
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 #[cfg(not(test))]
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -87,4 +89,31 @@ pub fn is_progress_json() -> bool {
 
 pub fn is_machine_mode() -> bool {
     !matches!(output_mode(), OutputMode::Human)
+}
+
+/// Resolve the user's home directory, with a debug-only override for
+/// hermetic integration tests that exercise live tool state.
+pub fn user_home() -> Option<PathBuf> {
+    #[cfg(debug_assertions)]
+    if let Some(path) = crate::auth::test_overrides::string("AISW_TEST_USER_HOME") {
+        return Some(PathBuf::from(path));
+    }
+
+    dirs::home_dir()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::user_home;
+    use crate::auth::test_overrides::EnvVarGuard;
+    use tempfile::tempdir;
+
+    #[test]
+    fn user_home_honors_the_hermetic_test_override() {
+        let _spawn_lock = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let temp = tempdir().unwrap();
+        let _home = EnvVarGuard::set("AISW_TEST_USER_HOME", temp.path());
+
+        assert_eq!(user_home().as_deref(), Some(temp.path()));
+    }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -530,7 +530,7 @@ pub fn expand_tilde(path: &Path) -> Result<PathBuf> {
     let mut components = path.components();
     match components.next() {
         Some(Component::Normal(first)) if first == "~" => {
-            let home = dirs::home_dir().context("could not determine home directory")?;
+            let home = crate::runtime::user_home().context("could not determine home directory")?;
             let mut expanded = home;
             for component in components {
                 expanded.push(component.as_os_str());
@@ -710,7 +710,7 @@ mod tests {
     #[test]
     fn expand_tilde_expands_home_and_leaves_plain_paths_unchanged() {
         let _temp = TempDir::new().unwrap();
-        let home = dirs::home_dir().expect("home directory should be available");
+        let home = crate::runtime::user_home().expect("home directory should be available");
         let expanded = expand_tilde(Path::new("~/clients/acme")).unwrap();
         assert_eq!(expanded, home.join("clients").join("acme"));
         assert_eq!(

--- a/tests/real_credential_store_canary.rs
+++ b/tests/real_credential_store_canary.rs
@@ -73,6 +73,20 @@ fn canary_cmd(env: &TestEnv, bin_dir: &Path, args: &[&str]) -> std::process::Out
         .env_remove("CODEX_HOME")
         .env_remove("XDG_CONFIG_HOME")
         .env_remove("XDG_DATA_HOME");
+    #[cfg(windows)]
+    {
+        // `dirs::home_dir()` uses the Windows profile known folder, not HOME.
+        // Keep the canary's live-state writes inside its temporary sandbox.
+        let roaming = env.fake_home.join("AppData").join("Roaming");
+        let local = env.fake_home.join("AppData").join("Local");
+        fs::create_dir_all(&roaming).expect("failed to create fake AppData/Roaming");
+        fs::create_dir_all(&local).expect("failed to create fake AppData/Local");
+        cmd.env_remove("HOMEDRIVE")
+            .env_remove("HOMEPATH")
+            .env("USERPROFILE", &env.fake_home)
+            .env("APPDATA", roaming)
+            .env("LOCALAPPDATA", local);
+    }
     cmd.output().unwrap()
 }
 
@@ -249,6 +263,11 @@ fn real_credential_store_canary_covers_secure_auth_modes() {
     assert_success(
         &canary_cmd(&env, &bin_dir, &["use", "codex", &codex_api]),
         "codex api use",
+    );
+
+    assert!(
+        env.fake_home.join(".codex").join("auth.json").is_file(),
+        "Codex live credentials should stay inside the canary home"
     );
 
     let status = json_output(&env, &bin_dir, &["status", "--json"]);

--- a/tests/real_credential_store_canary.rs
+++ b/tests/real_credential_store_canary.rs
@@ -66,6 +66,7 @@ fn canary_cmd(env: &TestEnv, bin_dir: &Path, args: &[&str]) -> std::process::Out
     cmd.args(args)
         .env("AISW_HOME", &env.aisw_home)
         .env("HOME", &env.fake_home)
+        .env("AISW_TEST_USER_HOME", &env.fake_home)
         .env("PATH", bin_dir)
         .env_remove("AISW_KEYRING_TEST_DIR")
         .env_remove("AISW_SECURITY_BIN")


### PR DESCRIPTION
Refs #62

## Why

The real credential-store canary overrides `HOME`, but Windows `dirs::home_dir()` resolves the OS known-folder API rather than environment variables. The canary could therefore write Codex or Claude live state outside its temporary test home while validating the real system credential store.

## What changed

- Add a debug-only `AISW_TEST_USER_HOME` override in the centralized runtime home resolver.
- Route every command and auth path that resolves the live user home through that resolver.
- Set the override in the credential-store canary while retaining Windows profile variables for subprocess compatibility.
- Assert that Codex live credentials are created inside the temporary canary home.

This is deliberately independent of the open policy question about whether canary failures should block releases.

## Trade-offs

The resolver is available only to debug/test builds, so release binaries cannot be redirected by this test knob. Centralizing the override touches the live-home resolution boundary used by commands, workspace expansion, and auth capture; that is broader than setting one environment variable, but it prevents any canary subcommand from escaping the sandbox on Windows.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked --lib runtime::tests::user_home_honors_the_hermetic_test_override`
- `cargo test --locked --test real_credential_store_canary --no-run`
- default canary test invocation (1 opt-in test ignored)
- full pre-commit and pre-push gates passed, including all tests and release build
