### PR TITLE
Refresh compatibility baseline provenance

### DIFF
--- a/docs/acceptance-matrix.md
+++ b/docs/acceptance-matrix.md
@@ -4,7 +4,7 @@ This matrix records the current end-to-end acceptance status for supported `aisw
 
 ## Versioned compatibility baseline
 
-The baseline below records the upstream releases checked against `aisw` `0.3.8` at commit `2fd9cf7`, verified on 2026-09-09. The release pins make the audit reproducible; they are not a guarantee that a future upstream release preserves the same storage contracts. Verification is based on the repository's unit and integration tests plus the documented upstream release and authentication behavior; it does not claim that each vendor binary was installed on every listed operating system in CI.
+The baseline below records the upstream releases checked against `aisw` `0.3.8` at commit `03b3003`, verified on 2026-09-09. The release pins make the audit reproducible; they are not a guarantee that a future upstream release preserves the same storage contracts. Verification is based on the repository's unit and integration tests plus the documented upstream release and authentication behavior; it does not claim that each vendor binary was installed on every listed operating system in CI.
 
 | Agent | Upstream release | OS coverage | Compatibility basis | Result | Sources |
 | --- | --- | --- | --- | --- | --- |

--- a/tests/acceptance_matrix_consistency.rs
+++ b/tests/acceptance_matrix_consistency.rs
@@ -114,7 +114,7 @@ fn acceptance_matrix_records_current_versioned_agent_baseline() {
         "versioned compatibility baseline should record its verification date"
     );
     assert!(
-        matrix.contains("against `aisw` `0.3.8` at commit `2fd9cf7`"),
+        matrix.contains("against `aisw` `0.3.8` at commit `03b3003`"),
         "versioned compatibility baseline should identify the aisw baseline"
     );
 


### PR DESCRIPTION
Closes #195

## Why
The acceptance matrix called its compatibility table current while pinning the `aisw` audit to commit `2fd9cf7`, which predates several merged reliability fixes and the dependency refresh. That makes release-readiness evidence harder to trust.

## What changed
- anchor the matrix to the current audited `main` commit
- update the consistency test so stale provenance fails loudly

## Trade-offs
This changes only evidence provenance. It preserves the existing upstream release pins and the explicit limitation that vendor binaries were not installed on every operating system in CI; it does not broaden compatibility claims.

## Verification
- targeted acceptance-matrix provenance test passed
- `.githooks/pre-commit` passed: formatting, clippy, release build, full tests, and completion smoke
- `.githooks/pre-push` passed: full tests and release build
