### PR TITLE
Serialize init operations

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -100,10 +100,13 @@ Backups are also created before profile switching when `backup_on_switch` is ena
 
 All commands that modify `~/.aisw/config.json` take an exclusive lock on the file before writing. If two `aisw` commands run concurrently, the second will wait briefly and then fail with a clear error rather than producing a partial write. This prevents config corruption in parallel CI environments.
 
-Live profile switches, backup restores, and profile lifecycle mutations take
-the same operation lock for their storage changes. This prevents concurrent
-`use`, `context use`, `backup restore`, `rename`, and `remove` commands from
-interleaving credential-file, keyring, and active-profile metadata updates.
+Initialization, live profile switches, backup restores, and profile lifecycle
+mutations take the same operation lock for their storage changes. This
+prevents concurrent `init`, `use`, `context use`, `backup restore`, `rename`,
+and `remove` commands from interleaving credential-file, keyring, shell-hook,
+and active-profile metadata updates. Machine-readable initialization holds
+the lock while creating or loading AISW state, then performs read-only
+detection outside it.
 
 Profile additions and live imports use the same lock because OAuth capture and
 credential writes can also change the live credential owner. An interactive

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -73,6 +73,10 @@ pub(crate) fn run_inner(
     shell_env: Option<&str>,
     confirmed: bool,
 ) -> Result<()> {
+    // Init imports credentials and may activate profiles, so it must not
+    // interleave with another operation that changes managed state.
+    let _switch_lock = ConfigStore::new(aisw_home).acquire_switch_lock()?;
+
     // Ensure ~/.aisw/ exists with a default config.json.
     fs::create_dir_all(aisw_home)
         .with_context(|| format!("could not create {}", aisw_home.display()))?;
@@ -131,7 +135,11 @@ pub(crate) fn run_machine(
         );
     }
 
-    let (created_home, created_config) = ensure_aisw_home(aisw_home)?;
+    let (created_home, created_config) = {
+        // Home/config creation is the only mutating part of machine init.
+        let _switch_lock = ConfigStore::new(aisw_home).acquire_switch_lock()?;
+        ensure_aisw_home(aisw_home)?
+    };
     let detected_tools = detect_supported_tools();
     let shell_name = normalized_shell_name(shell_env);
     let live_accounts = if args.detect_live {
@@ -1479,6 +1487,8 @@ fn import_gemini(
 #[cfg(test)]
 mod tests {
     use std::fs;
+    #[cfg(not(windows))]
+    use std::{thread, time::Duration};
 
     use tempfile::tempdir;
 
@@ -1500,6 +1510,25 @@ mod tests {
         let (created_home, created_config) = ensure_aisw_home(&aisw_home).unwrap();
         assert!(!created_home);
         assert!(!created_config);
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn init_waits_for_an_in_progress_switch() {
+        let tmp = tempdir().unwrap();
+        let aisw_home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("home");
+        let config_store = ConfigStore::new(&aisw_home);
+        let switch_lock = config_store.acquire_switch_lock().unwrap();
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            drop(switch_lock);
+        });
+
+        run(&aisw_home, &user_home, None).unwrap();
+        releaser.join().unwrap();
+
+        assert!(aisw_home.join("config.json").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Why

`aisw init` is a state-changing workflow: it can create managed state, install shell hooks, import live credentials, create profiles, and activate them. Without the shared operation lock, it can interleave with a profile switch or lifecycle mutation and leave managed files, keyring state, or active-profile metadata out of sync.

## What changed

- Serialize interactive init for its full mutating workflow.
- Serialize machine init only while creating/loading AISW home and config; keep tool and live-account detection outside the lock because it is read-only.
- Add Unix lock-contention coverage and document the cross-command invariant.

The implementation uses the existing lock and preserves the Windows behavior already documented for lock contention tests: Windows rejects a second handle before the retry loop can observe contention, so the timing test is Unix-only while the production lock remains cross-platform.

Closes #178

## Verification

- `cargo fmt --all -- --check`
- `cargo test commands::init::tests --lib` (20 passed)
- `./.githooks/pre-commit` (617 passed, 1 ignored; clippy, release build, completions passed)
- `./.githooks/pre-push` (full suite and release build passed)
