### PR TITLE
Preserve diagnostic JSON in quiet mode

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -427,12 +427,10 @@ pub fn run_in(
     let report = collect(home, user_home, path_var);
     let failed = report.any_failed();
 
-    if !runtime::is_quiet() {
-        if args.json {
-            print_json(&report)?;
-        } else {
-            print_text(&report);
-        }
+    if args.json {
+        print_json(&report)?;
+    } else if !runtime::is_quiet() {
+        print_text(&report);
     }
 
     Ok(!failed)

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -63,12 +63,10 @@ pub(crate) fn run_in(
     let report = collect(home, user_home, path_var)?;
     let passed = report.summary.status != VerifyStatus::Fail;
 
-    if !runtime::is_quiet() {
-        if args.json {
-            println!("{}", serde_json::to_string_pretty(&report)?);
-        } else {
-            print_text(&report);
-        }
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else if !runtime::is_quiet() {
+        print_text(&report);
     }
 
     Ok(passed)

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -192,6 +192,17 @@ fn verify_json_reports_failures_and_remediation() {
 }
 
 #[test]
+fn quiet_mode_does_not_suppress_diagnostic_json() {
+    let env = TestEnv::new();
+
+    for command in ["doctor", "verify"] {
+        let output = env.output(&["--quiet", command, "--json"]);
+        assert!(!output.stdout.is_empty(), "{command} should emit JSON");
+        assert!(serde_json::from_slice::<serde_json::Value>(&output.stdout).is_ok());
+    }
+}
+
+#[test]
 fn repair_json_dry_run_reports_planned_safe_fixes() {
     let env = TestEnv::new();
     let missing_home = env.dir.path().join("missing-aisw-home");


### PR DESCRIPTION
Closes #199

## Why

`--quiet` currently suppresses the JSON payload from `doctor` and `verify`, despite the automation contract promising that machine-readable output remains available. CI callers can see a failure exit code but cannot inspect the diagnostic result.

## Change

- emit JSON whenever `--json` is selected
- keep human-readable output gated by `--quiet`
- add an integration regression test covering both diagnostic commands

## Trade-offs

JSON is explicitly machine-readable and must remain available for scripts. Quiet mode continues to suppress only human-oriented presentation output.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `cargo test` — 623 passed, 1 ignored
- `bash tests/completions_smoke.sh`
- repository pre-commit and pre-push hooks passed
