### PR TITLE
Serialize backup restores

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -100,10 +100,10 @@ Backups are also created before profile switching when `backup_on_switch` is ena
 
 All commands that modify `~/.aisw/config.json` take an exclusive lock on the file before writing. If two `aisw` commands run concurrently, the second will wait briefly and then fail with a clear error rather than producing a partial write. This prevents config corruption in parallel CI environments.
 
-Live profile switches and profile lifecycle mutations take the same operation
-lock for their storage changes. This prevents concurrent `use`, `context use`,
-`rename`, and `remove` commands from interleaving credential-file, keyring, and
-active-profile metadata updates.
+Live profile switches, backup restores, and profile lifecycle mutations take
+the same operation lock for their storage changes. This prevents concurrent
+`use`, `context use`, `backup restore`, `rename`, and `remove` commands from
+interleaving credential-file, keyring, and active-profile metadata updates.
 
 Profile additions and live imports use the same lock because OAuth capture and
 credential writes can also change the live credential owner. An interactive

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -224,6 +224,9 @@ pub(crate) fn run_restore_inner(
     let manager = BackupManager::new(home);
     let profile_store = ProfileStore::new(home);
     let config_store = ConfigStore::new(home);
+    // Restores mutate profile files and config, so they must not interleave
+    // with switching or another profile lifecycle operation.
+    let _switch_lock = config_store.acquire_switch_lock()?;
 
     let entries = manager.list()?;
     let matching: Vec<_> = entries
@@ -259,6 +262,9 @@ pub(crate) fn run_restore_inner(
 
 #[cfg(test)]
 mod tests {
+    use std::thread;
+    use std::time::Duration;
+
     use tempfile::tempdir;
 
     use super::*;
@@ -348,6 +354,23 @@ mod tests {
 
         let contents = ps.read_file(Tool::Claude, "work", "creds.json").unwrap();
         assert_eq!(contents, b"{\"key\":\"val\"}");
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn restore_waits_for_an_in_progress_switch() {
+        let dir = tempdir().unwrap();
+        make_profile(dir.path(), Tool::Claude, "work");
+        let backup_id = snapshot(dir.path(), Tool::Claude, "work");
+
+        let switch_lock = ConfigStore::new(dir.path()).acquire_switch_lock().unwrap();
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            drop(switch_lock);
+        });
+
+        run_restore_inner(&backup_id, dir.path()).unwrap();
+        releaser.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Closes #176

## Why

Backup restore writes managed profile files and configuration, but it was outside the shared operation lock. A restore racing with `use`, `add`, `rename`, or `remove` could leave those stores from different operations combined.

## Trade-offs

Restore now waits behind the same short operation lock used by profile switching and lifecycle changes. If the competing operation exceeds the existing timeout, restore fails with the normal actionable lock diagnostic rather than risking mixed credential state.

## Verification

- `cargo fmt --all -- --check`
- `cargo test backup::tests --lib`
- `cargo test --test backup_cmd`
- project pre-commit hook passed (format, clippy, release build, 617 tests, completion smoke)
- project pre-push hook passed (617 tests, release build)
