### PR TITLE
Scope Ubuntu package installation

### DIFF
--- a/.github/scripts/install-linux-dependencies.sh
+++ b/.github/scripts/install-linux-dependencies.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub-hosted images may preconfigure third-party APT sources. Restrict the
+# update to Ubuntu's source file so an unrelated vendor index cannot block CI.
+ubuntu_sources=$(find /etc/apt/sources.list.d -maxdepth 1 -type f -name 'ubuntu.sources' -print -quit)
+if [[ -z "$ubuntu_sources" ]]; then
+  ubuntu_sources=/etc/apt/sources.list
+fi
+
+apt_options=(
+  -o "Dir::Etc::sourcelist=$ubuntu_sources"
+  -o "Dir::Etc::sourceparts=-"
+)
+
+sudo apt-get "${apt_options[@]}" update
+sudo apt-get "${apt_options[@]}" install -y "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: bash .github/scripts/install-linux-dependencies.sh libdbus-1-dev pkg-config
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install system dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: bash .github/scripts/install-linux-dependencies.sh libdbus-1-dev pkg-config
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: bash .github/scripts/install-linux-dependencies.sh libdbus-1-dev pkg-config
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/credential-store-canary.yml
+++ b/.github/workflows/credential-store-canary.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install system dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y dbus-x11 gnome-keyring libdbus-1-dev pkg-config
+        run: bash .github/scripts/install-linux-dependencies.sh dbus-x11 gnome-keyring libdbus-1-dev pkg-config
 
       - name: Configure disposable macOS Keychain
         if: matrix.os == 'macos-15-intel'

--- a/tests/acceptance_matrix_consistency.rs
+++ b/tests/acceptance_matrix_consistency.rs
@@ -157,3 +157,34 @@ fn credential_store_canary_is_bounded_and_fail_closed() {
         "credential-store canary failures must remain release-visible"
     );
 }
+
+#[test]
+fn linux_ci_dependency_install_ignores_unrelated_apt_sources() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script_path = repo_root
+        .join(".github")
+        .join("scripts")
+        .join("install-linux-dependencies.sh");
+    let script = std::fs::read_to_string(&script_path)
+        .expect("Linux dependency installer should be readable");
+    let ci = std::fs::read_to_string(repo_root.join(".github/workflows/ci.yml"))
+        .expect("CI workflow should be readable");
+    let canary =
+        std::fs::read_to_string(repo_root.join(".github/workflows/credential-store-canary.yml"))
+            .expect("credential-store canary workflow should be readable");
+
+    assert!(
+        script.contains("Dir::Etc::sourceparts=-"),
+        "Linux dependency installation must ignore third-party APT source parts"
+    );
+    assert_eq!(
+        ci.matches("bash .github/scripts/install-linux-dependencies.sh")
+            .count(),
+        3,
+        "every Ubuntu CI job should use the scoped dependency installer"
+    );
+    assert!(
+        canary.contains("bash .github/scripts/install-linux-dependencies.sh"),
+        "the Linux credential-store canary should use the scoped dependency installer"
+    );
+}


### PR DESCRIPTION
Closes #201

## Why

Every Ubuntu CI job runs `apt-get update` against all repositories preconfigured on the GitHub-hosted image. A transient hash mismatch in the unrelated Google Chrome repository blocked the test, lint, and coverage jobs before Rust ran, while the project only needs Ubuntu packages from the distribution repositories.

## Change

- add one scoped Linux dependency installer that selects Ubuntu's `ubuntu.sources` file and disables other APT source parts
- use it from test, lint, coverage, and credential-store canary workflows
- add a regression check that keeps all Linux workflows on the scoped path

## Trade-offs

The workflow intentionally trusts only the runner's Ubuntu source configuration for these packages. This keeps required package installation fail-closed while removing unrelated vendor repositories from the update path; it does not suppress errors from Ubuntu mirrors or package installation.

## Verification

- `actionlint`
- `shellcheck .github/scripts/install-linux-dependencies.sh`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `cargo test` — 623 passed, 1 ignored
- repository pre-commit and pre-push hooks passed
