### PR TITLE
Show configured paths in init diagnostics

### DIFF
--- a/src/auth/claude/mod.rs
+++ b/src/auth/claude/mod.rs
@@ -28,8 +28,6 @@ use keychain::{
     keychain_service_for_config_dir as scoped_keychain_service_for_config_dir, ClaudeAuthStorage,
     ClaudeKeychainScheme as KeychainScheme,
 };
-use paths::live_credentials_path;
-
 // ---- Constants ----
 
 pub(super) const CREDENTIALS_FILE: &str = ".credentials.json";
@@ -116,7 +114,7 @@ pub use oauth::{
     restore_live_state_after_oauth_add, sync_profile_from_active_state_if_same_identity,
     sync_profile_from_live_if_same_identity,
 };
-pub use paths::live_local_state_dir;
+pub use paths::{live_credentials_path, live_local_state_dir};
 
 /// Classifies credential payloads that aisw knows how to apply to Claude.
 ///

--- a/src/auth/claude/paths.rs
+++ b/src/auth/claude/paths.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 /// Returns the path to the active `.credentials.json` file. An explicit
 /// `CLAUDE_CONFIG_DIR` takes precedence; otherwise the XDG secondary location
 /// is preferred only when it exists and the primary does not.
-pub(super) fn live_credentials_path(user_home: &Path) -> PathBuf {
+pub fn live_credentials_path(user_home: &Path) -> PathBuf {
     if let Some(config_dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
         return PathBuf::from(config_dir).join(super::CREDENTIALS_FILE);
     }
@@ -29,6 +29,16 @@ pub(super) fn live_credentials_path(user_home: &Path) -> PathBuf {
 
 /// Returns both possible live credentials paths in priority order.
 pub(super) fn live_credentials_paths(user_home: &Path) -> [PathBuf; 2] {
+    if let Some(config_dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        return [
+            PathBuf::from(config_dir).join(super::CREDENTIALS_FILE),
+            user_home
+                .join(".config")
+                .join("claude")
+                .join(super::CREDENTIALS_FILE),
+        ];
+    }
+
     [
         user_home.join(".claude").join(super::CREDENTIALS_FILE),
         user_home

--- a/src/auth/codex.rs
+++ b/src/auth/codex.rs
@@ -33,7 +33,7 @@ fn live_dir(user_home: &Path) -> PathBuf {
         .unwrap_or_else(|| user_home.join(".codex"))
 }
 
-fn live_auth_path(user_home: &Path) -> PathBuf {
+pub fn live_auth_path(user_home: &Path) -> PathBuf {
     live_dir(user_home).join(AUTH_FILE)
 }
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -653,10 +653,10 @@ fn detect_live_claude(
         {
             (
                 "local_state_without_importable_auth",
-                Some(
-                    "Claude local state exists, but aisw could not find importable auth in ~/.claude/.credentials.json or the system keyring."
-                        .to_owned(),
-                ),
+                Some(format!(
+                    "Claude local state exists, but aisw could not find importable auth in {} or the system keyring.",
+                    auth::claude::live_credentials_path(user_home).display()
+                )),
             )
         } else {
             ("no_live_auth", None)
@@ -748,11 +748,11 @@ fn detect_live_codex(
             let storage = auth::codex::live_auth_storage(user_home)?
                 .unwrap_or(auth::codex::LiveAuthStorage::Auto);
             Some(match storage {
-                auth::codex::LiveAuthStorage::Keyring => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json or the system keyring.".to_owned(),
-                auth::codex::LiveAuthStorage::Auto => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json. Codex may be using the system keyring instead of a file backend.".to_owned(),
-                auth::codex::LiveAuthStorage::File => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json even though the configured backend is file.".to_owned(),
+                auth::codex::LiveAuthStorage::Keyring => format!("Codex local state exists, but aisw could not find importable auth in {} or the system keyring.", auth::codex::live_auth_path(user_home).display()),
+                auth::codex::LiveAuthStorage::Auto => format!("Codex local state exists, but aisw could not find importable auth in {}. Codex may be using the system keyring instead of a file backend.", auth::codex::live_auth_path(user_home).display()),
+                auth::codex::LiveAuthStorage::File => format!("Codex local state exists, but aisw could not find importable auth in {} even though the configured backend is file.", auth::codex::live_auth_path(user_home).display()),
                 auth::codex::LiveAuthStorage::Ephemeral => "Codex is configured for ephemeral credentials, which are process-local and cannot be imported by aisw. Use a durable file or keyring auth mode before running init.".to_owned(),
-                auth::codex::LiveAuthStorage::Unknown => "Codex local state exists, but aisw could not find importable auth in ~/.codex/auth.json. The configured auth backend is not recognized.".to_owned(),
+                auth::codex::LiveAuthStorage::Unknown => format!("Codex local state exists, but aisw could not find importable auth in {}. The configured auth backend is not recognized.", auth::codex::live_auth_path(user_home).display()),
             })
         } else {
             None
@@ -986,10 +986,10 @@ fn import_claude(
     let Some(snapshot) = auth::claude::live_credentials_snapshot_for_import(user_home)? else {
         if auth::claude::keychain_import_supported() && local_state.is_some() {
             output::print_kv("Credentials", "not found in file or Keychain");
-            output::print_info(
-                "Claude local state exists, but aisw could not find importable auth in \
-                 ~/.claude/.credentials.json or the system keyring.",
-            );
+            output::print_info(format!(
+                "Claude local state exists, but aisw could not find importable auth in {} or the system keyring.",
+                auth::claude::live_credentials_path(user_home).display()
+            ));
         } else {
             output::print_kv("Credentials", "not found");
         }
@@ -1206,29 +1206,25 @@ fn import_codex(
                 .unwrap_or(auth::codex::LiveAuthStorage::Auto);
             output::print_kv("Credentials", "not found in auth.json");
             match storage {
-                auth::codex::LiveAuthStorage::Keyring => output::print_info(
-                    "Codex local state exists, but aisw could not find importable auth in \
-                     ~/.codex/auth.json or the system keyring. This install appears to use \
-                     keyring-backed auth, but aisw could not locate a readable credential there.",
-                ),
-                auth::codex::LiveAuthStorage::Auto => output::print_info(
-                    "Codex local state exists, but aisw could not find importable auth in \
-                     ~/.codex/auth.json. Codex defaults to its auto auth-storage mode here, \
-                     which may be using the system keyring instead of a file backend.",
-                ),
-                auth::codex::LiveAuthStorage::File => output::print_info(
-                    "Codex local state exists, but aisw could not find importable auth in \
-                     ~/.codex/auth.json even though the configured backend is file.",
-                ),
+                auth::codex::LiveAuthStorage::Keyring => output::print_info(format!(
+                    "Codex local state exists, but aisw could not find importable auth in {} or the system keyring. This install appears to use keyring-backed auth, but aisw could not locate a readable credential there.",
+                    auth::codex::live_auth_path(user_home).display()
+                )),
+                auth::codex::LiveAuthStorage::Auto => output::print_info(format!(
+                    "Codex local state exists, but aisw could not find importable auth in {}. Codex defaults to its auto auth-storage mode here, which may be using the system keyring instead of a file backend.",
+                    auth::codex::live_auth_path(user_home).display()
+                )),
+                auth::codex::LiveAuthStorage::File => output::print_info(format!(
+                    "Codex local state exists, but aisw could not find importable auth in {} even though the configured backend is file.",
+                    auth::codex::live_auth_path(user_home).display()
+                )),
                 auth::codex::LiveAuthStorage::Ephemeral => output::print_info(
-                    "Codex is configured for ephemeral credentials, which are process-local and \
-                     cannot be imported by aisw. Use a durable file or keyring auth mode before \
-                     running init.",
+                    "Codex is configured for ephemeral credentials, which are process-local and cannot be imported by aisw. Use a durable file or keyring auth mode before running init.",
                 ),
-                auth::codex::LiveAuthStorage::Unknown => output::print_info(
-                    "Codex local state exists, but aisw could not find importable auth in \
-                     ~/.codex/auth.json. The configured auth backend is not recognized.",
-                ),
+                auth::codex::LiveAuthStorage::Unknown => output::print_info(format!(
+                    "Codex local state exists, but aisw could not find importable auth in {}. The configured auth backend is not recognized.",
+                    auth::codex::live_auth_path(user_home).display()
+                )),
             }
             output::print_kv("Auth storage", storage.description());
         } else {

--- a/tests/init_cmd.rs
+++ b/tests/init_cmd.rs
@@ -490,12 +490,14 @@ fn init_prefers_claude_keychain_over_file_on_macos() {
 fn init_reports_claude_local_state_without_importable_auth() {
     let env = TestEnv::new();
     add_fake_security_tool(&env);
-    let claude_dir = env.fake_home.join(".claude");
+    env.add_fake_tool("claude", "claude 2.3.0");
+    let claude_dir = env.fake_home.join("claude-config");
     fs::create_dir_all(&claude_dir).unwrap();
     fs::write(claude_dir.join("settings.json"), b"{\"theme\":\"dark\"}").unwrap();
 
     env.cmd()
         .args(["init", "--yes"])
+        .env("CLAUDE_CONFIG_DIR", &claude_dir)
         .env("AISW_CLAUDE_AUTH_STORAGE", "keychain")
         .env("AISW_SECURITY_BIN", env.bin_dir.join("security"))
         .env("USER", "tester")
@@ -503,7 +505,7 @@ fn init_reports_claude_local_state_without_importable_auth() {
         .success()
         .stdout(contains("Claude Code"))
         .stdout(contains("Local state"))
-        .stdout(contains(".claude"))
+        .stdout(contains(claude_dir.to_string_lossy().as_ref()))
         .stdout(contains("not found in file or Keychain"))
         .stdout(contains("could not find importable auth"));
 
@@ -518,7 +520,8 @@ fn init_reports_claude_local_state_without_importable_auth() {
 #[test]
 fn init_reports_codex_local_state_without_importable_auth() {
     let env = TestEnv::new();
-    let codex_dir = env.fake_home.join(".codex");
+    env.add_fake_tool("codex", "codex 1.0.0");
+    let codex_dir = env.fake_home.join("codex-home");
     fs::create_dir_all(&codex_dir).unwrap();
     fs::write(
         codex_dir.join("config.toml"),
@@ -526,11 +529,14 @@ fn init_reports_codex_local_state_without_importable_auth() {
     )
     .unwrap();
 
-    run_init(&env)
+    env.cmd()
+        .args(["init", "--yes"])
+        .env("CODEX_HOME", &codex_dir)
+        .assert()
         .success()
         .stdout(contains("Codex CLI"))
         .stdout(contains("Local state"))
-        .stdout(contains(".codex"))
+        .stdout(contains(codex_dir.to_string_lossy().as_ref()))
         .stdout(contains("not found in auth.json"))
         .stdout(contains("Auth storage"))
         .stdout(contains("keyring"))


### PR DESCRIPTION
Closes #143

## Why

`init` reported hard-coded default Claude and Codex credential paths even when the tools were configured to use non-default roots. That made a real local-state/import failure misleading to users and automation.

## Trade-offs

- Diagnostics now use the same configured-root resolvers as live credential detection.
- The existing ephemeral Codex guidance remains path-free because process-local credentials have no durable file path.
- No credential discovery or import behavior changes beyond the displayed diagnostic path.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `cargo test --locked` (608 unit tests plus integration suite; 1 opt-in canary ignored)
- pre-commit and pre-push hooks passed
