### PR TITLE
Document Antigravity profile onboarding

### DIFF
--- a/docs/adding-profiles.md
+++ b/docs/adding-profiles.md
@@ -9,7 +9,7 @@ description: How to add and capture named profiles in aisw using API keys, OAuth
 aisw add <tool> <profile> [--api-key KEY] [--from-env] [--from-live] [--label TEXT] [--credential-backend file|system-keyring] [--set-active]
 ```
 
-`<tool>` is one of: `claude`, `codex`, `gemini`.
+`<tool>` is one of: `claude`, `codex`, `gemini`, `antigravity`.
 `<profile>` is any identifier you choose: `work`, `personal`, `client-acme`, `ci`.
 
 ## API key

--- a/tests/machine_interface_docs.rs
+++ b/tests/machine_interface_docs.rs
@@ -26,3 +26,17 @@ fn automation_docs_publish_the_machine_interface_contract() {
         }
     }
 }
+
+#[test]
+fn profile_onboarding_lists_every_supported_tool() {
+    for path in [
+        "docs/adding-profiles.md",
+        "website/src/content/docs/adding-profiles.md",
+    ] {
+        let content = read_repo_file(path);
+        assert!(
+            content.contains("`<tool>` is one of: `claude`, `codex`, `gemini`, `antigravity`."),
+            "profile onboarding is missing a supported tool: {path}"
+        );
+    }
+}

--- a/website/src/content/docs/adding-profiles.md
+++ b/website/src/content/docs/adding-profiles.md
@@ -26,7 +26,7 @@ head:
 aisw add <tool> <profile> [--api-key KEY] [--from-env] [--from-live] [--label TEXT] [--credential-backend file|system-keyring] [--set-active]
 ```
 
-`<tool>` is one of: `claude`, `codex`, `gemini`.
+`<tool>` is one of: `claude`, `codex`, `gemini`, `antigravity`.
 `<profile>` is any identifier you choose: `work`, `personal`, `client-acme`, `ci`.
 
 ## API key


### PR DESCRIPTION
Closes #197

## Why
The profile onboarding guide told users that `aisw add` supported only Claude, Codex, and Gemini, despite Antigravity being a supported tool. That makes first-run discovery inconsistent with the command reference and actual behavior.

## What changed
- add Antigravity to the canonical and website onboarding tool lists
- add a documentation consistency test covering both copies

## Trade-offs
This is documentation-only. It aligns the stated tool set without changing authentication behavior or expanding compatibility claims.

## Verification
- focused documentation test passed
- `.githooks/pre-commit` passed: formatting, clippy, release build, full tests, and completion smoke
