### PR TITLE
Serialize profile lifecycle changes

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -100,7 +100,10 @@ Backups are also created before profile switching when `backup_on_switch` is ena
 
 All commands that modify `~/.aisw/config.json` take an exclusive lock on the file before writing. If two `aisw` commands run concurrently, the second will wait briefly and then fail with a clear error rather than producing a partial write. This prevents config corruption in parallel CI environments.
 
-Live profile switches take a separate operation lock for their full multi-file transaction. This prevents concurrent `use` and `context use` commands from interleaving credential-file writes with active-profile metadata updates.
+Live profile switches and profile lifecycle mutations take the same operation
+lock for their storage changes. This prevents concurrent `use`, `context use`,
+`rename`, and `remove` commands from interleaving credential-file, keyring, and
+active-profile metadata updates.
 
 ### Input validation
 

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -52,6 +52,8 @@ pub fn run(args: RemoveArgs, home: &Path) -> Result<()> {
 
 /// Entry point for non-interactive use (tests and `--yes` flag).
 pub(crate) fn run_inner(args: RemoveArgs, home: &Path, confirmed: bool) -> Result<()> {
+    // Profile directory and secure-store changes must not race a live switch.
+    let _switch_lock = ConfigStore::new(home).acquire_switch_lock()?;
     let profile_name = args
         .profile_name
         .as_deref()

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -26,6 +26,8 @@ pub fn run(args: RenameArgs, home: &Path) -> Result<()> {
 }
 
 pub(crate) fn run_inner(args: RenameArgs, home: &Path) -> Result<()> {
+    // Profile directory and secure-store changes must not race a live switch.
+    let _switch_lock = ConfigStore::new(home).acquire_switch_lock()?;
     let old_name = args
         .old_name
         .as_deref()
@@ -225,6 +227,8 @@ mod tests {
     use std::ffi::OsString;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
+    use std::thread;
+    use std::time::Duration;
 
     use tempfile::tempdir;
 
@@ -355,6 +359,32 @@ mod tests {
         assert!(ps.exists(Tool::Claude, "work"));
         assert!(config.profiles_for(Tool::Claude).contains_key("work"));
         assert!(!config.profiles_for(Tool::Claude).contains_key("default"));
+    }
+
+    #[test]
+    fn rename_waits_for_an_in_progress_switch() {
+        let tmp = tempdir().unwrap();
+        let ps = ProfileStore::new(tmp.path());
+        let cs = ConfigStore::new(tmp.path());
+        auth::claude::add_api_key(
+            &ps,
+            &cs,
+            "default",
+            "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            None,
+        )
+        .unwrap();
+
+        let switch_lock = cs.acquire_switch_lock().unwrap();
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            drop(switch_lock);
+        });
+
+        run_inner(rename_args(Tool::Claude, "default", "work"), tmp.path()).unwrap();
+        releaser.join().unwrap();
+
+        assert!(ps.exists(Tool::Claude, "work"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #170

## Why

Live switches already serialize filesystem, keyring, and active-profile updates with an operation lock. `rename` and `remove` did not take that lock, so a concurrent switch could observe a profile while its directory or secure credential was being moved or deleted.

## Decision

Use the existing operation lock at the mutation boundary for `rename` and `remove`. Interactive profile selection and confirmation stay outside the lock; only the validated storage/config transaction is serialized. This keeps the change small and avoids introducing a second coordination mechanism.

## Trade-offs

A lifecycle command may wait briefly behind a switch, but that is preferable to a transient missing credential or mismatched live/config state. `add` and uninstall are deliberately left for a separate review because OAuth duration and whole-home deletion require different lock-scope decisions.

## Verification

- `cargo test --locked commands::rename::tests:: --lib`
- `cargo test --locked commands::remove::tests:: --lib`
- `.githooks/pre-commit` — passed; 614 unit tests plus integration suites and completion smoke
- `.githooks/pre-push` — passed; full tests and release build
