### PR TITLE
Skip optional docs deploy notification

### DIFF
--- a/.github/workflows/notify-aiswitcher-dev.yml
+++ b/.github/workflows/notify-aiswitcher-dev.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "AISWITCHER_DEV_DISPATCH_TOKEN secret is not set. Skipping." >&2
-            exit 1
+            exit 0
           fi
           status=$(curl -s -o /dev/null -w "%{http_code}" \
             -X POST \

--- a/tests/acceptance_matrix_consistency.rs
+++ b/tests/acceptance_matrix_consistency.rs
@@ -188,3 +188,20 @@ fn linux_ci_dependency_install_ignores_unrelated_apt_sources() {
         "the Linux credential-store canary should use the scoped dependency installer"
     );
 }
+
+#[test]
+fn optional_docs_deploy_notification_skips_without_token() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workflow_path = repo_root
+        .join(".github")
+        .join("workflows")
+        .join("notify-aiswitcher-dev.yml");
+    let workflow = std::fs::read_to_string(&workflow_path)
+        .expect("docs deploy notification workflow should be readable");
+
+    assert!(
+        workflow.contains("AISWITCHER_DEV_DISPATCH_TOKEN secret is not set. Skipping.")
+            && workflow.contains("exit 0"),
+        "missing optional dispatch token must skip successfully"
+    );
+}


### PR DESCRIPTION
Closes #205

## Why

The docs deploy notification is optional, but a missing dispatch token currently exits with failure after printing that it is skipping. This makes docs-only pushes report a failed workflow when the downstream integration is not configured.

## Trade-offs

A missing token is treated as an intentional skip. A configured token that receives a non-2xx response still fails the workflow, preserving visibility into real integration failures.

## Verification

- `cargo fmt --check`
- `cargo test --locked --test acceptance_matrix_consistency` (5 passed)
- `actionlint`
- `shellcheck .github/scripts/*.sh`
