### PR TITLE
Honor Claude configured credential paths

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -64,7 +64,8 @@ On Linux, if the Secret Service daemon is not available at runtime (e.g. headles
 
 **Credential locations:**
 - macOS: `~/Library/Application Support/Claude/` (Keychain) and `~/.claude/.credentials.json` (file fallback)
-- Linux/Windows: `~/.claude/.credentials.json`
+- Linux/Windows: `~/.claude/.credentials.json`, or
+  `$CLAUDE_CONFIG_DIR/.credentials.json` when configured
 - OAuth account metadata: `~/.claude.json` (`oauthAccount` field)
 
 **How `aisw` captures credentials:**

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -52,6 +52,11 @@ Antigravity does not currently expose a documented per-profile auth/data root li
 | Linux | `~/.claude/.credentials.json` | Supported via Secret Service |
 | Windows | `~/.claude/.credentials.json` | Supported via Windows Credential Manager |
 
+When `CLAUDE_CONFIG_DIR` is set, Claude Code reads `.credentials.json` from
+that directory instead of the default locations above. `aisw` honors the
+explicit variable for live credential reads, writes, detection, and cleanup;
+the separate OAuth account metadata file remains `~/.claude.json`.
+
 OAuth account metadata (display name, organization) is stored in `~/.claude.json` under the `oauthAccount` key. `aisw` captures and restores this alongside credentials.
 
 Claude Code also stores MCP OAuth tokens in the credentials payload. `aisw` preserves the full credential payload including `mcpOAuth` keys when writing to any backend.

--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -28,7 +28,7 @@ use keychain::{
     keychain_service_for_config_dir as scoped_keychain_service_for_config_dir, ClaudeAuthStorage,
     ClaudeKeychainScheme as KeychainScheme,
 };
-use paths::live_credentials_path;
+use paths::{live_credentials_path, live_credentials_root};
 
 // ---- Constants ----
 
@@ -172,7 +172,7 @@ pub fn apply_live_credentials(
 
     match auth_storage(user_home) {
         ClaudeAuthStorage::File => crate::live_apply::apply_transaction(
-            user_home,
+            &live_credentials_root(user_home),
             vec![crate::live_apply::LiveFileChange::write(
                 live_credentials_path(user_home),
                 stored,

--- a/src/auth/claude/oauth.rs
+++ b/src/auth/claude/oauth.rs
@@ -30,7 +30,8 @@ use super::keychain::{
     ClaudeAuthStorage,
 };
 use super::paths::{
-    live_account_metadata_path, live_credentials_path, live_credentials_paths, live_local_state_dir,
+    live_account_metadata_path, live_credentials_path, live_credentials_paths,
+    live_credentials_root, live_local_state_dir,
 };
 use super::{read_stored_credentials, LiveCredentialSnapshot, LiveCredentialSource};
 use crate::live_apply::{apply_transaction, LiveFileChange};
@@ -122,7 +123,10 @@ fn restore_live_credentials_snapshot(
     match snapshot {
         Some(snapshot) => match snapshot.source {
             LiveCredentialSource::File(path) => {
-                apply_transaction(user_home, vec![LiveFileChange::write(path, snapshot.bytes)])?;
+                apply_transaction(
+                    &live_credentials_root(user_home),
+                    vec![LiveFileChange::write(path, snapshot.bytes)],
+                )?;
             }
             LiveCredentialSource::Keychain => {
                 super::keychain::write_keychain_credentials(&snapshot.bytes)?;
@@ -134,7 +138,7 @@ fn restore_live_credentials_snapshot(
                 .filter(|path| path.exists())
                 .map(LiveFileChange::delete)
                 .collect();
-            apply_transaction(user_home, changes)?;
+            apply_transaction(&live_credentials_root(user_home), changes)?;
             // Best effort cleanup for environments where Claude stores auth in keychain.
             let _ = super::keychain::delete_keychain_credentials();
         }

--- a/src/auth/claude/paths.rs
+++ b/src/auth/claude/paths.rs
@@ -6,9 +6,27 @@
 
 use std::path::{Path, PathBuf};
 
+fn configured_dir(user_home: &Path) -> Option<PathBuf> {
+    std::env::var_os("CLAUDE_CONFIG_DIR")
+        .filter(|raw| !raw.is_empty())
+        .map(|raw| {
+            let path = PathBuf::from(raw);
+            if path.is_absolute() {
+                path
+            } else {
+                user_home.join(path)
+            }
+        })
+}
+
 /// Returns the path to the live `.credentials.json` file, preferring the XDG
-/// secondary location only when it exists and the primary does not.
+/// secondary location only when it exists and the primary does not. An
+/// explicit `CLAUDE_CONFIG_DIR` takes precedence over both defaults.
 pub(super) fn live_credentials_path(user_home: &Path) -> PathBuf {
+    if let Some(config_dir) = configured_dir(user_home) {
+        return config_dir.join(super::CREDENTIALS_FILE);
+    }
+
     let primary = user_home.join(".claude").join(super::CREDENTIALS_FILE);
     let secondary = user_home
         .join(".config")
@@ -23,8 +41,12 @@ pub(super) fn live_credentials_path(user_home: &Path) -> PathBuf {
 }
 
 /// Returns both possible live credentials paths in priority order.
-pub(super) fn live_credentials_paths(user_home: &Path) -> [PathBuf; 2] {
-    [
+pub(super) fn live_credentials_paths(user_home: &Path) -> Vec<PathBuf> {
+    if let Some(config_dir) = configured_dir(user_home) {
+        return vec![config_dir.join(super::CREDENTIALS_FILE)];
+    }
+
+    vec![
         user_home.join(".claude").join(super::CREDENTIALS_FILE),
         user_home
             .join(".config")
@@ -33,15 +55,23 @@ pub(super) fn live_credentials_paths(user_home: &Path) -> [PathBuf; 2] {
     ]
 }
 
+pub(super) fn live_credentials_root(user_home: &Path) -> PathBuf {
+    configured_dir(user_home).unwrap_or_else(|| user_home.to_owned())
+}
+
 /// Returns the path to `~/.claude.json`, where Claude stores OAuth account
 /// metadata (`oauthAccount` field).
 pub(super) fn live_account_metadata_path(user_home: &Path) -> PathBuf {
     user_home.join(".claude.json")
 }
 
-/// Returns the Claude local state directory if it exists. Returns `None` when
-/// neither `~/.claude/` nor `~/.config/claude/` is present.
+/// Returns the Claude local state directory if it exists. An explicit
+/// `CLAUDE_CONFIG_DIR` takes precedence over the default locations.
 pub fn live_local_state_dir(user_home: &Path) -> Option<PathBuf> {
+    if let Some(config_dir) = configured_dir(user_home) {
+        return config_dir.exists().then_some(config_dir);
+    }
+
     let primary = user_home.join(".claude");
     if primary.exists() {
         return Some(primary);
@@ -52,5 +82,65 @@ pub fn live_local_state_dir(user_home: &Path) -> Option<PathBuf> {
         Some(secondary)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::test_overrides::EnvVarGuard;
+    use tempfile::tempdir;
+
+    #[test]
+    fn configured_dir_replaces_default_credential_locations() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("home");
+        let configured = dir.path().join("claude-state");
+        std::fs::create_dir_all(user_home.join(".claude")).unwrap();
+        std::fs::create_dir_all(&configured).unwrap();
+        let _config = EnvVarGuard::set("CLAUDE_CONFIG_DIR", &configured);
+
+        assert_eq!(
+            live_credentials_path(&user_home),
+            configured.join(super::super::CREDENTIALS_FILE)
+        );
+        assert_eq!(
+            live_credentials_paths(&user_home),
+            vec![configured.join(super::super::CREDENTIALS_FILE)]
+        );
+        assert_eq!(live_credentials_root(&user_home), configured);
+        assert_eq!(live_local_state_dir(&user_home), Some(configured));
+    }
+
+    #[test]
+    fn relative_configured_dir_is_resolved_under_user_home() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("home");
+        let _config = EnvVarGuard::set("CLAUDE_CONFIG_DIR", "custom-claude");
+
+        assert_eq!(
+            live_credentials_path(&user_home),
+            user_home
+                .join("custom-claude")
+                .join(super::super::CREDENTIALS_FILE)
+        );
+    }
+
+    #[test]
+    fn default_locations_remain_when_configured_dir_is_unset() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("home");
+        let _config = EnvVarGuard::set("CLAUDE_CONFIG_DIR", "");
+
+        assert_eq!(
+            live_credentials_path(&user_home),
+            user_home
+                .join(".claude")
+                .join(super::super::CREDENTIALS_FILE)
+        );
+        assert_eq!(live_credentials_root(&user_home), user_home);
     }
 }

--- a/tests/use_cmd.rs
+++ b/tests/use_cmd.rs
@@ -258,6 +258,27 @@ fn use_claude_api_key_emit_env_prints_claude_config_dir() {
 }
 
 #[test]
+fn use_claude_honors_configured_credential_directory() {
+    let env = TestEnv::new();
+    add_claude_profile(&env, "work");
+    let configured_dir = env.fake_home.join("claude-config");
+
+    env.cmd()
+        .env("AISW_CLAUDE_AUTH_STORAGE", "file")
+        .env("CLAUDE_CONFIG_DIR", &configured_dir)
+        .args(["use", "claude", "work"])
+        .assert()
+        .success();
+
+    assert!(configured_dir.join(".credentials.json").is_file());
+    assert!(!env
+        .fake_home
+        .join(".claude")
+        .join(".credentials.json")
+        .exists());
+}
+
+#[test]
 fn use_claude_shared_emit_env_unsets_claude_config_dir() {
     let env = TestEnv::new();
     add_claude_profile(&env, "work");

--- a/website/src/content/docs/how-it-works.md
+++ b/website/src/content/docs/how-it-works.md
@@ -81,7 +81,8 @@ On Linux, if the Secret Service daemon is not available at runtime (e.g. headles
 
 **Credential locations:**
 - macOS: `~/Library/Application Support/Claude/` (Keychain) and `~/.claude/.credentials.json` (file fallback)
-- Linux/Windows: `~/.claude/.credentials.json`
+- Linux/Windows: `~/.claude/.credentials.json`, or
+  `$CLAUDE_CONFIG_DIR/.credentials.json` when configured
 - OAuth account metadata: `~/.claude.json` (`oauthAccount` field)
 
 **How `aisw` captures credentials:**

--- a/website/src/content/docs/supported-tools.md
+++ b/website/src/content/docs/supported-tools.md
@@ -69,6 +69,11 @@ Antigravity does not currently expose a documented per-profile auth/data root li
 | Linux | `~/.claude/.credentials.json` | Supported via Secret Service |
 | Windows | `~/.claude/.credentials.json` | Supported via Windows Credential Manager |
 
+When `CLAUDE_CONFIG_DIR` is set, Claude Code reads `.credentials.json` from
+that directory instead of the default locations above. `aisw` honors the
+explicit variable for live credential reads, writes, detection, and cleanup;
+the separate OAuth account metadata file remains `~/.claude.json`.
+
 OAuth account metadata (display name, organization) is stored in `~/.claude.json` under the `oauthAccount` key. `aisw` captures and restores this alongside credentials.
 
 Claude Code also stores MCP OAuth tokens in the credentials payload. `aisw` preserves the full credential payload including `mcpOAuth` keys when writing to any backend.


### PR DESCRIPTION
Closes #131

## Why

Claude Code documents `CLAUDE_CONFIG_DIR` as the location for its credentials file, but aisw previously detected and wrote only the default credential locations. That could make a configured Claude installation appear inactive or cause profile switches to update the wrong live state.

## What changed

- honor an explicit `CLAUDE_CONFIG_DIR`, including relative values resolved under aisw's user-home abstraction
- use the configured directory for Claude credential detection, reads, writes, cleanup, and local-state probing
- keep home-level `.claude.json` metadata separate from the configured credential directory
- route configured live writes through the guarded transaction root introduced by #128
- add path and integration coverage and synchronize user/developer documentation

## Trade-offs

- the PR is intentionally stacked on #128 because configured live paths must share its symlink-safe transaction boundary
- the existing default and XDG fallback precedence remains unchanged when `CLAUDE_CONFIG_DIR` is unset

## Verification

- `cargo fmt --all`
- `git diff --check` with the repository's configured whitespace policy
- `cargo test --locked --lib auth::claude`
- `cargo test --locked --test use_cmd use_claude_honors_configured_credential_directory`
- repository pre-commit hook: passed (`580 passed; 1 ignored` in the full run)
- repository pre-push hook: passed
