### PR TITLE
Preflight secure backup credentials

### DIFF
--- a/src/auth/secure_store.rs
+++ b/src/auth/secure_store.rs
@@ -67,6 +67,15 @@ pub fn snapshot_profile_secret(tool: Tool, profile_name: &str, backup_id: &str) 
 }
 
 pub fn restore_profile_secret(tool: Tool, profile_name: &str, backup_id: &str) -> Result<()> {
+    let bytes = read_backup_secret(tool, profile_name, backup_id)?;
+    write_profile_secret(tool, profile_name, &bytes)
+}
+
+pub fn ensure_backup_secret(tool: Tool, profile_name: &str, backup_id: &str) -> Result<()> {
+    read_backup_secret(tool, profile_name, backup_id).map(|_| ())
+}
+
+fn read_backup_secret(tool: Tool, profile_name: &str, backup_id: &str) -> Result<Vec<u8>> {
     let Some(bytes) = secure_backend::read_generic_password(
         BACKEND,
         SERVICE,
@@ -81,7 +90,7 @@ pub fn restore_profile_secret(tool: Tool, profile_name: &str, backup_id: &str) -
             profile_name
         );
     };
-    write_profile_secret(tool, profile_name, &bytes)
+    Ok(bytes)
 }
 
 pub fn delete_backup_secret(tool: Tool, profile_name: &str, backup_id: &str) -> Result<()> {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -205,6 +205,9 @@ impl BackupManager {
                 let profile_meta =
                     restore_profile_meta(config_store, tool, &profile_name, &profile_path)?;
                 profile_meta.credential_backend.validate_for_tool(tool)?;
+                if profile_meta.credential_backend == CredentialBackend::SystemKeyring {
+                    secure_store::ensure_backup_secret(tool, &profile_name, backup_id)?;
+                }
 
                 let changes = prepare_profile_restore(&profile_path, &dest_dir)?;
                 plans.push(RestorePlan {
@@ -853,6 +856,49 @@ mod tests {
         assert!(cs.load().unwrap().profiles_for(Tool::Claude).is_empty());
         assert!(!ps.exists(Tool::Gemini, "broken"));
         assert!(claude_backup.join("state.json").exists());
+    }
+
+    #[test]
+    fn restore_preflights_missing_secure_secret_before_mutating_files() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempdir().unwrap();
+        let _keyring = EnvVarGuard::set("AISW_KEYRING_TEST_DIR", dir.path().join("keychain"));
+        let backup_id = "missing-secure-secret";
+        let backup_dir = write_legacy_backup(
+            dir.path(),
+            backup_id,
+            Tool::Claude,
+            "work",
+            &[("state.json", b"restored")],
+        );
+        write_metadata(
+            &backup_dir.join(METADATA_FILE),
+            &BackupProfileMetadata {
+                profile_meta: ProfileMeta {
+                    auth_method: AuthMethod::OAuth,
+                    credential_backend: CredentialBackend::SystemKeyring,
+                    ..profile_meta()
+                },
+            },
+        )
+        .unwrap();
+
+        let ps = profile_store(dir.path());
+        ps.create(Tool::Claude, "work").unwrap();
+        ps.write_file(Tool::Claude, "work", "state.json", b"original")
+            .unwrap();
+        let cs = ConfigStore::new(dir.path());
+
+        let err = manager(dir.path())
+            .restore(backup_id, &ps, &cs)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("missing secure credentials"));
+        assert_eq!(
+            ps.read_file(Tool::Claude, "work", "state.json").unwrap(),
+            b"original"
+        );
+        assert!(cs.load().unwrap().profiles_for(Tool::Claude).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #152

## Why
A backup restore could apply profile files before discovering that a keyring-backed backup credential was missing, leaving an error with partial recovery state.

## Trade-offs
The existing all-entry preflight now performs a presence/readability check for secure backup credentials. The credential is still written only during the restore phase, preserving the existing restore flow while preventing the known missing-entry partial mutation.

## Verification
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `cargo test` (609 unit tests and all integration suites)
- completion smoke via pre-commit hook
- regression test for missing secure credentials before file mutation