### PR TITLE
Honor active isolated agent roots

### DIFF
--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -98,9 +98,13 @@ The hook installs two sets of wrappers in your shell.
 
 The `aisw` shell function intercepts `aisw use ...` and `aisw context use ...`:
 
-1. Runs the command with `--emit-env` to write live credential files and print shell exports to stdout.
+1. Runs the command with `--emit-env` to calculate the selected state and print shell exports to stdout.
 2. Evals those exports so `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, and `GEMINI_API_KEY` are set immediately in the current session.
-3. Passes all other subcommands through to the binary unchanged.
+3. Runs the command again so credentials are applied to the root the agent will read, then passes all other subcommands through to the binary unchanged.
+
+For isolated Claude and Codex profiles, the second invocation honors the
+active `CLAUDE_CONFIG_DIR` or `CODEX_HOME`. Without shell integration, it
+continues to apply credentials to each tool's standard home directory.
 
 Without the hook, you can do this manually:
 

--- a/src/auth/claude/paths.rs
+++ b/src/auth/claude/paths.rs
@@ -6,9 +6,14 @@
 
 use std::path::{Path, PathBuf};
 
-/// Returns the path to the live `.credentials.json` file, preferring the XDG
-/// secondary location only when it exists and the primary does not.
+/// Returns the path to the active `.credentials.json` file. An explicit
+/// `CLAUDE_CONFIG_DIR` takes precedence; otherwise the XDG secondary location
+/// is preferred only when it exists and the primary does not.
 pub(super) fn live_credentials_path(user_home: &Path) -> PathBuf {
+    if let Some(config_dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        return PathBuf::from(config_dir).join(super::CREDENTIALS_FILE);
+    }
+
     let primary = user_home.join(".claude").join(super::CREDENTIALS_FILE);
     let secondary = user_home
         .join(".config")
@@ -39,9 +44,14 @@ pub(super) fn live_account_metadata_path(user_home: &Path) -> PathBuf {
     user_home.join(".claude.json")
 }
 
-/// Returns the Claude local state directory if it exists. Returns `None` when
-/// neither `~/.claude/` nor `~/.config/claude/` is present.
+/// Returns the active Claude local state directory if it exists. Returns
+/// `None` when the configured directory or both default locations are absent.
 pub fn live_local_state_dir(user_home: &Path) -> Option<PathBuf> {
+    if let Some(config_dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        let config_dir = PathBuf::from(config_dir);
+        return config_dir.exists().then_some(config_dir);
+    }
+
     let primary = user_home.join(".claude");
     if primary.exists() {
         return Some(primary);

--- a/src/auth/codex.rs
+++ b/src/auth/codex.rs
@@ -28,7 +28,9 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 const OAUTH_CAPTURE_DIR: &str = ".oauth-capture";
 
 fn live_dir(user_home: &Path) -> PathBuf {
-    user_home.join(".codex")
+    std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| user_home.join(".codex"))
 }
 
 fn live_auth_path(user_home: &Path) -> PathBuf {

--- a/tests/use_cmd.rs
+++ b/tests/use_cmd.rs
@@ -281,6 +281,48 @@ fn use_claude_shared_emit_env_unsets_claude_config_dir() {
 }
 
 #[test]
+fn use_claude_applies_credentials_to_active_config_dir() {
+    let env = TestEnv::new();
+    add_claude_profile(&env, "work");
+    let active_config_dir = env.fake_home.join("claude-isolated");
+    std::fs::create_dir_all(&active_config_dir).unwrap();
+    std::fs::write(
+        active_config_dir.join(".credentials.json"),
+        br#"{"apiKey":"stale"}"#,
+    )
+    .unwrap();
+
+    env.cmd()
+        .env("CLAUDE_CONFIG_DIR", &active_config_dir)
+        .args(["use", "claude", "work"])
+        .assert()
+        .success();
+
+    let credentials = std::fs::read_to_string(active_config_dir.join(".credentials.json"))
+        .expect("active Claude config directory should contain credentials");
+    assert!(credentials.contains(VALID_CLAUDE_KEY));
+}
+
+#[test]
+fn use_codex_applies_credentials_to_active_codex_home() {
+    let env = TestEnv::new();
+    add_codex_profile(&env, "work");
+    let active_codex_home = env.fake_home.join("codex-isolated");
+    std::fs::create_dir_all(&active_codex_home).unwrap();
+    std::fs::write(active_codex_home.join("auth.json"), br#"{"token":"stale"}"#).unwrap();
+
+    env.cmd()
+        .env("CODEX_HOME", &active_codex_home)
+        .args(["use", "codex", "work"])
+        .assert()
+        .success();
+
+    let credentials = std::fs::read_to_string(active_codex_home.join("auth.json"))
+        .expect("active Codex home should contain credentials");
+    assert!(credentials.contains(VALID_CODEX_KEY));
+}
+
+#[test]
 fn use_claude_macos_oauth_isolated_mode_is_blocked_before_live_mutation() {
     let env = TestEnv::new();
     let profile_dir = env.aisw_home.join("profiles").join("claude").join("work");

--- a/website/src/content/docs/shell-integration.md
+++ b/website/src/content/docs/shell-integration.md
@@ -115,9 +115,13 @@ The hook installs two sets of wrappers in your shell.
 
 The `aisw` shell function intercepts `aisw use ...` and `aisw context use ...`:
 
-1. Runs the command with `--emit-env` to write live credential files and print shell exports to stdout.
+1. Runs the command with `--emit-env` to calculate the selected state and print shell exports to stdout.
 2. Evals those exports so `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, and `GEMINI_API_KEY` are set immediately in the current session.
-3. Passes all other subcommands through to the binary unchanged.
+3. Runs the command again so credentials are applied to the root the agent will read, then passes all other subcommands through to the binary unchanged.
+
+For isolated Claude and Codex profiles, the second invocation honors the
+active `CLAUDE_CONFIG_DIR` or `CODEX_HOME`. Without shell integration, it
+continues to apply credentials to each tool's standard home directory.
 
 Without the hook, you can do this manually:
 


### PR DESCRIPTION
Closes #141

## Why

The shell hook first evaluates `--emit-env`, then runs `aisw use` again with the selected agent root exported. Claude and Codex still derived live credential paths from the default home directory, so isolated API-key switches could report success while the agent read stale credentials elsewhere.

## What changed

- make Claude resolve `.credentials.json` from `CLAUDE_CONFIG_DIR` when set
- make Codex resolve live files from `CODEX_HOME` when set
- preserve standard home-directory behavior when those variables are absent
- add end-to-end regressions for both tools
- document the hook's two-step application behavior

## Trade-offs

The environment variables are the agent-supported source of truth for the active isolated root. The change is centralized in path resolution so status, synchronization, and apply operations observe the same root rather than adding tool-specific exceptions.

## Verification

- reproducer tests failed before the change and pass after it
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `shellcheck install.sh`
- full pre-commit hook: release build, all tests, completion smoke
