### PR TITLE
Reject symlinked live state paths

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -108,6 +108,11 @@ For Claude Code, `aisw` uses the most reliable auth target the installed Claude 
 
 It does not access any other files or system resources.
 
+For both managed profiles and live agent state, `aisw` refuses to traverse a
+symlinked directory or intermediate parent. This keeps credential reads and
+writes inside the documented storage boundary; symlink-based layouts must be
+replaced with real directories before switching or restoring state.
+
 ## Reporting a vulnerability
 
 To report a security issue, open a private advisory at [github.com/burakdede/aisw/security/advisories](https://github.com/burakdede/aisw/security/advisories) or email the repository owner directly.

--- a/src/auth/antigravity.rs
+++ b/src/auth/antigravity.rs
@@ -303,7 +303,7 @@ pub fn apply_live_credentials(
     };
 
     let changes = build_apply_transaction(profile_store, profile_name, user_home)?;
-    crate::live_apply::apply_transaction(changes)?;
+    crate::live_apply::apply_transaction(user_home, changes)?;
     super::system_keyring::upsert_generic_password(
         &keyring_ref.service,
         &keyring_ref.account,
@@ -512,7 +512,7 @@ pub fn restore_snapshot_to_live(snapshot: &LiveSnapshot, user_home: &Path) -> Re
         ));
         changes
     };
-    crate::live_apply::apply_transaction(changes)?;
+    crate::live_apply::apply_transaction(user_home, changes)?;
     match snapshot.keyring_secret.as_deref() {
         Some(secret) => super::system_keyring::upsert_generic_password(
             &snapshot.keyring_ref.service,

--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -1231,6 +1231,37 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn apply_live_oauth_account_metadata_refuses_a_symlinked_live_directory() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("home");
+        let outside = dir.path().join("outside");
+        fs::create_dir_all(&user_home).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join(".claude.json"), b"{}").unwrap();
+        std::os::unix::fs::symlink(outside.join(".claude.json"), user_home.join(".claude.json"))
+            .unwrap();
+
+        let (ps, _cs) = stores(dir.path());
+        ps.create(Tool::Claude, "work").unwrap();
+        ps.write_file(
+            Tool::Claude,
+            "work",
+            OAUTH_ACCOUNT_FILE,
+            br#"{"emailAddress":"new@example.com"}"#,
+        )
+        .unwrap();
+
+        let err = oauth::apply_live_oauth_account_metadata(&ps, "work", &user_home).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("symlink"),
+            "expected symlink refusal, got: {err}"
+        );
+        assert_eq!(fs::read(outside.join(".claude.json")).unwrap(), b"{}");
+    }
+
+    #[test]
     #[cfg(all(unix, not(target_os = "macos")))]
     fn oauth_credentials_file_has_600_permissions() {
         let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());

--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -171,12 +171,13 @@ pub fn apply_live_credentials(
     let stored = read_stored_credentials(profile_store, name, backend)?;
 
     match auth_storage(user_home) {
-        ClaudeAuthStorage::File => {
-            crate::live_apply::apply_transaction(vec![crate::live_apply::LiveFileChange::write(
+        ClaudeAuthStorage::File => crate::live_apply::apply_transaction(
+            user_home,
+            vec![crate::live_apply::LiveFileChange::write(
                 live_credentials_path(user_home),
                 stored,
-            )])
-        }
+            )],
+        ),
         ClaudeAuthStorage::Keychain => {
             let service = match state_mode {
                 StateMode::Shared => KEYCHAIN_SERVICE.to_owned(),

--- a/src/auth/claude/oauth.rs
+++ b/src/auth/claude/oauth.rs
@@ -33,6 +33,7 @@ use super::paths::{
     live_account_metadata_path, live_credentials_path, live_credentials_paths, live_local_state_dir,
 };
 use super::{read_stored_credentials, LiveCredentialSnapshot, LiveCredentialSource};
+use crate::live_apply::{apply_transaction, LiveFileChange};
 
 fn persist_oauth_storage(
     profile_store: &ProfileStore,
@@ -121,25 +122,19 @@ fn restore_live_credentials_snapshot(
     match snapshot {
         Some(snapshot) => match snapshot.source {
             LiveCredentialSource::File(path) => {
-                if let Some(parent) = path.parent() {
-                    fs::create_dir_all(parent)
-                        .with_context(|| format!("could not create {}", parent.display()))?;
-                }
-                fs::write(&path, snapshot.bytes)
-                    .with_context(|| format!("could not write {}", path.display()))?;
-                files::set_permissions_600(&path)?;
+                apply_transaction(user_home, vec![LiveFileChange::write(path, snapshot.bytes)])?;
             }
             LiveCredentialSource::Keychain => {
                 super::keychain::write_keychain_credentials(&snapshot.bytes)?;
             }
         },
         None => {
-            for path in live_credentials_paths(user_home) {
-                if path.exists() {
-                    fs::remove_file(&path)
-                        .with_context(|| format!("could not remove {}", path.display()))?;
-                }
-            }
+            let changes = live_credentials_paths(user_home)
+                .into_iter()
+                .filter(|path| path.exists())
+                .map(LiveFileChange::delete)
+                .collect();
+            apply_transaction(user_home, changes)?;
             // Best effort cleanup for environments where Claude stores auth in keychain.
             let _ = super::keychain::delete_keychain_credentials();
         }
@@ -181,9 +176,7 @@ fn restore_live_oauth_account_metadata_snapshot(
 
     let bytes = serde_json::to_vec_pretty(&live_json)
         .context("could not serialize Claude metadata for live-state restore")?;
-    fs::write(&live_path, bytes)
-        .with_context(|| format!("could not write {}", live_path.display()))?;
-    files::set_permissions_600(&live_path)
+    apply_transaction(user_home, vec![LiveFileChange::write(live_path, bytes)])
 }
 
 /// Restores Claude live credentials/metadata after an OAuth add that should not
@@ -254,9 +247,7 @@ pub(super) fn apply_live_oauth_account_metadata(
 
     let bytes = serde_json::to_vec_pretty(&live_json)
         .context("could not serialize Claude metadata for live state")?;
-    fs::write(&live_path, bytes)
-        .with_context(|| format!("could not write {}", live_path.display()))?;
-    files::set_permissions_600(&live_path)
+    apply_transaction(user_home, vec![LiveFileChange::write(live_path, bytes)])
 }
 
 // ---- OAuth add flow ----

--- a/src/auth/codex.rs
+++ b/src/auth/codex.rs
@@ -666,10 +666,13 @@ pub fn apply_live_credentials(
     let config_dest = live_config_path(user_home);
     let config_bytes = desired_live_file_store_config(user_home)?.into_bytes();
 
-    crate::live_apply::apply_transaction(vec![
-        LiveFileChange::write(auth_dest, auth_bytes),
-        LiveFileChange::write(config_dest, config_bytes),
-    ])
+    crate::live_apply::apply_transaction(
+        user_home,
+        vec![
+            LiveFileChange::write(auth_dest, auth_bytes),
+            LiveFileChange::write(config_dest, config_bytes),
+        ],
+    )
 }
 
 pub fn apply_live_files(profile_store: &ProfileStore, name: &str, user_home: &Path) -> Result<()> {

--- a/src/auth/files.rs
+++ b/src/auth/files.rs
@@ -34,7 +34,13 @@ pub fn apply_profile_file(
     dest: PathBuf,
 ) -> Result<()> {
     let bytes = profile_store.read_file(tool, name, stored_filename)?;
-    crate::live_apply::apply_transaction(vec![LiveFileChange::write(dest, bytes)])
+    let root = dest
+        .parent()
+        .and_then(Path::parent)
+        .or_else(|| dest.parent())
+        .unwrap_or_else(|| Path::new("."))
+        .to_owned();
+    crate::live_apply::apply_transaction(&root, vec![LiveFileChange::write(dest, bytes)])
 }
 
 pub fn stored_profile_file_matches_live(

--- a/src/auth/gemini.rs
+++ b/src/auth/gemini.rs
@@ -668,7 +668,8 @@ pub fn apply_token_cache(
     let env_file = gemini_dir.join(ENV_FILE);
     changes.push(LiveFileChange::delete(env_file));
 
-    crate::live_apply::apply_transaction(changes)
+    let root = gemini_dir.parent().unwrap_or(gemini_dir);
+    crate::live_apply::apply_transaction(root, changes)
 }
 
 pub fn live_token_cache_matches(

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -190,7 +190,7 @@ impl BackupManager {
                     restore_profile_meta(config_store, tool, &profile_name, &profile_path)?;
                 profile_meta.credential_backend.validate_for_tool(tool)?;
 
-                let restored_files = restore_profile_tree(&profile_path, &dest_dir)?;
+                let restored_files = restore_profile_tree(&self.home, &profile_path, &dest_dir)?;
                 restored += restored_files;
 
                 if profile_meta.credential_backend == CredentialBackend::SystemKeyring {
@@ -285,7 +285,7 @@ fn copy_profile_tree(src_root: &Path, dest_root: &Path) -> Result<()> {
     Ok(())
 }
 
-fn restore_profile_tree(src_root: &Path, dest_root: &Path) -> Result<usize> {
+fn restore_profile_tree(home: &Path, src_root: &Path, dest_root: &Path) -> Result<usize> {
     let mut changes = Vec::new();
     for file in crate::auth::files::list_regular_files_recursive(src_root)? {
         if file.file_name == METADATA_FILE {
@@ -298,7 +298,7 @@ fn restore_profile_tree(src_root: &Path, dest_root: &Path) -> Result<usize> {
         changes.push(crate::live_apply::LiveFileChange::write(dst, contents));
     }
     let restored = changes.len();
-    crate::live_apply::apply_transaction(changes)?;
+    crate::live_apply::apply_transaction(home, changes)?;
     Ok(restored)
 }
 

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -609,8 +609,10 @@ fn restore_live_state_for_context(
                 oauth_account_metadata.clone(),
                 user_home,
             )?,
-            LiveStateSnapshot::Codex { files } => restore_file_snapshots(files)?,
-            LiveStateSnapshot::Gemini { dir, files } => restore_regular_files(dir, files)?,
+            LiveStateSnapshot::Codex { files } => restore_file_snapshots(user_home, files)?,
+            LiveStateSnapshot::Gemini { dir, files } => {
+                restore_regular_files(user_home, dir, files)?
+            }
             LiveStateSnapshot::Antigravity { snapshot } => {
                 auth::antigravity::restore_snapshot_to_live(snapshot, user_home)?
             }
@@ -644,7 +646,7 @@ fn snapshot_regular_files(dir: &Path) -> Result<Vec<NamedFileSnapshot>> {
     Ok(files)
 }
 
-fn restore_file_snapshots(files: &[FileSnapshot]) -> Result<()> {
+fn restore_file_snapshots(root: &Path, files: &[FileSnapshot]) -> Result<()> {
     let changes = files
         .iter()
         .map(|snapshot| match &snapshot.bytes {
@@ -652,10 +654,10 @@ fn restore_file_snapshots(files: &[FileSnapshot]) -> Result<()> {
             None => LiveFileChange::delete(snapshot.path.clone()),
         })
         .collect::<Vec<_>>();
-    crate::live_apply::apply_transaction(changes)
+    crate::live_apply::apply_transaction(root, changes)
 }
 
-fn restore_regular_files(dir: &Path, files: &[NamedFileSnapshot]) -> Result<()> {
+fn restore_regular_files(root: &Path, dir: &Path, files: &[NamedFileSnapshot]) -> Result<()> {
     let mut changes = Vec::new();
     let expected = files
         .iter()
@@ -677,7 +679,7 @@ fn restore_regular_files(dir: &Path, files: &[NamedFileSnapshot]) -> Result<()> 
         ));
     }
 
-    crate::live_apply::apply_transaction(changes)
+    crate::live_apply::apply_transaction(root, changes)
 }
 
 fn normalized_profiles_json(profiles: &ContextProfiles) -> serde_json::Value {

--- a/src/live_apply.rs
+++ b/src/live_apply.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -40,7 +40,11 @@ enum OriginalFileState {
     },
 }
 
-pub fn apply_transaction(changes: Vec<LiveFileChange>) -> Result<()> {
+/// Apply live-file changes without traversing symlinked components below `root`.
+///
+/// The caller supplies the live-state boundary so legitimate system path
+/// aliases above the agent's directory do not become false positives.
+pub fn apply_transaction(root: &Path, changes: Vec<LiveFileChange>) -> Result<()> {
     if changes.is_empty() {
         return Ok(());
     }
@@ -48,6 +52,7 @@ pub fn apply_transaction(changes: Vec<LiveFileChange>) -> Result<()> {
     let mut seen_paths = HashSet::new();
     for change in &changes {
         let path = change.path();
+        reject_symlinked_parent_components(root, path)?;
         if !seen_paths.insert(path.to_path_buf()) {
             bail!(
                 "live apply transaction includes duplicate target '{}'",
@@ -79,6 +84,38 @@ fn snapshot_original_state(
         );
     }
     Ok(snapshots)
+}
+
+fn reject_symlinked_parent_components(root: &Path, path: &Path) -> Result<()> {
+    reject_symlink(root)?;
+    let parent = path.parent().unwrap_or(path);
+    let relative = parent
+        .strip_prefix(root)
+        .with_context(|| format!("live path {} is outside {}", path.display(), root.display()))?;
+    let mut current = root.to_owned();
+    for component in relative.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {
+                bail!("live path '{}' is not relative to root", path.display())
+            }
+            Component::CurDir => {}
+            Component::ParentDir => bail!("live path '{}' escapes its root", path.display()),
+            Component::Normal(part) => {
+                current.push(part);
+                reject_symlink(&current)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reject_symlink(path: &Path) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            bail!("refusing to operate through symlink: {}", path.display())
+        }
+        _ => Ok(()),
+    }
 }
 
 fn read_original_state(path: &Path) -> Result<OriginalFileState> {
@@ -335,10 +372,13 @@ mod tests {
         let dir = tempdir().unwrap();
         let target = dir.path().join("auth.json");
 
-        let err = apply_transaction(vec![
-            LiveFileChange::write(target.clone(), b"one".to_vec()),
-            LiveFileChange::write(target.clone(), b"two".to_vec()),
-        ])
+        let err = apply_transaction(
+            dir.path(),
+            vec![
+                LiveFileChange::write(target.clone(), b"one".to_vec()),
+                LiveFileChange::write(target.clone(), b"two".to_vec()),
+            ],
+        )
         .unwrap_err();
 
         assert!(err.to_string().contains("duplicate target"));
@@ -353,14 +393,38 @@ mod tests {
         std::fs::write(&target, "token").unwrap();
         std::os::unix::fs::symlink(&target, &symlink_path).unwrap();
 
-        let err = apply_transaction(vec![LiveFileChange::write(
-            symlink_path.clone(),
-            b"new-token".to_vec(),
-        )])
+        let err = apply_transaction(
+            dir.path(),
+            vec![LiveFileChange::write(
+                symlink_path.clone(),
+                b"new-token".to_vec(),
+            )],
+        )
         .unwrap_err();
 
         assert!(!err.to_string().is_empty());
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "token");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn refuses_to_follow_symlinked_parent_directories() {
+        let dir = tempdir().unwrap();
+        let live_root = dir.path().join("live");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir(&live_root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, live_root.join("state")).unwrap();
+
+        let target = live_root.join("state").join("auth.json");
+        let err = apply_transaction(
+            dir.path(),
+            vec![LiveFileChange::write(target, b"secret".to_vec())],
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("symlink"));
+        assert!(!outside.join("auth.json").exists());
     }
 
     #[test]
@@ -377,7 +441,8 @@ mod tests {
             std::env::set_var("AISW_FAULT_INJECTION", "live_apply.commit_delete");
         }
 
-        let err = apply_transaction(vec![LiveFileChange::delete(target.clone())]).unwrap_err();
+        let err = apply_transaction(dir.path(), vec![LiveFileChange::delete(target.clone())])
+            .unwrap_err();
         assert!(err.to_string().contains("injected live-apply failure"));
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "original");
 
@@ -404,10 +469,13 @@ mod tests {
             std::env::set_var("AISW_FAULT_INJECTION", "live_apply.commit_write:2");
         }
 
-        let err = apply_transaction(vec![
-            LiveFileChange::write(first.clone(), b"new-auth".to_vec()),
-            LiveFileChange::write(second.clone(), b"new-config".to_vec()),
-        ])
+        let err = apply_transaction(
+            dir.path(),
+            vec![
+                LiveFileChange::write(first.clone(), b"new-auth".to_vec()),
+                LiveFileChange::write(second.clone(), b"new-config".to_vec()),
+            ],
+        )
         .unwrap_err();
 
         assert!(err.to_string().contains("injected live-apply failure"));
@@ -432,10 +500,10 @@ mod tests {
             std::env::set_var("AISW_FAULT_INJECTION", "live_apply.commit_write");
         }
 
-        let err = apply_transaction(vec![LiveFileChange::write(
-            target.clone(),
-            b"new-auth".to_vec(),
-        )])
+        let err = apply_transaction(
+            dir.path(),
+            vec![LiveFileChange::write(target.clone(), b"new-auth".to_vec())],
+        )
         .unwrap_err();
         assert!(err.to_string().contains("injected live-apply failure"));
         assert!(!target.exists());

--- a/website/src/content/docs/security.md
+++ b/website/src/content/docs/security.md
@@ -125,6 +125,11 @@ For Claude Code, `aisw` uses the most reliable auth target the installed Claude 
 
 It does not access any other files or system resources.
 
+For both managed profiles and live agent state, `aisw` refuses to traverse a
+symlinked directory or intermediate parent. This keeps credential reads and
+writes inside the documented storage boundary; symlink-based layouts must be
+replaced with real directories before switching or restoring state.
+
 ## Reporting a vulnerability
 
 To report a security issue, open a private advisory at [github.com/burakdede/aisw/security/advisories](https://github.com/burakdede/aisw/security/advisories) or email the repository owner directly.


### PR DESCRIPTION
Closes #127

## Why

The live transaction already refused symlinked destination files, but `create_dir_all` could still traverse a symlinked intermediate directory. A nested live path could therefore write credentials or agent state outside the intended user-owned tree.

## What changed

- Make each live transaction explicit about its filesystem root.
- Reject targets outside that root and reject symlinked parent components before snapshotting or staging.
- Route Claude, Codex, Gemini, Antigravity, context rollback, and backup restore transactions through their live or managed root.
- Add a Unix regression proving a nested write cannot escape through a symlinked parent.

Existing target-file checks, atomic staging, and rollback behavior remain unchanged.

## Trade-offs

The explicit root keeps legitimate aliases above the agent directory from producing false positives while making the security boundary visible at each caller. Symlinked live-state layouts are intentionally refused, and this remains a persistent preflight check rather than an OS-specific atomic openat-style defense against a concurrent TOCTOU race.

## Verification

- Reproduced the unfixed behavior with a failing regression before implementation.
- Focused live-apply tests: 6 passed.
- Library tests: 576 passed, 1 ignored.
- Commit and pre-push hooks: format, clippy, release build, full integration suite, and completion smoke passed.
- Hosted CI: Linux, macOS, Windows, lint, and coverage passed.
- `git diff --check` passed.
