### PR TITLE
Serialize workspace mutations

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -100,16 +100,19 @@ Backups are also created before profile switching when `backup_on_switch` is ena
 
 All commands that modify `~/.aisw/config.json` take an exclusive lock on the file before writing. If two `aisw` commands run concurrently, the second will wait briefly and then fail with a clear error rather than producing a partial write. This prevents config corruption in parallel CI environments.
 
-Initialization, repair apply, context mutations, live profile switches,
+Initialization, repair apply, context mutations, workspace policy mutations,
+live profile switches,
 backup restores, and profile lifecycle mutations take the same operation lock
 for their storage changes. This prevents concurrent `init`, `context create`,
-`context set`, `context unset`, `context remove`, `context rename`, `use`,
-`context use`, `backup restore`, `rename`, `remove`, and `repair --apply`
+`context set`, `context unset`, `context remove`, `context rename`,
+`workspace bind`, `workspace unbind`, `workspace guard`, `use`, `context use`,
+`backup restore`, `rename`, `remove`, and `repair --apply`
 commands from interleaving credential-file, keyring, shell-hook, permission,
-and active-profile metadata updates.
+workspace-policy, and active-profile metadata updates.
 Machine-readable initialization holds the lock while creating or loading AISW
 state, then performs read-only detection outside it. Repair dry runs remain
-read-only and do not acquire the operation lock.
+read-only and do not acquire the operation lock; workspace status, doctor, and
+check are likewise read-only.
 
 Profile additions and live imports use the same lock because OAuth capture and
 credential writes can also change the live credential owner. An interactive

--- a/src/commands/workspace.rs
+++ b/src/commands/workspace.rs
@@ -21,13 +21,21 @@ use crate::workspace::{
 
 pub fn run(args: WorkspaceArgs, home: &Path) -> Result<()> {
     match args.command {
-        WorkspaceCommand::Bind(args) => bind(args, home),
-        WorkspaceCommand::Unbind(args) => unbind(args, home),
+        WorkspaceCommand::Bind(args) => with_operation_lock(home, || bind(args, home)),
+        WorkspaceCommand::Unbind(args) => with_operation_lock(home, || unbind(args, home)),
         WorkspaceCommand::Status(args) => status(args, home),
         WorkspaceCommand::Doctor(args) => doctor(args, home),
-        WorkspaceCommand::Guard(args) => guard(args, home),
+        WorkspaceCommand::Guard(args) => with_operation_lock(home, || guard(args, home)),
         WorkspaceCommand::Check(args) => check(args, home),
     }
+}
+
+fn with_operation_lock<F>(home: &Path, operation: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    let _switch_lock = ConfigStore::new(home).acquire_switch_lock()?;
+    operation()
 }
 
 fn bind(args: WorkspaceBindArgs, home: &Path) -> Result<()> {
@@ -648,5 +656,49 @@ fn doctor_check(name: &str, status: &'static str, message: String) -> DoctorChec
         name: name.to_owned(),
         status,
         message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(windows))]
+    use std::{thread, time::Duration};
+
+    #[cfg(not(windows))]
+    use tempfile::tempdir;
+
+    #[cfg(not(windows))]
+    use super::*;
+    #[cfg(not(windows))]
+    use crate::cli::{WorkspaceCommand, WorkspaceGuardMode};
+
+    #[test]
+    #[cfg(not(windows))]
+    fn workspace_guard_waits_for_an_in_progress_switch() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("aisw");
+        let config_store = ConfigStore::new(&home);
+        let switch_lock = config_store.acquire_switch_lock().unwrap();
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            drop(switch_lock);
+        });
+
+        run(
+            WorkspaceArgs {
+                command: WorkspaceCommand::Guard(WorkspaceGuardArgs {
+                    mode: WorkspaceGuardMode::Strict,
+                    json: true,
+                }),
+            },
+            &home,
+        )
+        .unwrap();
+        releaser.join().unwrap();
+
+        assert_eq!(
+            WorkspaceStore::new(&home).load().unwrap().guard_mode,
+            GuardMode::Strict
+        );
     }
 }


### PR DESCRIPTION
## Why

Workspace policy edits can race with profile activation because they currently only take the workspace-file lock. A concurrent `use` or `context use` can therefore read workspace policy while it is being changed, leaving the operation boundary inconsistent.

## What changed

- Serialize `workspace bind`, `workspace unbind`, and `workspace guard` with the shared operation lock.
- Keep `workspace status`, `workspace doctor`, and the internal `workspace check` read-only and lock-free.
- Add a contention regression test.
- Document the lock boundary and read-only exceptions.

## Trade-offs

Policy edits may wait behind a live profile operation, but this gives state-changing commands one consistent serialization boundary. Read-only inspection remains immediately available.

## Verification

- `cargo fmt --all -- --check`
- `cargo test commands::workspace::tests --lib` (1 passed)
- `./.githooks/pre-commit` (622 tests, 1 ignored, clippy, release build, integration suites, completions smoke)
- `./.githooks/pre-push` (full test suite and release build)

Closes #186
