### PR TITLE
Install verified binaries atomically

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -235,9 +235,15 @@ main() {
 
     # Create a temp directory for the download.
     TMP_DIR=$(mktemp -d)
+    STAGED_INSTALL_PATH=
     # Clean up the temp directory on exit regardless of success/failure.
-    # shellcheck disable=SC2064
-    trap "rm -rf '$TMP_DIR'" EXIT
+    cleanup() {
+        rm -rf "$TMP_DIR"
+        if [ -n "${STAGED_INSTALL_PATH:-}" ]; then
+            rm -f "$STAGED_INSTALL_PATH"
+        fi
+    }
+    trap cleanup EXIT
 
     TMP_BINARY="$TMP_DIR/$BINARY_NAME"
     TMP_CHECKSUM="$TMP_DIR/${BINARY_NAME}.sha256"
@@ -270,8 +276,17 @@ main() {
   Set AISW_INSTALL_DIR to a user-writable path and re-run the installer."
     fi
 
-    cp "$TMP_BINARY" "$INSTALL_PATH"
-    chmod +x "$INSTALL_PATH"
+    # Stage beside the destination so the final rename cannot cross filesystems
+    # and a failed update leaves the currently installed binary intact.
+    STAGED_INSTALL_PATH=$(mktemp "$INSTALL_DIR/.aisw-install.XXXXXX") || \
+        die "Could not create a staging file in $INSTALL_DIR"
+    cp "$TMP_BINARY" "$STAGED_INSTALL_PATH" || \
+        die "Could not stage binary in $INSTALL_DIR"
+    chmod +x "$STAGED_INSTALL_PATH" || \
+        die "Could not make staged binary executable"
+    mv -f "$STAGED_INSTALL_PATH" "$INSTALL_PATH" || \
+        die "Could not replace installed binary at $INSTALL_PATH"
+    STAGED_INSTALL_PATH=
 
     echo ""
     echo "aisw ${VERSION_LABEL} installed to $INSTALL_PATH"

--- a/tests/install_script.rs
+++ b/tests/install_script.rs
@@ -9,6 +9,7 @@ const TEST_SHA256: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 struct InstallerEnv {
     _dir: TempDir,
+    stub_dir: PathBuf,
     home_dir: PathBuf,
     curl_log: PathBuf,
     path: String,
@@ -115,6 +116,7 @@ printf '%s\n' "$HOME/.zfunc"
 
         Self {
             _dir: dir,
+            stub_dir,
             home_dir,
             curl_log,
             path,
@@ -309,6 +311,26 @@ fn install_script_rejects_symlinked_binary_destination() {
     assert!(!output.status.success());
     assert_eq!(fs::read_to_string(&outside_target).unwrap(), "keep me\n");
     assert!(String::from_utf8_lossy(&output.stderr).contains("symlinked binary destination"));
+}
+
+#[test]
+fn install_script_retains_existing_binary_when_replacement_fails() {
+    let env = InstallerEnv::new("Linux", "x86_64");
+    let install_dir = env.home_dir.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("aisw");
+    fs::write(&installed, "existing binary\n").unwrap();
+    write_executable(&env.stub_dir.join("mv"), "#!/bin/sh\nexit 1\n");
+
+    let output = env.run(None, Some(&install_dir));
+
+    assert!(!output.status.success());
+    assert_eq!(fs::read_to_string(&installed).unwrap(), "existing binary\n");
+    assert_eq!(
+        fs::read_dir(&install_dir).unwrap().count(),
+        1,
+        "failed replacement should clean up the staged binary"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why

The shell installer verified the downloaded artifact and then copied it directly over the existing executable. An interrupted copy or a full filesystem could therefore turn a valid installation into a truncated one.

## Decision

Stage the verified binary inside the destination directory, apply executable permissions, and rename it into place. The staging location keeps the final replacement on the same filesystem; the exit cleanup removes the staged file after any failure. Existing checksum, symlink, install-location, and completion behavior is unchanged.

## Trade-offs

This briefly requires space for two binaries, but preserves the working installation until the final replacement succeeds. Cargo and Homebrew retain their package-manager behavior because this change is scoped to the shell installer.

## Verification

- `shellcheck install.sh`
- `sh -n install.sh`
- installer tests, including failed-replacement preservation and staging cleanup
- repository pre-commit and pre-push gates: formatting, clippy, release build, full Rust tests, integration suites, and completion smoke

Closes #162
