### PR TITLE
Serialize profile additions

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -105,6 +105,11 @@ lock for their storage changes. This prevents concurrent `use`, `context use`,
 `rename`, and `remove` commands from interleaving credential-file, keyring, and
 active-profile metadata updates.
 
+Profile additions and live imports use the same lock because OAuth capture and
+credential writes can also change the live credential owner. An interactive
+login may therefore make a concurrent switch wait or fail with the normal lock
+timeout rather than allowing two commands to compete for live state.
+
 ### Input validation
 
 Profile names are restricted to `a-z`, `A-Z`, `0-9`, `-`, and `_`, and every read and write resolves inside the profile directory, so a name can never reach a path outside `~/.aisw/profiles/`. `aisw` refuses to read or write through a symlink at a credential path. Permission repair also refuses a symlinked `AISW_HOME` root, so it cannot traverse an alias into an unrelated directory.

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -27,6 +27,9 @@ pub fn run(args: AddArgs, home: &Path) -> Result<()> {
 }
 
 pub(crate) fn run_in(args: AddArgs, home: &Path, tool_path: OsString) -> Result<()> {
+    // Profile creation/import can mutate the live credential owner; serialize
+    // it with switches and other profile lifecycle operations.
+    let _switch_lock = ConfigStore::new(home).acquire_switch_lock()?;
     let mut progress = machine::ProgressReporter::new(
         "add",
         Some(args.tool.binary_name()),
@@ -1572,6 +1575,8 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
     use std::sync::{Mutex, OnceLock};
+    use std::thread;
+    use std::time::Duration;
 
     use tempfile::tempdir;
 
@@ -1726,6 +1731,33 @@ mod tests {
 
         let config = ConfigStore::new(&home).load().unwrap();
         assert!(config.profiles_for(Tool::Claude).contains_key("work"));
+    }
+
+    #[test]
+    fn add_waits_for_an_in_progress_switch() {
+        let _g = crate::SPAWN_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&bin_dir).unwrap();
+        make_fake_binary(&bin_dir, "claude");
+
+        let switch_lock = ConfigStore::new(&home).acquire_switch_lock().unwrap();
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            drop(switch_lock);
+        });
+
+        run_in(
+            add_args_api_key(Tool::Claude, "work", claude_key()),
+            &home,
+            path_of(&bin_dir),
+        )
+        .unwrap();
+        releaser.join().unwrap();
+
+        assert!(ProfileStore::new(&home).exists(Tool::Claude, "work"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #172

## Why

Live switches, rename, and remove already share an operation lock, but `add` and `--from-live` did not. That allowed profile creation or live OAuth capture to overlap a switch that owns the same credential state.

## Decision

Acquire the existing operation lock around the complete add/import workflow. This covers live capture, managed profile writes, secure-store writes, and active-profile updates without introducing another coordination mechanism.

## Trade-offs

Interactive OAuth can hold the lock while the user completes upstream login. A concurrent switch may therefore wait or receive the normal lock-timeout error, which is preferable to competing writes against one live credential owner. Uninstall remains separate because whole-home deletion needs its own recovery and lock-scope review.

## Verification

- `cargo test --locked commands::add::tests:: --lib` — 43 passed
- `.githooks/pre-commit` — passed; 615 unit tests plus integration suites and completion smoke
- `.githooks/pre-push` — passed; full tests and release build
