### PR TITLE
Reject symlinked repair roots

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -82,7 +82,7 @@ All commands that modify `~/.aisw/config.json` take an exclusive lock on the fil
 
 ### Input validation
 
-Profile names are restricted to `a-z`, `A-Z`, `0-9`, `-`, and `_`, and every read and write resolves inside the profile directory, so a name can never reach a path outside `~/.aisw/profiles/`. `aisw` refuses to read or write through a symlink at a credential path.
+Profile names are restricted to `a-z`, `A-Z`, `0-9`, `-`, and `_`, and every read and write resolves inside the profile directory, so a name can never reach a path outside `~/.aisw/profiles/`. `aisw` refuses to read or write through a symlink at a credential path. Permission repair also refuses a symlinked `AISW_HOME` root, so it cannot traverse an alias into an unrelated directory.
 
 API keys must be a single line. Keys containing control characters are rejected, because stored credentials are later materialized into formats where such characters change meaning rather than being escaped  -  a Gemini API key is written to a `.env` file the CLI sources, so an embedded newline would otherwise inject additional environment variables.
 

--- a/src/commands/repair.rs
+++ b/src/commands/repair.rs
@@ -239,6 +239,12 @@ fn apply_one(home: &Path, action: &PlannedAction) -> Result<()> {
 fn collect_permission_repairs(home: &Path, actions: &mut Vec<PlannedAction>) -> Result<()> {
     let root_meta =
         fs::symlink_metadata(home).with_context(|| format!("could not stat {}", home.display()))?;
+    if root_meta.file_type().is_symlink() {
+        anyhow::bail!(
+            "refusing to repair permissions through symlinked AISW_HOME '{}'",
+            home.display()
+        );
+    }
     if root_meta.is_dir() {
         maybe_collect_dir_permissions(home, actions);
     }
@@ -430,5 +436,32 @@ mod tests {
         assert!(actions
             .iter()
             .any(|action| matches!(action.kind, ActionKind::SetFilePermissions)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn plan_actions_rejects_symlinked_home_for_permissions() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("target");
+        let home = dir.path().join("aisw");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("secret"), b"credential").unwrap();
+        symlink(&target, &home).unwrap();
+
+        let error = plan_actions(&home, &[RepairFix::Permissions]).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("refusing to repair permissions through symlinked AISW_HOME"));
+        assert_eq!(
+            fs::metadata(target.join("secret"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
+        );
     }
 }

--- a/tests/audit_regressions.rs
+++ b/tests/audit_regressions.rs
@@ -459,6 +459,36 @@ fn doctor_still_fails_on_broad_credential_permissions() {
     assert!(!output.status.success(), "doctor should exit non-zero");
 }
 
+/// Permission repair must not follow an AISW_HOME symlink into another tree.
+#[test]
+#[cfg(unix)]
+fn repair_rejects_symlinked_aisw_home() {
+    use std::os::unix::fs::{symlink, PermissionsExt};
+
+    let env = TestEnv::new();
+    let target = env.dir.path().join("outside");
+    std::fs::create_dir_all(&target).unwrap();
+    let secret = target.join("secret");
+    std::fs::write(&secret, b"credential").unwrap();
+    std::fs::remove_dir(&env.aisw_home).unwrap();
+    symlink(&target, &env.aisw_home).unwrap();
+
+    let output = env.output(&["repair", "--json", "--dry-run", "--fix", "permissions"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stderr.contains("refusing to repair permissions through symlinked AISW_HOME")
+            || stdout.contains("refusing to repair permissions through symlinked AISW_HOME"),
+        "error should explain the rejected root; stderr={stderr:?}, stdout={stdout:?}"
+    );
+    assert_eq!(
+        std::fs::metadata(secret).unwrap().permissions().mode() & 0o777,
+        0o644
+    );
+}
+
 /// `use --all` dropped `--emit-env`, so the shell hook's
 /// `aisw use --all --profile X --emit-env` performed the full switch instead of
 /// printing exports — and then the hook ran the switch a second time.

--- a/website/src/content/docs/security.md
+++ b/website/src/content/docs/security.md
@@ -99,7 +99,7 @@ All commands that modify `~/.aisw/config.json` take an exclusive lock on the fil
 
 ### Input validation
 
-Profile names are restricted to `a-z`, `A-Z`, `0-9`, `-`, and `_`, and every read and write resolves inside the profile directory, so a name can never reach a path outside `~/.aisw/profiles/`. `aisw` refuses to read or write through a symlink at a credential path.
+Profile names are restricted to `a-z`, `A-Z`, `0-9`, `-`, and `_`, and every read and write resolves inside the profile directory, so a name can never reach a path outside `~/.aisw/profiles/`. `aisw` refuses to read or write through a symlink at a credential path. Permission repair also refuses a symlinked `AISW_HOME` root, so it cannot traverse an alias into an unrelated directory.
 
 API keys must be a single line. Keys containing control characters are rejected, because stored credentials are later materialized into formats where such characters change meaning rather than being escaped  -  a Gemini API key is written to a `.env` file the CLI sources, so an embedded newline would otherwise inject additional environment variables.
 


### PR DESCRIPTION
Closes #134

## Why

`repair --fix permissions` rejected symlinks below `AISW_HOME`, but the root itself was only inspected with `symlink_metadata` and then traversed with `read_dir`. A symlinked `AISW_HOME` could therefore make repair inspect and chmod an unrelated directory.

## Decision

Fail closed as soon as the managed root is identified as a symlink. This keeps the repair boundary explicit and avoids trying to canonicalize or follow user-provided aliases, which would make the safety guarantee dependent on the target tree.

The change adds both a command-level regression and a unit regression, and synchronizes the security documentation.

## Verification

- `cargo fmt --all`
- `git diff --check` with the repository whitespace policy
- `cargo test --locked --lib commands::repair::tests`
- `cargo test --locked --test audit_regressions`
- repository pre-commit hook: passed (`576 passed; 1 ignored` in the full run)
- repository pre-push hook: passed
