### PR TITLE
Reject symlinked installer destinations

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -22,6 +22,10 @@ description: aisw security posture  -  local-only credential storage, OS keyring
 
 Credentials are stored under `~/.aisw/profiles/<tool>/<name>/`. The central config file `~/.aisw/config.json` contains only profile metadata (name, auth method, timestamps, labels). It does not contain credential material.
 
+The shell installer refuses to write through a symlinked install directory or
+binary destination. This prevents a stale `aisw` link from redirecting an
+upgrade outside the directory selected by `AISW_INSTALL_DIR`.
+
 For keyring-backed profiles, the sensitive credential bytes are stored in the OS keyring. The profile directory on disk contains a minimal reference or empty file; the actual secret lives in the keyring.
 
 ### File permissions

--- a/install.sh
+++ b/install.sh
@@ -102,6 +102,16 @@ resolve_install_dir() {
     NEEDS_PATH_NOTE=1
 }
 
+reject_symlink() {
+    path="$1"
+    description="$2"
+
+    if [ -L "$path" ]; then
+        die "Refusing to write through symlinked ${description}: $path
+  Remove the symlink or set AISW_INSTALL_DIR to a real directory and re-run the installer."
+    fi
+}
+
 # ---------------------------------------------------------------------------
 # Checksum verification
 # ---------------------------------------------------------------------------
@@ -244,12 +254,16 @@ main() {
     info "Verifying checksum..."
     verify_checksum "$TMP_BINARY" "$TMP_CHECKSUM"
 
+    reject_symlink "$INSTALL_DIR" "install directory"
+
     # Create the install directory if it doesn't exist (e.g. ~/.local/bin).
     if [ ! -d "$INSTALL_DIR" ]; then
         mkdir -p "$INSTALL_DIR" || die "Could not create install directory: $INSTALL_DIR"
     fi
 
     INSTALL_PATH="$INSTALL_DIR/$BINARY"
+
+    reject_symlink "$INSTALL_PATH" "binary destination"
 
     if [ ! -w "$INSTALL_DIR" ] && [ "$(id -u)" -ne 0 ]; then
         die "Install directory is not writable: $INSTALL_DIR

--- a/tests/install_script.rs
+++ b/tests/install_script.rs
@@ -294,6 +294,23 @@ fn install_script_defaults_to_home_local_bin() {
     assert!(stdout.contains("Note:"));
 }
 
+#[cfg(unix)]
+#[test]
+fn install_script_rejects_symlinked_binary_destination() {
+    let env = InstallerEnv::new("Linux", "x86_64");
+    let install_dir = env.home_dir.join("install");
+    let outside_target = env.home_dir.join("outside");
+    fs::create_dir_all(&install_dir).unwrap();
+    fs::write(&outside_target, "keep me\n").unwrap();
+    std::os::unix::fs::symlink(&outside_target, install_dir.join("aisw")).unwrap();
+
+    let output = env.run(None, Some(&install_dir));
+
+    assert!(!output.status.success());
+    assert_eq!(fs::read_to_string(&outside_target).unwrap(), "keep me\n");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("symlinked binary destination"));
+}
+
 #[test]
 fn install_script_uses_expected_target_for_supported_platforms() {
     for (os, arch) in [


### PR DESCRIPTION
Closes #139

## Why

The release installer wrote directly to `AISW_INSTALL_DIR/aisw`. An existing symlink at that path could redirect an upgrade and overwrite a file outside the requested install directory.

## What changed

- reject symlinked install directories and binary destinations before writing
- add a regression test proving an outside symlink target is unchanged
- document the installer boundary in `docs/security.md`

## Trade-offs

The installer fails closed and asks the user to remove the symlink or choose a real directory. This avoids silently replacing a path whose ownership is ambiguous.

## Verification

- `sh -n install.sh`
- `shellcheck install.sh`
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked --test install_script`
- pre-commit hook: release build, full test suite, completion smoke
