### PR TITLE
Run CI on stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,3 +94,9 @@ Short subject line. No "feat:"/"fix:" prefixes. No bullet lists in the body unle
 ## Pull requests
 
 One logical change per PR. If a PR needs a long explanation, the code probably needs simplification first.
+
+Stacked pull requests are supported when a change depends on another open
+branch. Each stack member receives the normal hosted CI checks. Keep the
+dependency visible in the PR description and retarget the dependent PR to
+`main` after its parent merges when GitHub does not update the base
+automatically.


### PR DESCRIPTION
Closes #133

## Why

The CI workflow filtered `pull_request` events to `main`, so a dependent PR targeting another open branch received no hosted validation. That made stacked work look clean without exercising the platform matrix.

## Decision

Run the existing CI workflow for every pull-request base while keeping pushes limited to `main`. This preserves the current required matrix and concurrency key, and makes the smallest change needed to validate stacked branches. The contributor guide records the expected retargeting step after a parent branch merges.

## Verification

- `actionlint`
- `git diff --check`
- repository pre-commit hook: passed (`576` unit tests and full integration suite)
- repository pre-push hook: passed
