### PR TITLE
Reject prerelease compatibility matches

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -460,6 +460,9 @@ in `compatibility_baseline`; older, newer, missing, or unparseable versions
 are warnings and do not hard-fail `status`. Missing tools report `null` for
 the binary fields in JSON output.
 
+Prerelease and build-metadata suffixes are treated as unparseable so an
+unaudited build cannot be mistaken for the pinned stable release.
+
 | Flag | Effect |
 |---|---|
 | `--tool` | Filter to one tool: `claude`, `codex`, `gemini`, or `antigravity` |

--- a/src/compatibility.rs
+++ b/src/compatibility.rs
@@ -44,17 +44,57 @@ pub fn assess(tool: Tool, detected: Option<&str>) -> Status {
 }
 
 fn parse_version(raw: &str) -> Option<Version> {
-    raw.split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '.')
-        .filter_map(|part| part.strip_prefix('v').or(Some(part)))
-        .find_map(|part| {
-            let mut components = part.split('.');
-            let version = Version(
-                components.next()?.parse().ok()?,
-                components.next()?.parse().ok()?,
-                components.next()?.parse().ok()?,
-            );
-            components.next().is_none().then_some(version)
-        })
+    for (start, ch) in raw.char_indices() {
+        let version_start = if ch == 'v'
+            && raw
+                .get(start + ch.len_utf8()..)
+                .and_then(|rest| rest.chars().next())
+                .is_some_and(|next| next.is_ascii_digit())
+        {
+            start + ch.len_utf8()
+        } else if ch.is_ascii_digit() {
+            start
+        } else {
+            continue;
+        };
+
+        let end = raw[version_start..]
+            .char_indices()
+            .find_map(|(offset, ch)| {
+                (!ch.is_ascii_digit() && ch != '.').then_some(version_start + offset)
+            })
+            .unwrap_or(raw.len());
+        let suffix = &raw[end..];
+        if suffix.starts_with('-') || suffix.starts_with('+') {
+            continue;
+        }
+        if suffix
+            .chars()
+            .next()
+            .is_some_and(|next| next.is_ascii_alphanumeric() || next == '.')
+        {
+            continue;
+        }
+
+        let mut components = raw[version_start..end].split('.');
+        let (Some(major), Some(minor), Some(patch)) =
+            (components.next(), components.next(), components.next())
+        else {
+            continue;
+        };
+        if components.next().is_some() {
+            continue;
+        }
+        let (Ok(major), Ok(minor), Ok(patch)) = (
+            major.parse::<u64>(),
+            minor.parse::<u64>(),
+            patch.parse::<u64>(),
+        ) else {
+            continue;
+        };
+        return Some(Version(major, minor, patch));
+    }
+    None
 }
 
 #[cfg(test)]
@@ -90,6 +130,18 @@ mod tests {
         assert_eq!(assess(Tool::Gemini, None), Status::Unknown);
         assert_eq!(
             assess(Tool::Gemini, Some("gemini development")),
+            Status::Unknown
+        );
+    }
+
+    #[test]
+    fn treats_prerelease_and_build_metadata_as_unknown() {
+        assert_eq!(
+            assess(Tool::Codex, Some("codex-cli 0.153.4-beta.1")),
+            Status::Unknown
+        );
+        assert_eq!(
+            assess(Tool::Codex, Some("codex-cli 0.153.4+build.1")),
             Status::Unknown
         );
     }


### PR DESCRIPTION
## Why

The compatibility check extracted a stable-looking `major.minor.patch` prefix from prerelease strings such as `v0.153.4-beta.1`, classifying an unaudited build as the audited stable release.

## What changed

- Parse version candidates with explicit suffix-boundary checks.
- Treat prerelease and build metadata as `unknown`.
- Preserve normal vendor prefixes such as `rust-v0.153.4`.
- Add regression coverage and document the conservative behavior.

## Trade-offs

Some vendor output with unusual appended metadata may now be reported as unknown. This is intentionally safer than claiming compatibility that has not been audited; `status` remains advisory and exposes the warning.

## Verification

- `cargo fmt --all -- --check`
- `cargo test compatibility::tests --lib` (4 passed)
- `./.githooks/pre-commit` (624 unit tests, 1 ignored, integration suites, clippy, release build, completions smoke)
- `./.githooks/pre-push` (full test suite and release build)

Closes #190
