### PR TITLE
Serialize context mutations

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -100,12 +100,13 @@ Backups are also created before profile switching when `backup_on_switch` is ena
 
 All commands that modify `~/.aisw/config.json` take an exclusive lock on the file before writing. If two `aisw` commands run concurrently, the second will wait briefly and then fail with a clear error rather than producing a partial write. This prevents config corruption in parallel CI environments.
 
-Initialization, repair apply, live profile switches, backup restores, and
-profile lifecycle mutations take the same operation lock for their storage
-changes. This
-prevents concurrent `init`, `use`, `context use`, `backup restore`, `rename`,
-`remove`, and `repair --apply` commands from interleaving credential-file,
-keyring, shell-hook, permission, and active-profile metadata updates.
+Initialization, repair apply, context mutations, live profile switches,
+backup restores, and profile lifecycle mutations take the same operation lock
+for their storage changes. This prevents concurrent `init`, `context create`,
+`context set`, `context unset`, `context remove`, `context rename`, `use`,
+`context use`, `backup restore`, `rename`, `remove`, and `repair --apply`
+commands from interleaving credential-file, keyring, shell-hook, permission,
+and active-profile metadata updates.
 Machine-readable initialization holds the lock while creating or loading AISW
 state, then performs read-only detection outside it. Repair dry runs remain
 read-only and do not acquire the operation lock.

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -24,14 +24,22 @@ use crate::types::{StateMode, Tool};
 
 pub fn run(args: ContextArgs, home: &Path) -> Result<()> {
     match args.command {
-        ContextCommand::Create(args) => create(args, home),
+        ContextCommand::Create(args) => with_operation_lock(home, || create(args, home)),
         ContextCommand::List(args) => list(args, home),
         ContextCommand::Use(args) => use_context(args, home),
-        ContextCommand::Set(args) => set(args, home),
-        ContextCommand::Unset(args) => unset(args, home),
-        ContextCommand::Remove(args) => remove(args, home),
-        ContextCommand::Rename(args) => rename(args, home),
+        ContextCommand::Set(args) => with_operation_lock(home, || set(args, home)),
+        ContextCommand::Unset(args) => with_operation_lock(home, || unset(args, home)),
+        ContextCommand::Remove(args) => with_operation_lock(home, || remove(args, home)),
+        ContextCommand::Rename(args) => with_operation_lock(home, || rename(args, home)),
     }
+}
+
+fn with_operation_lock<F>(home: &Path, operation: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    let _switch_lock = ConfigStore::new(home).acquire_switch_lock()?;
+    operation()
 }
 
 fn create(args: ContextCreateArgs, home: &Path) -> Result<()> {
@@ -710,4 +718,67 @@ fn remaining_context_names(config: &Config) -> Vec<String> {
     let mut names = config.contexts().keys().cloned().collect::<Vec<_>>();
     names.sort();
     names
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(windows))]
+    use std::{thread, time::Duration};
+
+    use chrono::Utc;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::config::{AuthMethod, CredentialBackend, ProfileMeta};
+    use crate::profile::ProfileStore;
+
+    #[test]
+    #[cfg(not(windows))]
+    fn context_create_waits_for_an_in_progress_switch() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("aisw");
+        let profile_store = ProfileStore::new(&home);
+        let config_store = ConfigStore::new(&home);
+        profile_store.create(Tool::Claude, "work").unwrap();
+        config_store
+            .add_profile(
+                Tool::Claude,
+                "work",
+                ProfileMeta {
+                    added_at: Utc::now(),
+                    auth_method: AuthMethod::ApiKey,
+                    credential_backend: CredentialBackend::File,
+                    label: None,
+                },
+            )
+            .unwrap();
+
+        let switch_lock = config_store.acquire_switch_lock().unwrap();
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            drop(switch_lock);
+        });
+
+        run(
+            ContextArgs {
+                command: ContextCommand::Create(ContextCreateArgs {
+                    context_name: "work".to_owned(),
+                    claude: Some("work".to_owned()),
+                    codex: None,
+                    gemini: None,
+                    antigravity: None,
+                    json: true,
+                }),
+            },
+            &home,
+        )
+        .unwrap();
+        releaser.join().unwrap();
+
+        assert!(ConfigStore::new(&home)
+            .load()
+            .unwrap()
+            .context("work")
+            .is_some());
+    }
 }


### PR DESCRIPTION
## Why

Context activation already takes the shared operation lock because it resolves mappings and changes live agent state. Context `create`, `set`, `unset`, `remove`, and `rename` did not take that lock, so a context definition could change while activation was reading and applying it.

## What changed

- Serialize all mutating context commands with the existing operation lock.
- Keep context listing read-only and preserve `context use`'s existing lock.
- Add lock-contention coverage and document the ordering guarantee.

The config-file lock still protects each atomic write; the operation lock coordinates those writes with live profile operations. The timing test follows the repository's Unix-only lock-contention convention, while production behavior remains cross-platform.

Closes #184

## Verification

- `cargo fmt --all -- --check`
- `cargo test commands::context::tests --lib` (1 passed)
- `./.githooks/pre-commit` (621 passed, 1 ignored; clippy, release build, completions passed)
- `./.githooks/pre-push` (full suite and release build passed)
