### PR TITLE
Keep Antigravity apply callers compatible

### DIFF
--- a/src/auth/antigravity.rs
+++ b/src/auth/antigravity.rs
@@ -417,7 +417,7 @@ pub fn apply_api_key_settings(user_home: &Path) -> Result<()> {
     object.insert("modelProvider".to_owned(), serde_json::json!("gemini"));
     let bytes =
         serde_json::to_vec_pretty(&settings).context("could not serialize Antigravity settings")?;
-    crate::live_apply::apply_transaction(vec![LiveFileChange::write(path, bytes)])
+    crate::live_apply::apply_transaction(user_home, vec![LiveFileChange::write(path, bytes)])
 }
 
 fn build_apply_transaction(


### PR DESCRIPTION
Closes #144

## Why

The live-apply safety boundary now requires each caller to provide its live-state root. Antigravity's API-key settings path still used the old call shape, leaving `main` uncompilable after the safety hardening landed.

## Trade-off

The caller passes the existing user-home boundary; no new path policy or fallback is introduced. This keeps the safety check aligned with the other Antigravity mutation and restore paths.

## Verification

- `cargo fmt --all`
- `cargo test --locked --lib auth::antigravity::tests`
- repository pre-commit hook: formatting, clippy, release build, full test suite, completions smoke
