### PR TITLE
Recognize Codex ephemeral auth mode

### DIFF
--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -78,6 +78,7 @@ Supported Codex auth models in `aisw`:
 - Durable: ChatGPT-managed profiles authenticated directly inside their own isolated `CODEX_HOME`.
 - Durable when already live upstream: personal access token sessions imported with `aisw add codex <name> --from-live` after `codex login --with-access-token`.
 - Bootstrap only: ChatGPT-managed profiles imported with `aisw add codex <name> --from-live`.
+- Unsupported for import: `ephemeral` credentials are process-local and cannot produce a durable aisw profile.
 - Unsupported: shared-mode ChatGPT auth switching for ChatGPT-managed refresh-token auth.
 
 Codex's keyring account identifier is an opaque string, not the system username. `aisw` discovers the identifier from the live keyring entry during import and stores it so subsequent switches write to the correct account. `aisw` will not fabricate a keyring account name if it cannot read the live identifier.

--- a/src/auth/codex.rs
+++ b/src/auth/codex.rs
@@ -44,6 +44,7 @@ pub enum LiveAuthStorage {
     Auto,
     File,
     Keyring,
+    Ephemeral,
     Unknown,
 }
 
@@ -53,6 +54,7 @@ impl LiveAuthStorage {
             LiveAuthStorage::Auto => "auto",
             LiveAuthStorage::File => "file",
             LiveAuthStorage::Keyring => "keyring",
+            LiveAuthStorage::Ephemeral => "ephemeral",
             LiveAuthStorage::Unknown => "unknown",
         }
     }
@@ -182,6 +184,7 @@ fn auth_storage_from_str(raw: &str) -> LiveAuthStorage {
         "auto" => LiveAuthStorage::Auto,
         "file" => LiveAuthStorage::File,
         "keyring" => LiveAuthStorage::Keyring,
+        "ephemeral" => LiveAuthStorage::Ephemeral,
         _ => LiveAuthStorage::Unknown,
     }
 }
@@ -956,6 +959,15 @@ mod tests {
             parse_live_auth_storage("cli_auth_credentials_store = \"keyring\"\n"),
             LiveAuthStorage::Keyring
         );
+    }
+
+    #[test]
+    fn parse_live_auth_storage_reads_ephemeral_backend() {
+        assert_eq!(
+            parse_live_auth_storage("cli_auth_credentials_store = \"ephemeral\"\n"),
+            LiveAuthStorage::Ephemeral
+        );
+        assert_eq!(LiveAuthStorage::Ephemeral.description(), "ephemeral");
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -713,6 +713,7 @@ fn detect_live_codex(
                 auth::codex::LiveAuthStorage::Keyring => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json or the system keyring.".to_owned(),
                 auth::codex::LiveAuthStorage::Auto => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json. Codex may be using the system keyring instead of a file backend.".to_owned(),
                 auth::codex::LiveAuthStorage::File => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json even though the configured backend is file.".to_owned(),
+                auth::codex::LiveAuthStorage::Ephemeral => "Codex is configured for ephemeral credentials, which are process-local and cannot be imported by aisw. Use a durable file or keyring auth mode before running init.".to_owned(),
                 auth::codex::LiveAuthStorage::Unknown => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json. The configured auth backend is not recognized.".to_owned(),
             })
         } else {
@@ -1101,6 +1102,11 @@ fn import_codex(
                 auth::codex::LiveAuthStorage::File => output::print_info(
                     "Codex local state exists, but aisw could not find importable auth in \
                      ~/.codex/auth.json even though the configured backend is file.",
+                ),
+                auth::codex::LiveAuthStorage::Ephemeral => output::print_info(
+                    "Codex is configured for ephemeral credentials, which are process-local and \
+                     cannot be imported by aisw. Use a durable file or keyring auth mode before \
+                     running init.",
                 ),
                 auth::codex::LiveAuthStorage::Unknown => output::print_info(
                     "Codex local state exists, but aisw could not find importable auth in \

--- a/tests/init_cmd.rs
+++ b/tests/init_cmd.rs
@@ -524,6 +524,26 @@ fn init_reports_codex_local_state_without_importable_auth() {
 }
 
 #[test]
+fn init_reports_codex_ephemeral_backend_without_calling_it_unknown() {
+    let env = TestEnv::new();
+    let codex_dir = env.fake_home.join(".codex");
+    fs::create_dir_all(&codex_dir).unwrap();
+    fs::write(
+        codex_dir.join("config.toml"),
+        b"cli_auth_credentials_store = \"ephemeral\"\n",
+    )
+    .unwrap();
+
+    run_init(&env)
+        .success()
+        .stdout(contains("Auth storage"))
+        .stdout(contains("ephemeral"))
+        .stdout(contains("process-local"))
+        .stdout(contains("cannot be imported by aisw"))
+        .stdout(predicates::str::contains("not recognized").not());
+}
+
+#[test]
 fn init_reports_codex_auto_backend_without_importable_auth() {
     let env = TestEnv::new();
     let codex_dir = env.fake_home.join(".codex");

--- a/website/src/content/docs/supported-tools.md
+++ b/website/src/content/docs/supported-tools.md
@@ -95,6 +95,7 @@ Supported Codex auth models in `aisw`:
 - Durable: ChatGPT-managed profiles authenticated directly inside their own isolated `CODEX_HOME`.
 - Durable when already live upstream: personal access token sessions imported with `aisw add codex <name> --from-live` after `codex login --with-access-token`.
 - Bootstrap only: ChatGPT-managed profiles imported with `aisw add codex <name> --from-live`.
+- Unsupported for import: `ephemeral` credentials are process-local and cannot produce a durable aisw profile.
 - Unsupported: shared-mode ChatGPT auth switching for ChatGPT-managed refresh-token auth.
 
 Codex's keyring account identifier is an opaque string, not the system username. `aisw` discovers the identifier from the live keyring entry during import and stores it so subsequent switches write to the correct account. `aisw` will not fabricate a keyring account name if it cannot read the live identifier.


### PR DESCRIPTION
Closes #137

## Why

Current Codex configuration supports `cli_auth_credentials_store = "ephemeral"`, but aisw classified every value outside `auto`, `file`, and `keyring` as unknown. That made a valid process-local setup look like a configuration error during onboarding.

## Decision

Represent `ephemeral` explicitly and explain that it cannot be imported into a durable aisw profile. The behavior remains fail-closed: aisw neither attempts to capture process-local credentials nor claims they are available.

## Verification

- current Codex configuration reference checked: `cli_auth_credentials_store` documents `file`, `keyring`, `auto`, and `ephemeral`
- `cargo fmt --all`
- `git diff --check` with the repository whitespace policy
- `cargo test --locked --lib auth::codex::tests::parse_live_auth_storage`
- `cargo test --locked --test init_cmd`
- repository pre-commit hook: passed (`577` unit tests plus the full integration suite)
- repository pre-push hook: passed
