### PR TITLE
Serialize uninstall operations

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -121,7 +121,7 @@ API keys must be a single line. Keys containing control characters are rejected,
 
 ### Deletion
 
-`aisw uninstall --remove-data` deletes `~/.aisw/` **and** the OS keyring entries `aisw` created for profiles and backups, so no managed secret outlives the data directory. It refuses to run when `AISW_HOME` points at your home directory. If managed metadata cannot be read or a keyring entry cannot be removed, uninstall fails before deleting `AISW_HOME`, leaving the data available for retry.
+`aisw uninstall --remove-data` deletes `~/.aisw/` **and** the OS keyring entries `aisw` created for profiles and backups, so no managed secret outlives the data directory. It refuses to run when `AISW_HOME` points at your home directory. Applying uninstall takes the shared operation lock for hook removal, secret purge, and data deletion, so it cannot interleave with a profile operation. If managed metadata cannot be read or a keyring entry cannot be removed, uninstall fails before deleting `AISW_HOME`, leaving the data available for retry.
 
 ## OAuth flows
 

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -39,14 +39,18 @@ pub fn run(args: UninstallArgs, home: &Path, user_home: &Path) -> Result<()> {
 }
 
 pub(crate) fn run_inner(args: UninstallArgs, home: &Path, user_home: &Path) -> Result<()> {
-    let plan = build_plan(home, user_home)?;
-
     if args.dry_run {
+        let plan = build_plan(home, user_home)?;
         print_summary("Uninstall dry run", &plan, &args, true);
         output::print_blank_line();
         output::print_next_step("Review the plan above, then run 'aisw uninstall --yes' or add '--remove-data' if you also want to delete AISW_HOME.");
         return Ok(());
     }
+
+    // Uninstall removes shared state and may purge keyring credentials, so
+    // keep the complete destructive workflow exclusive with other operations.
+    let _switch_lock = ConfigStore::new(home).acquire_switch_lock()?;
+    let plan = build_plan(home, user_home)?;
 
     let mut removed_hooks = Vec::new();
     for rc in &plan.shell_hook_files {
@@ -315,6 +319,9 @@ fn strip_hook_block(contents: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(windows))]
+    use std::{thread, time::Duration};
+
     use tempfile::tempdir;
 
     use super::*;
@@ -386,6 +393,36 @@ mod tests {
         assert!(fs::read_to_string(zshrc)
             .unwrap()
             .contains("shell-hook zsh"));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn uninstall_waits_for_an_in_progress_switch() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("aisw");
+        let user_home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&user_home).unwrap();
+        let config_store = ConfigStore::new(&home);
+        let switch_lock = config_store.acquire_switch_lock().unwrap();
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            drop(switch_lock);
+        });
+
+        run_inner(
+            UninstallArgs {
+                remove_data: false,
+                dry_run: false,
+                yes: true,
+            },
+            &home,
+            &user_home,
+        )
+        .unwrap();
+        releaser.join().unwrap();
+
+        assert!(home.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Why

Applying `aisw uninstall` removes managed shell hooks and can purge keyring credentials before deleting AISW_HOME. It previously did that without the shared operation lock, allowing a concurrent switch, import, or restore to mutate the same state during cleanup.

## What changed

- Keep dry-run planning read-only and unlocked.
- Lock the complete applying workflow, including a fresh plan, hook removal, secret purge, and data deletion.
- Add Unix contention coverage and document the destructive-operation invariant.

The existing safe-home guard and fail-closed purge behavior are unchanged. Windows retains the repository's platform-specific lock-test exclusion because a second handle to a locked file fails before the retry path can observe contention; production locking remains cross-platform.

Closes #180

## Verification

- `cargo fmt --all -- --check`
- `cargo test commands::uninstall::tests --lib` (10 passed)
- `./.githooks/pre-commit` (618 passed, 1 ignored; clippy, release build, completions passed)
- `./.githooks/pre-push` (full suite and release build passed)
