### PR TITLE
Gate native credential canary failures

### DIFF
--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -41,8 +41,9 @@ jobs:
           security create-keychain -p "" "$keychain_path"
           security set-keychain-settings -lut 3600 "$keychain_path"
           security unlock-keychain -p "" "$keychain_path"
-          security list-keychains -d user -s "$keychain_path"
-          security default-keychain -d user -s "$keychain_path"
+          security list-keychains -s "$keychain_path"
+          security default-keychain -s "$keychain_path"
+          test "$(security default-keychain)" = "\"$keychain_path\""
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -57,7 +58,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(gnome-keyring-daemon --start --components=secrets)\"; cargo test --locked --test real_credential_store_canary -- --list | grep -F \"real_credential_store_canary_covers_secure_auth_modes\""
+            dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(printf '\\n' | gnome-keyring-daemon --unlock --components=secrets)\"; cargo test --locked --test real_credential_store_canary -- --list | grep -F \"real_credential_store_canary_covers_secure_auth_modes\""
           else
             cargo test --locked --test real_credential_store_canary -- --list \
               | grep -F "real_credential_store_canary_covers_secure_auth_modes"
@@ -70,7 +71,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(gnome-keyring-daemon --start --components=secrets)\"; cargo test --locked --test real_credential_store_canary real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture"
+            dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(printf '\\n' | gnome-keyring-daemon --unlock --components=secrets)\"; cargo test --locked --test real_credential_store_canary real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture"
           else
             cargo test --locked --test real_credential_store_canary \
               real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture

--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -21,6 +21,7 @@ jobs:
     if: ${{ inputs.run_canary || github.event_name == 'schedule' }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
@@ -30,6 +31,18 @@ jobs:
       - name: Install system dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y dbus-x11 gnome-keyring libdbus-1-dev pkg-config
+
+      - name: Configure disposable macOS Keychain
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          keychain_path="$RUNNER_TEMP/aisw-canary.keychain-db"
+          security create-keychain -p "" "$keychain_path"
+          security set-keychain-settings -lut 3600 "$keychain_path"
+          security unlock-keychain -p "" "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          security default-keychain -d user -s "$keychain_path"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -61,4 +74,13 @@ jobs:
           else
             cargo test --locked --test real_credential_store_canary \
               real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture
+          fi
+
+      - name: Remove disposable macOS Keychain
+        if: ${{ always() && matrix.os == 'macos-latest' }}
+        shell: bash
+        run: |
+          keychain_path="$RUNNER_TEMP/aisw-canary.keychain-db"
+          if [ -f "$keychain_path" ]; then
+            security delete-keychain "$keychain_path"
           fi

--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -8,6 +8,8 @@ on:
         required: true
         default: false
         type: boolean
+  schedule:
+    - cron: "17 3 * * 1"
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,9 +18,8 @@ env:
 jobs:
   real-credential-store-canary:
     name: Real credential-store canary (${{ matrix.os }})
-    if: ${{ inputs.run_canary }}
+    if: ${{ inputs.run_canary || github.event_name == 'schedule' }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -28,7 +29,7 @@ jobs:
 
       - name: Install system dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y dbus-x11 gnome-keyring libdbus-1-dev pkg-config
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -39,9 +40,25 @@ jobs:
       - name: Run real credential-store canary (ignored test)
         env:
           AISW_ENABLE_REAL_CREDENTIAL_STORE_CANARY: "1"
-        run: cargo test --locked --test real_credential_store_canary -- --list | rg -F "real_credential_store_canary_covers_secure_auth_modes"
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(gnome-keyring-daemon --start --components=secrets)\"; cargo test --locked --test real_credential_store_canary -- --list | rg -F \"real_credential_store_canary_covers_secure_auth_modes\""
+          else
+            cargo test --locked --test real_credential_store_canary -- --list \
+              | rg -F "real_credential_store_canary_covers_secure_auth_modes"
+          fi
 
       - name: Execute real credential-store canary
         env:
           AISW_ENABLE_REAL_CREDENTIAL_STORE_CANARY: "1"
-        run: cargo test --locked --test real_credential_store_canary real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(gnome-keyring-daemon --start --components=secrets)\"; cargo test --locked --test real_credential_store_canary real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture"
+          else
+            cargo test --locked --test real_credential_store_canary \
+              real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture
+          fi

--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -43,7 +43,7 @@ jobs:
           security set-keychain-settings -lut 3600 "$keychain_path"
           security unlock-keychain -p "" "$keychain_path"
           security list-keychains -s "$keychain_path"
-          security default-keychain -s "$keychain_path"
+          security default-keychain -d user -s "$keychain_path"
           security default-keychain
 
       - name: Install Rust

--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -60,6 +60,12 @@ jobs:
           set -euo pipefail
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(printf '\\n' | gnome-keyring-daemon --unlock --components=secrets)\"; cargo test --locked --test real_credential_store_canary -- --list | grep -F \"real_credential_store_canary_covers_secure_auth_modes\""
+          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+            keychain_path="$HOME/Library/Keychains/aisw-canary.keychain-db"
+            security unlock-keychain -p "" "$keychain_path"
+            security default-keychain -d user -s "$keychain_path"
+            cargo test --locked --test real_credential_store_canary -- --list \
+              | grep -F "real_credential_store_canary_covers_secure_auth_modes"
           else
             cargo test --locked --test real_credential_store_canary -- --list \
               | grep -F "real_credential_store_canary_covers_secure_auth_modes"
@@ -73,6 +79,12 @@ jobs:
           set -euo pipefail
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(printf '\\n' | gnome-keyring-daemon --unlock --components=secrets)\"; cargo test --locked --test real_credential_store_canary real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture"
+          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+            keychain_path="$HOME/Library/Keychains/aisw-canary.keychain-db"
+            security unlock-keychain -p "" "$keychain_path"
+            security default-keychain -d user -s "$keychain_path"
+            cargo test --locked --test real_credential_store_canary \
+              real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture
           else
             cargo test --locked --test real_credential_store_canary \
               real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture

--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -44,10 +44,10 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(gnome-keyring-daemon --start --components=secrets)\"; cargo test --locked --test real_credential_store_canary -- --list | rg -F \"real_credential_store_canary_covers_secure_auth_modes\""
+            dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(gnome-keyring-daemon --start --components=secrets)\"; cargo test --locked --test real_credential_store_canary -- --list | grep -F \"real_credential_store_canary_covers_secure_auth_modes\""
           else
             cargo test --locked --test real_credential_store_canary -- --list \
-              | rg -F "real_credential_store_canary_covers_secure_auth_modes"
+              | grep -F "real_credential_store_canary_covers_secure_auth_modes"
           fi
 
       - name: Execute real credential-store canary

--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -23,7 +23,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macOS 13 is the Intel image; ARM hosted images cannot unlock a
+        # newly-created keychain for SecItemCopyMatching (actions/runner-images#13476).
+        os: [ubuntu-latest, macos-15-intel, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +35,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y dbus-x11 gnome-keyring libdbus-1-dev pkg-config
 
       - name: Configure disposable macOS Keychain
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-15-intel'
         shell: bash
         run: |
           set -euo pipefail
@@ -60,7 +62,7 @@ jobs:
           set -euo pipefail
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(printf '\\n' | gnome-keyring-daemon --unlock --components=secrets)\"; cargo test --locked --test real_credential_store_canary -- --list | grep -F \"real_credential_store_canary_covers_secure_auth_modes\""
-          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+          elif [ "${{ matrix.os }}" = "macos-15-intel" ]; then
             keychain_path="$HOME/Library/Keychains/aisw-canary.keychain-db"
             security unlock-keychain -p "" "$keychain_path"
             security default-keychain -d user -s "$keychain_path"
@@ -79,7 +81,7 @@ jobs:
           set -euo pipefail
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             dbus-run-session -- bash -c "set -euo pipefail; eval \"\$(printf '\\n' | gnome-keyring-daemon --unlock --components=secrets)\"; cargo test --locked --test real_credential_store_canary real_credential_store_canary_covers_secure_auth_modes -- --ignored --nocapture"
-          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+          elif [ "${{ matrix.os }}" = "macos-15-intel" ]; then
             keychain_path="$HOME/Library/Keychains/aisw-canary.keychain-db"
             security unlock-keychain -p "" "$keychain_path"
             security default-keychain -d user -s "$keychain_path"
@@ -91,7 +93,7 @@ jobs:
           fi
 
       - name: Remove disposable macOS Keychain
-        if: ${{ always() && matrix.os == 'macos-latest' }}
+        if: ${{ always() && matrix.os == 'macos-15-intel' }}
         shell: bash
         run: |
           keychain_path="$HOME/Library/Keychains/aisw-canary.keychain-db"

--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -37,13 +37,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          keychain_path="$RUNNER_TEMP/aisw-canary.keychain-db"
+          keychain_path="$HOME/Library/Keychains/aisw-canary.keychain-db"
+          mkdir -p "$(dirname "$keychain_path")"
           security create-keychain -p "" "$keychain_path"
           security set-keychain-settings -lut 3600 "$keychain_path"
           security unlock-keychain -p "" "$keychain_path"
           security list-keychains -s "$keychain_path"
           security default-keychain -s "$keychain_path"
-          test "$(security default-keychain)" = "\"$keychain_path\""
+          security default-keychain
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -81,7 +82,7 @@ jobs:
         if: ${{ always() && matrix.os == 'macos-latest' }}
         shell: bash
         run: |
-          keychain_path="$RUNNER_TEMP/aisw-canary.keychain-db"
+          keychain_path="$HOME/Library/Keychains/aisw-canary.keychain-db"
           if [ -f "$keychain_path" ]; then
             security delete-keychain "$keychain_path"
           fi

--- a/docs/acceptance-matrix.md
+++ b/docs/acceptance-matrix.md
@@ -36,4 +36,4 @@ The baseline below records the upstream releases checked against `aisw` `0.3.8` 
 - `Supported diagnostic` means `aisw` can detect and explain the situation without treating it as importable credentials.
 - `Fail-closed` means `aisw` intentionally refuses to guess or synthesize a live secure-store identity when doing so could write an unusable or misleading credential entry.
 - For secure-backed profiles, `aisw` stores the managed secret in the system keyring rather than downgrading it into `AISW_HOME`.
-- The opt-in real credential-store canary runs the secure-profile lifecycle for Claude, Codex, and Antigravity; its Antigravity coverage also preserves and restores the shared `gemini` / `antigravity` live keyring entry.
+- The real credential-store canary runs the secure-profile lifecycle for Claude, Codex, and Antigravity on macOS, Linux, and Windows. It runs weekly and can be launched manually; its Antigravity coverage also preserves and restores the shared `gemini` / `antigravity` live keyring entry. The workflow deliberately fails when a native credential store cannot be initialized rather than treating that platform as a pass.

--- a/docs/security.md
+++ b/docs/security.md
@@ -46,6 +46,13 @@ Directories under `~/.aisw/` are created with `0700`.
 | Linux | Secret Service protocol (GNOME Keyring, KWallet) with vendored libdbus  -  no system dbus development package required |
 | Windows | Windows Credential Manager via WinCred API |
 
+The repository also runs a real credential-store canary across the supported
+macOS, Linux, and Windows runners. It creates uniquely named temporary entries,
+exercises profile switching and removal, and restores any pre-existing entry it
+touches. The canary runs weekly or can be started manually from GitHub Actions;
+it is intentionally fail-closed when a runner cannot initialize its native
+credential store.
+
 On macOS, when writing Claude Code credentials to the Keychain, `aisw` sets a trusted-application ACL so the entry is bound to the `claude` binary path. This prevents other applications from reading the credential without a Keychain access prompt.
 
 On Linux, if the Secret Service daemon is not running (common on headless servers), `aisw` detects this at runtime, emits a diagnostic, and falls back to `0600` file storage rather than silently using a less-secure path.

--- a/tests/real_credential_store_canary.rs
+++ b/tests/real_credential_store_canary.rs
@@ -78,6 +78,31 @@ fn assert_entry_absent(service: &str, account: &str) {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn preauthorize_ci_keychain_entry(service: &str, account: &str) {
+    if std::env::var_os("GITHUB_ACTIONS").is_none() {
+        return;
+    }
+    let output = std::process::Command::new("security")
+        .args([
+            "add-generic-password",
+            "-A",
+            "-s",
+            service,
+            "-a",
+            account,
+            "-w",
+            "aisw-canary-placeholder",
+        ])
+        .output()
+        .expect("security should be available on macOS");
+    assert!(
+        output.status.success(),
+        "could not preauthorize disposable keychain entry {service}/{account}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn canary_suffix() -> String {
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -331,6 +356,17 @@ fn real_credential_store_canary_covers_secure_auth_modes() {
     cleanup.track(codex_api_account.clone()).unwrap();
     cleanup.track(antigravity_account.clone()).unwrap();
     let previous_antigravity_live_secret = cleanup.track_entry("gemini", "antigravity").unwrap();
+
+    for account in [
+        &claude_oauth_account,
+        &claude_api_account,
+        &codex_oauth_account,
+        &codex_api_account,
+        &antigravity_account,
+    ] {
+        preauthorize_ci_keychain_entry(KEYRING_SERVICE, account);
+    }
+    preauthorize_ci_keychain_entry("gemini", "antigravity");
 
     keyring::Entry::new(KEYRING_SERVICE, &claude_oauth_account)
         .unwrap()

--- a/tests/real_credential_store_canary.rs
+++ b/tests/real_credential_store_canary.rs
@@ -118,7 +118,10 @@ fn canary_cmd(env: &TestEnv, bin_dir: &Path, args: &[&str]) -> std::process::Out
         .env_remove("XDG_CONFIG_HOME")
         .env_remove("XDG_DATA_HOME");
     #[cfg(target_os = "macos")]
-    cmd.env_remove("HOME");
+    cmd.env(
+        "HOME",
+        std::env::var("HOME").expect("macOS runner home should be set"),
+    );
     #[cfg(windows)]
     {
         // `dirs::home_dir()` uses the Windows profile known folder, not HOME.

--- a/tests/real_credential_store_canary.rs
+++ b/tests/real_credential_store_canary.rs
@@ -69,6 +69,15 @@ impl Drop for CanaryCleanup {
     }
 }
 
+fn assert_entry_absent(service: &str, account: &str) {
+    let entry = keyring::Entry::new(service, account).unwrap();
+    match entry.get_password() {
+        Err(keyring::Error::NoEntry) => {}
+        Ok(_) => panic!("canary entry was not removed: {service}/{account}"),
+        Err(error) => panic!("could not verify canary cleanup for {service}/{account}: {error}"),
+    }
+}
+
 fn canary_suffix() -> String {
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -441,6 +450,10 @@ fn real_credential_store_canary_covers_secure_auth_modes() {
         ),
         "antigravity remove",
     );
+
+    for tracked in &cleanup.entries[..5] {
+        assert_entry_absent(&tracked.service, &tracked.account);
+    }
 
     cleanup.restore();
     let restored_live_secret = keyring::Entry::new("gemini", "antigravity")

--- a/tests/real_credential_store_canary.rs
+++ b/tests/real_credential_store_canary.rs
@@ -357,16 +357,19 @@ fn real_credential_store_canary_covers_secure_auth_modes() {
     cleanup.track(antigravity_account.clone()).unwrap();
     let previous_antigravity_live_secret = cleanup.track_entry("gemini", "antigravity").unwrap();
 
-    for account in [
-        &claude_oauth_account,
-        &claude_api_account,
-        &codex_oauth_account,
-        &codex_api_account,
-        &antigravity_account,
-    ] {
-        preauthorize_ci_keychain_entry(KEYRING_SERVICE, account);
+    #[cfg(target_os = "macos")]
+    {
+        for account in [
+            &claude_oauth_account,
+            &claude_api_account,
+            &codex_oauth_account,
+            &codex_api_account,
+            &antigravity_account,
+        ] {
+            preauthorize_ci_keychain_entry(KEYRING_SERVICE, account);
+        }
+        preauthorize_ci_keychain_entry("gemini", "antigravity");
     }
-    preauthorize_ci_keychain_entry("gemini", "antigravity");
 
     keyring::Entry::new(KEYRING_SERVICE, &claude_oauth_account)
         .unwrap()

--- a/tests/real_credential_store_canary.rs
+++ b/tests/real_credential_store_canary.rs
@@ -117,6 +117,8 @@ fn canary_cmd(env: &TestEnv, bin_dir: &Path, args: &[&str]) -> std::process::Out
         .env_remove("CODEX_HOME")
         .env_remove("XDG_CONFIG_HOME")
         .env_remove("XDG_DATA_HOME");
+    #[cfg(target_os = "macos")]
+    cmd.env_remove("HOME");
     #[cfg(windows)]
     {
         // `dirs::home_dir()` uses the Windows profile known folder, not HOME.

--- a/website/src/content/docs/security.md
+++ b/website/src/content/docs/security.md
@@ -59,6 +59,13 @@ Directories under `~/.aisw/` are created with `0700`.
 | Linux | Secret Service protocol (GNOME Keyring, KWallet) with vendored libdbus  -  no system dbus development package required |
 | Windows | Windows Credential Manager via WinCred API |
 
+The repository also runs a real credential-store canary across the supported
+macOS, Linux, and Windows runners. It creates uniquely named temporary entries,
+exercises profile switching and removal, and restores any pre-existing entry it
+touches. The canary runs weekly or can be started manually from GitHub Actions;
+it is intentionally fail-closed when a runner cannot initialize its native
+credential store.
+
 On macOS, when writing Claude Code credentials to the Keychain, `aisw` sets a trusted-application ACL so the entry is bound to the `claude` binary path. This prevents other applications from reading the credential without a Keychain access prompt.
 
 On Linux, if the Secret Service daemon is not running (common on headless servers), `aisw` detects this at runtime, emits a diagnostic, and falls back to `0600` file storage rather than silently using a less-secure path.


### PR DESCRIPTION
Related to #147

## Why

Native keyring paths are part of aisw's supported security model, but the existing canary was manual-only and explicitly allowed failures. That made an unavailable or broken credential store indistinguishable from a healthy release baseline.

## Trade-offs

- The canary remains separate from fast PR CI and runs weekly or on demand, so every PR does not mutate a native credential store.
- Linux provisions a disposable Secret Service session; Windows uses its hosted native store directly.
- macOS remains an explicit hosted-runner limitation tracked in #149 rather than being treated as green coverage.
- The test keeps unique entry names and restores pre-existing live state.

## Verification

- `actionlint .github/workflows/credential-store-canary.yml`
- `cargo fmt --all`
- `cargo test --locked --test real_credential_store_canary -- --list`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `cargo test --locked` via commit and push hooks
- Hosted canary: Ubuntu and Windows pass; macOS is intentionally visible as unresolved and tracked in #149.

This PR makes the supported hosted canary failures visible. #147 remains open until macOS coverage is available.
