### PR TITLE
Cover Antigravity tool detection

### DIFF
--- a/src/tool_detection.rs
+++ b/src/tool_detection.rs
@@ -312,37 +312,38 @@ mod tests {
     }
 
     #[test]
-    fn detect_all_has_all_three_keys() {
+    fn detect_all_has_all_tool_keys() {
         let dir = tempdir().unwrap();
         let path = path_of(dir.path());
-        let all: HashMap<Tool, Option<DetectedTool>> = [Tool::Claude, Tool::Codex, Tool::Gemini]
+        let all: HashMap<Tool, Option<DetectedTool>> = Tool::ALL
             .into_iter()
             .map(|t| (t, detect_in(t, path.clone())))
             .collect();
-        assert!(all.contains_key(&Tool::Claude));
-        assert!(all.contains_key(&Tool::Codex));
-        assert!(all.contains_key(&Tool::Gemini));
+        for tool in Tool::ALL {
+            assert!(all.contains_key(&tool));
+        }
     }
 
     #[test]
     fn detect_all_finds_installed_tools() {
         let dir = tempdir().unwrap();
         make_dummy_binary(dir.path(), "gemini", "irrelevant", true);
+        make_dummy_binary(dir.path(), "agy", "irrelevant", true);
 
         // detect_all uses env PATH; drive detect_at directly for isolation.
         let path = path_of(dir.path());
-        let results: HashMap<Tool, Option<DetectedTool>> =
-            [Tool::Claude, Tool::Codex, Tool::Gemini]
-                .into_iter()
-                .map(|t| {
-                    (
-                        t,
-                        detect_at(t, path.clone(), VersionSource::Custom(no_version)),
-                    )
-                })
-                .collect();
+        let results: HashMap<Tool, Option<DetectedTool>> = Tool::ALL
+            .into_iter()
+            .map(|t| {
+                (
+                    t,
+                    detect_at(t, path.clone(), VersionSource::Custom(no_version)),
+                )
+            })
+            .collect();
 
         assert!(results[&Tool::Gemini].is_some());
+        assert!(results[&Tool::Antigravity].is_some());
         assert!(results[&Tool::Claude].is_none());
         assert!(results[&Tool::Codex].is_none());
     }


### PR DESCRIPTION
Closes #203

## Why

Antigravity is a supported tool and is included in `Tool::ALL`, but the detection tests still covered only the original three tools. That left the `agy` lookup path without direct regression coverage.

## Change

- make the all-tool detection test derive its keys from `Tool::ALL`
- add a positive `agy` executable detection case
- update the test name to reflect four-tool coverage

## Trade-offs

This is test-only coverage aligned with the existing implementation; no detection behavior changes.

## Verification

- `cargo fmt --all -- --check`
- `cargo test detect_all_` — 2 passed
- repository pre-commit and pre-push hooks passed
