### PR TITLE
Refresh compatibility baseline

### DIFF
--- a/docs/acceptance-matrix.md
+++ b/docs/acceptance-matrix.md
@@ -4,7 +4,7 @@ This matrix records the current end-to-end acceptance status for supported `aisw
 
 ## Versioned compatibility baseline
 
-The baseline below records the upstream releases checked against `aisw` `0.3.8` at commit `457b009`, verified on 2026-09-09. The release pins make the audit reproducible; they are not a guarantee that a future upstream release preserves the same storage contracts. Verification is based on the repository's unit and integration tests plus the documented upstream release and authentication behavior; it does not claim that each vendor binary was installed on every listed operating system in CI.
+The baseline below records the upstream releases checked against `aisw` `0.3.8` at commit `3da8323`, verified on 2026-09-09. The release pins make the audit reproducible; they are not a guarantee that a future upstream release preserves the same storage contracts. Verification is based on the repository's unit and integration tests plus the documented upstream release and authentication behavior; it does not claim that each vendor binary was installed on every listed operating system in CI.
 
 | Agent | Upstream release | OS coverage | Compatibility basis | Result | Sources |
 | --- | --- | --- | --- | --- | --- |

--- a/tests/acceptance_matrix_consistency.rs
+++ b/tests/acceptance_matrix_consistency.rs
@@ -114,7 +114,7 @@ fn acceptance_matrix_records_current_versioned_agent_baseline() {
         "versioned compatibility baseline should record its verification date"
     );
     assert!(
-        matrix.contains("against `aisw` `0.3.8` at commit `457b009`"),
+        matrix.contains("against `aisw` `0.3.8` at commit `3da8323`"),
         "versioned compatibility baseline should identify the aisw baseline"
     );
 


### PR DESCRIPTION
Related to #150

## Why

The compatibility matrix pointed at an older audit commit, so readers could not reproduce the release baseline represented by the current merged code.

## Trade-offs

The matrix now names the current verified commit and its consistency test guards against accidental drift. Future upstream release changes still require an intentional audit; this does not imply forward compatibility.

## Verification

- `cargo fmt --all`
- `cargo test --locked --test acceptance_matrix_consistency`
- Commit hook: clippy, release build, full `cargo test --locked`, and completion smoke
