### PR TITLE
Report dangling active profiles

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -662,6 +662,7 @@ Read-only confidence check that combines installation health with live profile c
 - Reuses `doctor` checks for binaries, config, shell hook, keyring, and permissions.
 - Verifies whether each active tool's live credentials still match the profile `aisw` records as active.
 - Returns non-zero when concrete failures are found, such as live mismatch, missing managed credentials, or missing binaries.
+- Reports a clear repair hint when the recorded active profile is missing from the managed profile map.
 
 | Flag | Effect |
 |---|---|

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -116,6 +116,14 @@ fn tool_verification(tool: &status::ToolStatus) -> ToolVerification {
             ));
             VerifyStatus::Warn
         }
+    } else if !tool.active_profile_registered {
+        issues.push("active profile is missing from aisw config".to_owned());
+        remediation.push(format!(
+            "Run 'aisw repair --apply' or re-add {} {}",
+            tool.tool.binary_name(),
+            tool.active_profile.as_deref().unwrap_or("<profile>")
+        ));
+        VerifyStatus::Fail
     } else if tool.credential_state == status::CredentialState::Unknown {
         issues.push("managed credential layout is not recognized".to_owned());
         remediation.push(
@@ -346,6 +354,20 @@ mod tests {
 
         assert_eq!(result.status, VerifyStatus::Warn);
         assert!(result.issues[0].contains("layout"));
+    }
+
+    #[test]
+    fn verify_fails_when_active_profile_is_dangling() {
+        let mut tool = tool_status(Tool::Claude);
+        tool.active_profile_registered = false;
+        tool.credentials_present = false;
+        tool.credential_state = status::CredentialState::Missing;
+
+        let result = tool_verification(&tool);
+
+        assert_eq!(result.status, VerifyStatus::Fail);
+        assert!(result.issues[0].contains("missing from aisw config"));
+        assert!(result.remediation[0].contains("aisw repair --apply"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

A config can retain an active profile name after the corresponding profile entry is gone. `status` identifies this root cause, but `verify` continued through the normal credential checks and reported a secondary failure, making automation and recovery less direct.

## What changed

- Make `verify` fail explicitly when the active profile is not registered.
- Point operators to `aisw repair --apply` or re-adding the named profile.
- Add regression coverage and document the verification behavior.

## Trade-offs

This stops verification at the actionable configuration defect instead of attempting checks against a profile that cannot be resolved. Existing status output and JSON shapes are unchanged.

## Verification

- `cargo fmt --all -- --check`
- targeted verify/status tests passed
- `./.githooks/pre-commit` passed (623 unit tests, 1 ignored, integration suites, clippy, release build, completions smoke)
- `./.githooks/pre-push` passed (full test suite and release build)

Closes #188
