### PR TITLE
Reject symlinked profile paths

### DIFF
--- a/src/auth/antigravity.rs
+++ b/src/auth/antigravity.rs
@@ -91,7 +91,7 @@ pub fn read_managed_secret(
     match backend {
         CredentialBackend::File => {
             let path = profile_store
-                .profile_dir(Tool::Antigravity, profile_name)
+                .validated_profile_dir(Tool::Antigravity, profile_name)?
                 .join(SECRET_FILE);
             if !path.exists() {
                 return Ok(None);
@@ -267,7 +267,7 @@ fn clear_profile_subtree(
     prefix: &str,
 ) -> Result<()> {
     let dir = profile_store
-        .profile_dir(Tool::Antigravity, profile_name)
+        .validated_profile_dir(Tool::Antigravity, profile_name)?
         .join(prefix);
     if dir.exists() {
         fs::remove_dir_all(&dir).with_context(|| format!("could not delete {}", dir.display()))?;
@@ -361,7 +361,7 @@ fn profile_tree_map(
     prefix: &str,
 ) -> Result<BTreeMap<String, Vec<u8>>> {
     let root = profile_store
-        .profile_dir(Tool::Antigravity, profile_name)
+        .validated_profile_dir(Tool::Antigravity, profile_name)?
         .join(prefix);
     if !root.exists() {
         return Ok(BTreeMap::new());

--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -133,7 +133,8 @@ pub fn classify_profile(
                         ClaudeAuthClassification::OAuthMacosKeychainSharedLive
                     }
                     KeychainScheme::ScopedByConfigDir => {
-                        let profile_dir = profile_store.profile_dir(Tool::Claude, name);
+                        let profile_dir =
+                            profile_store.validated_profile_dir(Tool::Claude, name)?;
                         let service = scoped_keychain_service_for_config_dir(
                             &profile_dir,
                             user_home,
@@ -181,7 +182,7 @@ pub fn apply_live_credentials(
             let service = match state_mode {
                 StateMode::Shared => KEYCHAIN_SERVICE.to_owned(),
                 StateMode::Isolated => scoped_keychain_service_for_config_dir(
-                    &profile_store.profile_dir(Tool::Claude, name),
+                    &profile_store.validated_profile_dir(Tool::Claude, name)?,
                     user_home,
                     current_keychain_scheme(),
                 ),
@@ -231,7 +232,7 @@ pub fn live_credentials_match(
             let service = match state_mode {
                 StateMode::Shared => KEYCHAIN_SERVICE.to_owned(),
                 StateMode::Isolated => scoped_keychain_service_for_config_dir(
-                    &profile_store.profile_dir(Tool::Claude, name),
+                    &profile_store.validated_profile_dir(Tool::Claude, name)?,
                     user_home,
                     current_keychain_scheme(),
                 ),

--- a/src/auth/claude/oauth.rs
+++ b/src/auth/claude/oauth.rs
@@ -223,7 +223,7 @@ pub(super) fn apply_live_oauth_account_metadata(
     user_home: &Path,
 ) -> Result<()> {
     let profile_path = profile_store
-        .profile_dir(Tool::Claude, name)
+        .validated_profile_dir(Tool::Claude, name)?
         .join(super::OAUTH_ACCOUNT_FILE);
     if !profile_path.exists() {
         return Ok(());
@@ -317,8 +317,9 @@ pub(super) fn add_oauth_with(
 
     let user_home = dirs::home_dir().context("could not determine home directory")?;
     let login_targets_profile_state = super::login_targets_profile_state(&user_home);
-    let target_config_dir =
-        login_targets_profile_state.then(|| profile_store.profile_dir(Tool::Claude, name));
+    let target_config_dir = login_targets_profile_state
+        .then(|| profile_store.validated_profile_dir(Tool::Claude, name))
+        .transpose()?;
 
     let auth_bytes = files::cleanup_profile_on_error(
         run_oauth_flow(
@@ -625,7 +626,7 @@ fn active_credentials_snapshot_for_sync(
                 return Ok(None);
             }
             let service = keychain_service_for_config_dir(
-                &profile_store.profile_dir(Tool::Claude, name),
+                &profile_store.validated_profile_dir(Tool::Claude, name)?,
                 user_home,
                 scheme,
             );

--- a/src/auth/codex.rs
+++ b/src/auth/codex.rs
@@ -451,21 +451,21 @@ fn persist_managed_credentials(
     }
 }
 
-fn imported_bootstrap_marker_path(profile_store: &ProfileStore, name: &str) -> PathBuf {
-    profile_store
-        .profile_dir(Tool::Codex, name)
-        .join(IMPORTED_BOOTSTRAP_MARKER_FILE)
+fn imported_bootstrap_marker_path(profile_store: &ProfileStore, name: &str) -> Result<PathBuf> {
+    Ok(profile_store
+        .validated_profile_dir(Tool::Codex, name)?
+        .join(IMPORTED_BOOTSTRAP_MARKER_FILE))
 }
 
 pub fn mark_imported_bootstrap(profile_store: &ProfileStore, name: &str) -> Result<()> {
-    let path = imported_bootstrap_marker_path(profile_store, name);
+    let path = imported_bootstrap_marker_path(profile_store, name)?;
     fs::write(&path, b"chatgpt_from_live_bootstrap\n")
         .with_context(|| format!("could not write {}", path.display()))?;
     files::set_permissions_600(&path)
 }
 
 pub fn clear_imported_bootstrap_marker(profile_store: &ProfileStore, name: &str) -> Result<()> {
-    let path = imported_bootstrap_marker_path(profile_store, name);
+    let path = imported_bootstrap_marker_path(profile_store, name)?;
     if path.exists() {
         fs::remove_file(&path).with_context(|| format!("could not remove {}", path.display()))?;
     }
@@ -473,7 +473,7 @@ pub fn clear_imported_bootstrap_marker(profile_store: &ProfileStore, name: &str)
 }
 
 pub fn is_imported_bootstrap(profile_store: &ProfileStore, name: &str) -> bool {
-    imported_bootstrap_marker_path(profile_store, name).exists()
+    imported_bootstrap_marker_path(profile_store, name).is_ok_and(|path| path.exists())
 }
 
 pub fn classify_profile(

--- a/src/auth/gemini.rs
+++ b/src/auth/gemini.rs
@@ -641,7 +641,7 @@ pub fn apply_token_cache(
     std::fs::create_dir_all(gemini_dir)
         .with_context(|| format!("could not create {}", gemini_dir.display()))?;
 
-    let profile_dir = profile_store.profile_dir(Tool::Gemini, name);
+    let profile_dir = profile_store.validated_profile_dir(Tool::Gemini, name)?;
     let mut expected_files = std::collections::BTreeSet::new();
     let mut changes = Vec::new();
     for file in files::list_regular_files_recursive(&profile_dir)? {
@@ -676,7 +676,7 @@ pub fn live_token_cache_matches(
     name: &str,
     gemini_dir: &Path,
 ) -> Result<bool> {
-    let profile_dir = profile_store.profile_dir(Tool::Gemini, name);
+    let profile_dir = profile_store.validated_profile_dir(Tool::Gemini, name)?;
     if !gemini_dir.exists() {
         return Ok(false);
     }

--- a/src/auth/identity.rs
+++ b/src/auth/identity.rs
@@ -264,7 +264,9 @@ fn resolve_identity_from_optional_profile_files(
     }
 
     for filename in filenames {
-        let path = profile_store.profile_dir(tool, profile_name).join(filename);
+        let path = profile_store
+            .validated_profile_dir(tool, profile_name)?
+            .join(filename);
         if !path.exists() {
             continue;
         }
@@ -284,7 +286,9 @@ fn read_optional_profile_file(
     profile_name: &str,
     filename: &str,
 ) -> Result<Option<Vec<u8>>> {
-    let path = profile_store.profile_dir(tool, profile_name).join(filename);
+    let path = profile_store
+        .validated_profile_dir(tool, profile_name)?
+        .join(filename);
     if !path.exists() {
         return Ok(None);
     }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -52,6 +52,15 @@ impl BackupManager {
         profile_meta: &ProfileMeta,
     ) -> Result<PathBuf> {
         profile_meta.credential_backend.validate_for_tool(tool)?;
+        let expected_profile_dir = ProfileStore::new(&self.home)
+            .validated_profile_dir(tool, name)
+            .with_context(|| format!("could not validate profile '{}' for backup", name))?;
+        if profile_dir != expected_profile_dir {
+            bail!(
+                "refusing to snapshot unexpected profile path '{}'",
+                profile_dir.display()
+            );
+        }
         let backup_id = backup_id_now();
         let dest = self
             .backups_dir()
@@ -185,7 +194,7 @@ impl BackupManager {
                     continue;
                 }
 
-                let dest_dir = profile_store.profile_dir(tool, &profile_name);
+                let dest_dir = profile_store.validated_profile_dir(tool, &profile_name)?;
                 let profile_meta =
                     restore_profile_meta(config_store, tool, &profile_name, &profile_path)?;
                 profile_meta.credential_backend.validate_for_tool(tool)?;
@@ -600,7 +609,11 @@ mod tests {
     #[test]
     fn failed_snapshot_removes_partial_backup() {
         let dir = tempdir().unwrap();
-        let missing_profile_dir = dir.path().join("missing-profile");
+        let missing_profile_dir = dir
+            .path()
+            .join("profiles")
+            .join(Tool::Claude.dir_name())
+            .join("work");
         let m = manager(dir.path());
 
         let err = m
@@ -609,6 +622,32 @@ mod tests {
 
         assert!(err.to_string().contains("could not read"));
         assert!(m.list().unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn snapshot_refuses_a_symlinked_profile_directory() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let profiles = dir.path().join("profiles").join("codex");
+        let outside = dir.path().join("outside");
+        fs::create_dir_all(&profiles).unwrap();
+        fs::create_dir(&outside).unwrap();
+        symlink(&outside, profiles.join("work")).unwrap();
+
+        let store = profile_store(dir.path());
+        let err = manager(dir.path())
+            .snapshot(
+                Tool::Codex,
+                "work",
+                &store.profile_dir(Tool::Codex, "work"),
+                &profile_meta(),
+            )
+            .unwrap_err();
+
+        assert!(format!("{err:#}").contains("symlink"));
+        assert!(!dir.path().join(BACKUPS_DIR).exists());
     }
 
     #[test]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -371,15 +371,15 @@ impl FromLiveOverwriteSnapshot {
         name: &str,
     ) -> Result<Self> {
         let config = config_store.load()?;
-        let files =
-            auth::files::list_regular_files_recursive(&profile_store.profile_dir(tool, name))?
-                .into_iter()
-                .map(|file| {
-                    let bytes = fs::read(&file.path)
-                        .with_context(|| format!("could not read {}", file.path.display()))?;
-                    Ok((file.file_name.to_string_lossy().into_owned(), bytes))
-                })
-                .collect::<Result<Vec<_>>>()?;
+        let profile_dir = profile_store.validated_profile_dir(tool, name)?;
+        let files = auth::files::list_regular_files_recursive(&profile_dir)?
+            .into_iter()
+            .map(|file| {
+                let bytes = fs::read(&file.path)
+                    .with_context(|| format!("could not read {}", file.path.display()))?;
+                Ok((file.file_name.to_string_lossy().into_owned(), bytes))
+            })
+            .collect::<Result<Vec<_>>>()?;
         let old_backend = config
             .profiles_for(tool)
             .get(name)

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -218,7 +218,13 @@ pub fn check_profile_permissions(
             continue;
         }
 
-        let profile_dir = profile_store.profile_dir(tool, name);
+        let profile_dir = match profile_store.validated_profile_dir(tool, name) {
+            Ok(path) => path,
+            Err(error) => {
+                results.push(CheckResult::fail(&check_name, error.to_string()));
+                continue;
+            }
+        };
 
         // Check every stored file rather than one hardcoded name per tool: the
         // filename depends on the auth method (Gemini stores `.env` for API

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -100,7 +100,7 @@ pub(crate) fn run_inner(args: RemoveArgs, home: &Path, confirmed: bool) -> Resul
     ensure_not_referenced_by_context(&config, args.tool, profile_name)?;
 
     // Final backup before deleting.
-    let profile_dir = profile_store.profile_dir(args.tool, profile_name);
+    let profile_dir = profile_store.validated_profile_dir(args.tool, profile_name)?;
     let profile_meta = config
         .profiles_for(args.tool)
         .get(profile_name)

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -271,14 +271,16 @@ fn collect_active_profile_status(
         });
     };
 
-    let profile_dir = profile_store.profile_dir(tool, name);
-    let (credential_state, permissions_ok) = check_profile_storage(
-        &profile_dir,
-        tool,
-        name,
-        meta.auth_method,
-        meta.credential_backend,
-    );
+    let (credential_state, permissions_ok) = match profile_store.validated_profile_dir(tool, name) {
+        Ok(profile_dir) => check_profile_storage(
+            &profile_dir,
+            tool,
+            name,
+            meta.auth_method,
+            meta.credential_backend,
+        ),
+        Err(_) => (CredentialState::Unknown, true),
+    };
     let credentials_present = credential_state == CredentialState::Present;
 
     // Only the owning tool's classifier runs; the others stay `None`.

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -335,7 +335,8 @@ pub(crate) fn apply_resolved_profile_switch(
     let profile_store = ProfileStore::new(home);
     if resolved.backup_on_switch {
         let backup_manager = BackupManager::new(home);
-        let profile_dir = profile_store.profile_dir(resolved.tool, &resolved.profile_name);
+        let profile_dir =
+            profile_store.validated_profile_dir(resolved.tool, &resolved.profile_name)?;
         backup_manager.snapshot(
             resolved.tool,
             &resolved.profile_name,

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -28,18 +28,22 @@ impl ProfileStore {
         self.home.join("profiles").join(tool.dir_name()).join(name)
     }
 
-    fn validated_profile_dir(&self, tool: Tool, name: &str) -> Result<PathBuf> {
+    pub fn validated_profile_dir(&self, tool: Tool, name: &str) -> Result<PathBuf> {
         validate_profile_name(name)?;
-        Ok(self.profile_dir(tool, name))
+        let dir = self.profile_dir(tool, name);
+        reject_symlinked_components(&self.home, &dir)?;
+        Ok(dir)
     }
 
     pub fn exists(&self, tool: Tool, name: &str) -> bool {
-        validate_profile_name(name).is_ok() && self.profile_dir(tool, name).is_dir()
+        self.validated_profile_dir(tool, name)
+            .is_ok_and(|dir| dir.is_dir())
     }
 
     pub fn create(&self, tool: Tool, name: &str) -> Result<PathBuf> {
         validate_profile_name(name)?;
         let dir = self.profile_dir(tool, name);
+        reject_symlinked_components(&self.home, &dir)?;
         if dir.exists() {
             bail!(
                 "profile '{}' already exists for {}.\n  \
@@ -106,6 +110,7 @@ impl ProfileStore {
 
     pub fn list_profiles(&self, tool: Tool) -> Result<Vec<String>> {
         let base = self.home.join("profiles").join(tool.dir_name());
+        reject_symlinked_components(&self.home, &base)?;
         if !base.exists() {
             return Ok(vec![]);
         }
@@ -179,7 +184,9 @@ impl ProfileStore {
     fn profile_file_path(&self, tool: Tool, name: &str, filename: &str) -> Result<PathBuf> {
         let dir = self.validated_profile_dir(tool, name)?;
         validate_relative_filename(filename)?;
-        Ok(dir.join(filename))
+        let path = dir.join(filename);
+        reject_symlinked_components(&dir, &path)?;
+        Ok(path)
     }
 
     pub fn check_permissions(&self, path: &Path) -> Result<()> {
@@ -222,6 +229,20 @@ fn reject_symlink(path: &Path) -> Result<()> {
         }
         _ => Ok(()),
     }
+}
+
+fn reject_symlinked_components(root: &Path, path: &Path) -> Result<()> {
+    let relative = path
+        .strip_prefix(root)
+        .with_context(|| format!("path {} is outside {}", path.display(), root.display()))?;
+    let mut current = root.to_owned();
+    for component in relative.components() {
+        if let Component::Normal(part) = component {
+            current.push(part);
+            reject_symlink(&current)?;
+        }
+    }
+    Ok(())
 }
 
 /// Validate a profile-relative file name such as `auth.json` or
@@ -374,6 +395,74 @@ mod tests {
         assert!(
             !target.exists(),
             "write must not create the symlink's target"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn write_file_refuses_a_symlinked_profile_directory() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        let tool_dir = dir.path().join("profiles").join(Tool::Codex.dir_name());
+        std::fs::create_dir_all(&tool_dir).unwrap();
+
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, tool_dir.join("work")).unwrap();
+
+        let err = s
+            .write_file(Tool::Codex, "work", "auth.json", b"secret")
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected a symlink refusal, got: {err}"
+        );
+        assert!(
+            !outside.join("auth.json").exists(),
+            "write must not follow a symlinked profile directory"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn write_file_refuses_a_symlinked_nested_directory() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        s.create(Tool::Codex, "work").unwrap();
+
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let nested = s.profile_dir(Tool::Codex, "work").join("nested");
+        std::os::unix::fs::symlink(&outside, &nested).unwrap();
+
+        let err = s
+            .write_file(Tool::Codex, "work", "nested/auth.json", b"secret")
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected a symlink refusal, got: {err}"
+        );
+        assert!(
+            !outside.join("auth.json").exists(),
+            "write must not follow a symlinked nested directory"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn list_profiles_refuses_a_symlinked_tool_directory() {
+        let dir = tempdir().unwrap();
+        let s = store(dir.path());
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let tool_dir = dir.path().join("profiles").join(Tool::Codex.dir_name());
+        std::fs::create_dir_all(tool_dir.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&outside, &tool_dir).unwrap();
+
+        let err = s.list_profiles(Tool::Codex).unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected a symlink refusal, got: {err}"
         );
     }
 


### PR DESCRIPTION
Closes #125

## Why

`ProfileStore` rejected symlinked credential files, but a symlinked profile, tool, or nested parent directory could still redirect reads and writes outside `AISW_HOME`. Higher-level backup and diagnostic paths also consumed the raw profile path directly, so protecting only the primitive file methods was incomplete.

## What changed

- Validate every existing component between `AISW_HOME` and profile files.
- Expose the validated profile path for higher-level callers that recursively read, back up, restore, or configure a profile.
- Apply the guard to profile existence, creation, listing, direct auth consumers, backup/restore, status, doctor, and file paths.
- Add Unix regressions for symlinked profile, nested, tool, and backup paths.

Existing atomic and rollback behavior is unchanged.

## Trade-offs

Symlinked storage paths are refused, including intentional symlink-based layouts, because the managed profile tree is the security boundary. The guard follows the existing persistent path checks and does not attempt to provide an OS-specific atomic openat-style defense against a concurrent TOCTOU race.

## Verification

- Focused profile tests: 28 passed.
- Focused backup tests: 27 passed.
- Commit hook: format, clippy, release build, 580-test library suite, full integration suite, and completion smoke passed.
- Pre-push hook: full test suite and release build passed.
- Hosted CI: Linux, macOS, Windows, lint, and coverage all passed.
- `git diff --check` passed.
