### PR TITLE
Serialize repair apply operations

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -100,13 +100,15 @@ Backups are also created before profile switching when `backup_on_switch` is ena
 
 All commands that modify `~/.aisw/config.json` take an exclusive lock on the file before writing. If two `aisw` commands run concurrently, the second will wait briefly and then fail with a clear error rather than producing a partial write. This prevents config corruption in parallel CI environments.
 
-Initialization, live profile switches, backup restores, and profile lifecycle
-mutations take the same operation lock for their storage changes. This
+Initialization, repair apply, live profile switches, backup restores, and
+profile lifecycle mutations take the same operation lock for their storage
+changes. This
 prevents concurrent `init`, `use`, `context use`, `backup restore`, `rename`,
-and `remove` commands from interleaving credential-file, keyring, shell-hook,
-and active-profile metadata updates. Machine-readable initialization holds
-the lock while creating or loading AISW state, then performs read-only
-detection outside it.
+`remove`, and `repair --apply` commands from interleaving credential-file,
+keyring, shell-hook, permission, and active-profile metadata updates.
+Machine-readable initialization holds the lock while creating or loading AISW
+state, then performs read-only detection outside it. Repair dry runs remain
+read-only and do not acquire the operation lock.
 
 Profile additions and live imports use the same lock because OAuth capture and
 credential writes can also change the live credential owner. An interactive

--- a/src/commands/repair.rs
+++ b/src/commands/repair.rs
@@ -82,10 +82,14 @@ pub fn run(args: RepairArgs, home: &Path) -> Result<()> {
         RepairMode::DryRun
     };
 
-    let actions = plan_actions(home, &requested_fixes)?;
     let result = if mode == RepairMode::Apply {
+        // Repair apply changes shared state, so refresh and apply the plan
+        // while excluding concurrent switches, restores, and cleanup.
+        let _switch_lock = ConfigStore::new(home).acquire_switch_lock()?;
+        let actions = plan_actions(home, &requested_fixes)?;
         apply_actions(home, &requested_fixes, actions)?
     } else {
+        let actions = plan_actions(home, &requested_fixes)?;
         dry_run_result(&requested_fixes, actions)
     };
 
@@ -395,6 +399,9 @@ fn print_text(result: &RepairResult) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(windows))]
+    use std::{thread, time::Duration};
+
     use super::*;
     use tempfile::tempdir;
 
@@ -463,5 +470,31 @@ mod tests {
                 & 0o777,
             0o644
         );
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn repair_apply_waits_for_an_in_progress_switch() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("aisw");
+        let switch_lock = ConfigStore::new(&home).acquire_switch_lock().unwrap();
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            drop(switch_lock);
+        });
+
+        run(
+            RepairArgs {
+                json: false,
+                dry_run: false,
+                apply: true,
+                fix: vec![RepairFix::Home],
+            },
+            &home,
+        )
+        .unwrap();
+        releaser.join().unwrap();
+
+        assert!(home.join("config.json").exists());
     }
 }


### PR DESCRIPTION
## Why

`aisw repair --apply` can create managed state and change permissions while another command is switching profiles, restoring a backup, initializing, or uninstalling. Without the shared operation lock, those writes can overlap.

## What changed

- Keep dry-run repair observational and unlocked.
- For apply, acquire the existing operation lock, recompute the repair plan under it, and apply all selected fixes while holding it.
- Add Unix contention coverage and document the cross-command invariant.

The existing permission and symlink protections remain unchanged. The production lock is cross-platform; as with the repository's other lock timing tests, the contention test is excluded on Windows because Windows rejects a second handle before the retry loop can observe contention.

Closes #182

## Verification

- `cargo fmt --all -- --check`
- `cargo test commands::repair::tests --lib` (4 passed)
- `./.githooks/pre-commit` (620 passed, 1 ignored; clippy, release build, completions passed)
- `./.githooks/pre-push` (full suite and release build passed)
