### PR TITLE
Correct backup ordering guidance

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -162,8 +162,8 @@ aisw status --json | jq '.[] | select(.active_profile_applied == false) | {tool,
 aisw status --json | jq '.[] | select(.credentials_present == false or .permissions_ok == false) | .tool'
 
 # Get the most recent backup for a specific profile
-# Backup ids sort lexicographically, newest last.
-aisw backup list --json | jq -r '[.[] | select(.tool == "claude" and .profile == "work")] | sort_by(.backup_id) | last | .backup_id'
+# Backup ids sort lexicographically, newest first.
+aisw backup list --json | jq -r '[.[] | select(.tool == "claude" and .profile == "work")] | sort_by(.backup_id) | first | .backup_id'
 ```
 
 ## Output contract

--- a/tests/machine_interface_docs.rs
+++ b/tests/machine_interface_docs.rs
@@ -19,6 +19,8 @@ fn automation_docs_publish_the_machine_interface_contract() {
             "The current value for each is `1`.",
             "ignore unknown fields",
             "Treat an unknown version as unsupported",
+            "Backup ids sort lexicographically, newest first.",
+            "sort_by(.backup_id) | first | .backup_id",
         ] {
             assert!(content.contains(expected), "missing {expected}");
         }

--- a/website/src/content/docs/automation.md
+++ b/website/src/content/docs/automation.md
@@ -179,8 +179,8 @@ aisw status --json | jq '.[] | select(.active_profile_applied == false) | {tool,
 aisw status --json | jq '.[] | select(.credentials_present == false or .permissions_ok == false) | .tool'
 
 # Get the most recent backup for a specific profile
-# Backup ids sort lexicographically, newest last.
-aisw backup list --json | jq -r '[.[] | select(.tool == "claude" and .profile == "work")] | sort_by(.backup_id) | last | .backup_id'
+# Backup ids sort lexicographically, newest first.
+aisw backup list --json | jq -r '[.[] | select(.tool == "claude" and .profile == "work")] | sort_by(.backup_id) | first | .backup_id'
 ```
 
 ## Output contract


### PR DESCRIPTION
Closes #154

## Why
The recovery recipe in the automation guide selected the oldest backup even though `backup list --json` returns entries newest-first. That made the documented “most recent backup” command unsafe for automated recovery.

## Trade-offs
The CLI behavior already matches the intended recovery semantics, so this keeps the change limited to the mirrored documentation and a contract assertion rather than introducing a new ordering flag or changing existing consumers.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test machine_interface_docs`
- full pre-commit hook: clippy, release build, 609 unit tests, integration suites, completion smoke
- `git diff --check` with repository whitespace policy