### PR TITLE
Expose use synchronization warnings

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -74,6 +74,12 @@ aisw doctor --json
 
 With `--json`, success and expected command failures are emitted as structured JSON on stdout. Human-oriented stdout/stderr output is suppressed. The process still exits non-zero on failure.
 
+Mutation results are wrapped in a top-level `result` object. For `use`,
+`result.warnings` contains non-fatal diagnostics such as a failed OAuth
+profile synchronization; an empty array means no such diagnostic was raised.
+Warnings never include credential contents. In `--emit-env` mode, stdout
+remains executable shell code and diagnostics stay on stderr.
+
 For OAuth-based `add`, use `--progress-json` to stream newline-delimited JSON progress events:
 
 ```sh

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -332,7 +332,7 @@ fn use_context(_args: ContextUseArgs, _home: &Path) -> Result<()> {
 
     if args.emit_env {
         for switch in &switches {
-            apply_resolved_profile_switch(switch, true, home, &user_home)?;
+            let _ = apply_resolved_profile_switch(switch, true, home, &user_home)?;
         }
         let activations = switches
             .iter()
@@ -369,7 +369,7 @@ fn use_context(_args: ContextUseArgs, _home: &Path) -> Result<()> {
 
     let apply_result = (|| -> Result<()> {
         for switch in &switches {
-            apply_resolved_profile_switch(switch, false, home, &user_home)?;
+            let _ = apply_resolved_profile_switch(switch, false, home, &user_home)?;
         }
         store.activate_profiles(&activations)?;
         Ok(())

--- a/src/commands/use_.rs
+++ b/src/commands/use_.rs
@@ -52,6 +52,7 @@ pub fn run(args: UseArgs, home: &Path) -> Result<()> {
             home,
             &user_home,
         )
+        .map(|_| ())
     }
 }
 
@@ -67,6 +68,7 @@ pub(crate) fn run_all_in(
     let config = config_store.load()?;
     let mut switched = 0usize;
     let mut errors = Vec::new();
+    let mut warnings = Vec::new();
     let before_backup_ids = backup_ids_for(home, None)?;
     let mut affected_tools = Vec::new();
 
@@ -93,9 +95,10 @@ pub(crate) fn run_all_in(
             home,
             user_home,
         ) {
-            Ok(()) => {
+            Ok(tool_warnings) => {
                 switched += 1;
                 affected_tools.push(tool);
+                warnings.extend(tool_warnings);
             }
             Err(e) => errors.push(format!("{}: {}", tool, e)),
         }
@@ -133,7 +136,7 @@ pub(crate) fn run_all_in(
                 "state_mode": state_mode_map(home, &affected_tools)?,
                 "live_match": live_match_map(home, user_home, &affected_tools)?,
                 "backup_ids": diff_backup_ids(&before_backup_ids, &after_backup_ids),
-                "warnings": Vec::<String>::new(),
+                "warnings": warnings,
             }),
         )?;
     }
@@ -155,6 +158,7 @@ pub(crate) fn run_in(args: UseArgs, home: &Path, user_home: &Path) -> Result<()>
         home,
         user_home,
     )
+    .map(|_| ())
 }
 
 fn run_for_tool(
@@ -165,7 +169,7 @@ fn run_for_tool(
     json: bool,
     home: &Path,
     user_home: &Path,
-) -> Result<()> {
+) -> Result<Vec<String>> {
     let before_backup_ids = backup_ids_for(home, Some(tool))?;
     let resolved = resolve_profile_switch_request(
         tool,
@@ -175,7 +179,7 @@ fn run_for_tool(
         home,
         user_home,
     )?;
-    apply_resolved_profile_switch(&resolved, emit_env, home, user_home)?;
+    let warnings = apply_resolved_profile_switch(&resolved, emit_env, home, user_home)?;
 
     ConfigStore::new(home).activate_profile(
         tool,
@@ -193,14 +197,14 @@ fn run_for_tool(
                 "state_mode": state_mode_map(home, &[tool])?,
                 "live_match": live_match_map(home, user_home, &[tool])?,
                 "backup_ids": diff_backup_ids(&before_backup_ids, &after_backup_ids),
-                "warnings": Vec::<String>::new(),
+                "warnings": warnings.clone(),
             }),
         )?;
     } else if !emit_env {
         print_switch_summary(&resolved, home, user_home);
     }
 
-    Ok(())
+    Ok(warnings)
 }
 
 pub(crate) fn resolve_profile_switch_request(
@@ -331,8 +335,9 @@ pub(crate) fn apply_resolved_profile_switch(
     emit_env: bool,
     home: &Path,
     user_home: &Path,
-) -> Result<()> {
+) -> Result<Vec<String>> {
     let profile_store = ProfileStore::new(home);
+    let mut warnings = Vec::new();
     if resolved.backup_on_switch {
         let backup_manager = BackupManager::new(home);
         let profile_dir = profile_store.profile_dir(resolved.tool, &resolved.profile_name);
@@ -351,9 +356,9 @@ pub(crate) fn apply_resolved_profile_switch(
             resolved.tool,
             user_home,
         ) {
-            output::print_warning_stderr(format!(
-                "Warning: could not sync active profile before switching: {e:#}"
-            ));
+            let warning = format!("could not sync active profile before switching: {e:#}");
+            output::print_warning_stderr(format!("Warning: {warning}"));
+            warnings.push(warning);
         }
     }
 
@@ -490,7 +495,7 @@ pub(crate) fn apply_resolved_profile_switch(
         }
     }
 
-    Ok(())
+    Ok(warnings)
 }
 
 fn maybe_sync_active_profile_before_switch(

--- a/tests/use_cmd.rs
+++ b/tests/use_cmd.rs
@@ -258,6 +258,102 @@ fn use_claude_api_key_emit_env_prints_claude_config_dir() {
 }
 
 #[test]
+#[cfg(unix)]
+fn use_json_reports_non_fatal_profile_sync_warnings() {
+    let env = TestEnv::new();
+    env.add_fake_tool("claude", "claude 2.3.0");
+
+    let work_dir = env.aisw_home.join("profiles").join("claude").join("work");
+    let personal_dir = env
+        .aisw_home
+        .join("profiles")
+        .join("claude")
+        .join("personal");
+    std::fs::create_dir_all(&work_dir).unwrap();
+    std::fs::create_dir_all(&personal_dir).unwrap();
+
+    let work_credentials = br#"{"oauthToken":"old","account":{"email":"work@example.com"}}"#;
+    std::fs::write(work_dir.join(".credentials.json"), work_credentials).unwrap();
+    std::fs::write(
+        work_dir.join("oauth-account.json"),
+        br#"{"emailAddress":"work@example.com"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        personal_dir.join(".credentials.json"),
+        format!(r#"{{"apiKey":"{VALID_CLAUDE_KEY}"}}"#),
+    )
+    .unwrap();
+
+    write_config_json(
+        &env,
+        serde_json::json!({
+            "version": 2,
+            "active": {"claude": "work", "codex": null, "gemini": null, "antigravity": null},
+            "profiles": {
+                "claude": {
+                    "work": {
+                        "added_at": "2026-03-25T00:00:00Z",
+                        "auth_method": "o_auth",
+                        "credential_backend": "file",
+                        "label": null
+                    },
+                    "personal": {
+                        "added_at": "2026-03-25T00:00:00Z",
+                        "auth_method": "api_key",
+                        "credential_backend": "file",
+                        "label": null
+                    }
+                },
+                "codex": {}, "gemini": {}, "antigravity": {}
+            },
+            "contexts": {},
+            "settings": {
+                "backup_on_switch": false,
+                "max_backups": 10,
+                "claude": {"state_mode": "shared"}
+            }
+        }),
+    );
+    std::fs::create_dir_all(env.fake_home.join(".claude")).unwrap();
+    std::fs::write(
+        env.fake_home.join(".claude").join(".credentials.json"),
+        work_credentials,
+    )
+    .unwrap();
+    std::fs::write(env.fake_home.join(".claude.json"), b"not-json").unwrap();
+
+    let output = env
+        .cmd()
+        .env("AISW_CLAUDE_AUTH_STORAGE", "file")
+        .args(["use", "claude", "personal", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["ok"], true);
+    assert!(result["result"]["warnings"].is_array(), "result: {result}");
+    assert_eq!(
+        result["result"]["warnings"].as_array().unwrap().len(),
+        1,
+        "result: {result}\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(result["result"]["warnings"][0]
+        .as_str()
+        .unwrap()
+        .contains("could not sync active profile"));
+    let warning = result["result"]["warnings"][0].as_str().unwrap();
+    assert!(!warning.contains("oauthToken"));
+    assert!(!warning.contains("old-refresh"));
+}
+
+#[test]
 fn use_claude_shared_emit_env_unsets_claude_config_dir() {
     let env = TestEnv::new();
     add_claude_profile(&env, "work");

--- a/website/src/content/docs/automation.md
+++ b/website/src/content/docs/automation.md
@@ -91,6 +91,12 @@ aisw doctor --json
 
 With `--json`, success and expected command failures are emitted as structured JSON on stdout. Human-oriented stdout/stderr output is suppressed. The process still exits non-zero on failure.
 
+Mutation results are wrapped in a top-level `result` object. For `use`,
+`result.warnings` contains non-fatal diagnostics such as a failed OAuth
+profile synchronization; an empty array means no such diagnostic was raised.
+Warnings never include credential contents. In `--emit-env` mode, stdout
+remains executable shell code and diagnostics stay on stderr.
+
 For OAuth-based `add`, use `--progress-json` to stream newline-delimited JSON progress events:
 
 ```sh


### PR DESCRIPTION
Closes #129

## Why

A profile switch can succeed while the best-effort OAuth synchronization of the currently active profile fails. Human mode already warns about that condition, but `use --json` reported `warnings: []`, leaving GUI and automation consumers unable to tell that managed state may be stale.

## What changed

- carry non-fatal pre-switch synchronization diagnostics through single-tool and `--all` switch results
- keep the existing human warning on stderr and preserve executable stdout for `--emit-env`
- add an integration regression that checks the JSON envelope and verifies credential values are not included
- document the warning contract in the canonical and website automation guides

## Trade-offs

Warnings are deliberately non-fatal: the requested switch still follows the existing behavior and exit-code contract. The warning text contains operation context and sanitized error chains, but never credential payloads.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked --lib` — 575 passed, 1 ignored
- `cargo test --locked --test use_cmd` — 38 passed
- repository pre-commit and pre-push hooks — passed
