### PR TITLE
Report parsed command failures

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -203,6 +203,10 @@ The JSON failure envelope carries the same information in a stable shape:
 }
 ```
 
+The top-level `command` identifies the parsed operation for execution
+failures, including nested commands such as `context_use` and
+`workspace_bind`. Parse failures that do not accept a command use `unknown`.
+
 Branch on `error.kind`, not on the message text  -  `kind` is stable, the message is not. `remediation` is present only when a suggested next command exists; `safe: true` means it is read-only and can be run automatically.
 
 `aisw doctor` and `aisw verify` exit non-zero when a check fails, so they work directly as CI gates.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,6 +129,32 @@ pub enum Command {
     Workspace(WorkspaceArgs),
 }
 
+#[allow(dead_code)]
+impl Command {
+    pub fn machine_name(&self) -> &'static str {
+        match self {
+            Self::Version(_) => "version",
+            Self::Capabilities(_) => "capabilities",
+            Self::Add(_) => "add",
+            Self::Context(args) => args.command.machine_name(),
+            Self::Use(_) => "use",
+            Self::List(_) => "list",
+            Self::Remove(_) => "remove",
+            Self::Rename(_) => "rename",
+            Self::Status(_) => "status",
+            Self::Init(_) => "init",
+            Self::Uninstall(_) => "uninstall",
+            Self::ShellHook(_) => "shell_hook",
+            Self::Backup(args) => args.command.machine_name(),
+            Self::Doctor(_) => "doctor",
+            Self::Verify(_) => "verify",
+            Self::Repair(_) => "repair",
+            Self::ProjectBindings(args) => args.command.machine_name(),
+            Self::Workspace(args) => args.command.machine_name(),
+        }
+    }
+}
+
 #[derive(Args, Debug)]
 pub struct DoctorArgs {
     /// Output results as JSON
@@ -180,6 +206,15 @@ pub enum ProjectBindingsCommand {
     List(ProjectBindingsListArgs),
 }
 
+#[allow(dead_code)]
+impl ProjectBindingsCommand {
+    fn machine_name(&self) -> &'static str {
+        match self {
+            Self::List(_) => "project_bindings_list",
+        }
+    }
+}
+
 #[derive(Args, Debug)]
 pub struct ProjectBindingsListArgs {
     /// Output as JSON
@@ -212,6 +247,20 @@ pub enum WorkspaceCommand {
 
     #[command(hide = true)]
     Check(WorkspaceCheckArgs),
+}
+
+#[allow(dead_code)]
+impl WorkspaceCommand {
+    fn machine_name(&self) -> &'static str {
+        match self {
+            Self::Bind(_) => "workspace_bind",
+            Self::Unbind(_) => "workspace_unbind",
+            Self::Status(_) => "workspace_status",
+            Self::Doctor(_) => "workspace_doctor",
+            Self::Guard(_) => "workspace_guard",
+            Self::Check(_) => "workspace_check",
+        }
+    }
 }
 
 #[derive(Args, Debug)]
@@ -423,6 +472,21 @@ pub enum ContextCommand {
 
     /// Rename a saved context
     Rename(ContextRenameArgs),
+}
+
+#[allow(dead_code)]
+impl ContextCommand {
+    fn machine_name(&self) -> &'static str {
+        match self {
+            Self::Create(_) => "context_create",
+            Self::List(_) => "context_list",
+            Self::Use(_) => "context_use",
+            Self::Set(_) => "context_set",
+            Self::Unset(_) => "context_unset",
+            Self::Remove(_) => "context_remove",
+            Self::Rename(_) => "context_rename",
+        }
+    }
 }
 
 #[derive(Args, Debug)]
@@ -740,6 +804,16 @@ pub enum BackupCommand {
 
     /// Restore a backup by id
     Restore(BackupRestoreArgs),
+}
+
+#[allow(dead_code)]
+impl BackupCommand {
+    fn machine_name(&self) -> &'static str {
+        match self {
+            Self::List(_) => "backup_list",
+            Self::Restore(_) => "backup_restore",
+        }
+    }
 }
 
 #[derive(Args, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run() -> Result<()> {
         }
     };
     runtime::configure(cli.non_interactive, cli.quiet, output_mode);
+    runtime::set_command(cli.command.machine_name());
     output::configure(cli.no_color, cli.quiet);
     commands::dispatch(cli)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
             .map(|ae| ae.exit_code())
             .unwrap_or(aisw::error::EXIT_GENERAL_ERROR);
         if aisw::runtime::is_machine_mode() {
-            aisw::machine::print_failure(None, &e, exit_code);
+            aisw::machine::print_failure(aisw::runtime::command(), &e, exit_code);
         } else {
             aisw::output::print_error_chain(&e);
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -12,12 +12,15 @@ static NON_INTERACTIVE: AtomicBool = AtomicBool::new(false);
 static QUIET: AtomicBool = AtomicBool::new(false);
 #[cfg(not(test))]
 static OUTPUT_MODE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+#[cfg(not(test))]
+static COMMAND: std::sync::Mutex<Option<&'static str>> = std::sync::Mutex::new(None);
 
 #[cfg(test)]
 thread_local! {
     static NON_INTERACTIVE: Cell<bool> = const { Cell::new(false) };
     static QUIET: Cell<bool> = const { Cell::new(false) };
     static OUTPUT_MODE: Cell<OutputMode> = const { Cell::new(OutputMode::Human) };
+    static COMMAND: Cell<Option<&'static str>> = const { Cell::new(None) };
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,12 +36,36 @@ pub fn configure(non_interactive: bool, quiet: bool, output_mode: OutputMode) {
         NON_INTERACTIVE.with(|flag| flag.set(non_interactive));
         QUIET.with(|flag| flag.set(quiet));
         OUTPUT_MODE.with(|flag| flag.set(output_mode));
+        COMMAND.with(|command| command.set(None));
     }
     #[cfg(not(test))]
     {
         NON_INTERACTIVE.store(non_interactive, Ordering::Relaxed);
         QUIET.store(quiet, Ordering::Relaxed);
         OUTPUT_MODE.store(output_mode as u8, Ordering::Relaxed);
+        *COMMAND.lock().unwrap_or_else(|poison| poison.into_inner()) = None;
+    }
+}
+
+pub fn set_command(command: &'static str) {
+    #[cfg(test)]
+    {
+        COMMAND.with(|current| current.set(Some(command)));
+    }
+    #[cfg(not(test))]
+    {
+        *COMMAND.lock().unwrap_or_else(|poison| poison.into_inner()) = Some(command);
+    }
+}
+
+pub fn command() -> Option<&'static str> {
+    #[cfg(test)]
+    {
+        COMMAND.with(Cell::get)
+    }
+    #[cfg(not(test))]
+    {
+        *COMMAND.lock().unwrap_or_else(|poison| poison.into_inner())
     }
 }
 

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -321,7 +321,7 @@ fn context_create_duplicate_is_structured_in_machine_mode() {
     assert!(output.stderr.is_empty());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
-    assert_eq!(json["command"], "unknown");
+    assert_eq!(json["command"], "context_create");
     assert_eq!(json["error"]["kind"], "context_already_exists");
     assert_eq!(
         json["error"]["remediation"]["command"],
@@ -339,7 +339,7 @@ fn context_use_missing_context_is_structured_in_machine_mode() {
     assert!(output.stderr.is_empty());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
-    assert_eq!(json["command"], "unknown");
+    assert_eq!(json["command"], "context_use");
     assert_eq!(json["error"]["kind"], "context_not_found");
     assert_eq!(
         json["error"]["remediation"]["command"],
@@ -357,7 +357,7 @@ fn context_create_missing_profile_is_structured_in_machine_mode() {
     assert!(output.stderr.is_empty());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
-    assert_eq!(json["command"], "unknown");
+    assert_eq!(json["command"], "context_create");
     assert_eq!(json["error"]["kind"], "profile_not_found");
 }
 
@@ -378,7 +378,7 @@ fn workspace_bind_missing_context_is_structured_in_machine_mode() {
     assert!(output.stderr.is_empty());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
-    assert_eq!(json["command"], "unknown");
+    assert_eq!(json["command"], "workspace_bind");
     assert_eq!(json["error"]["kind"], "context_not_found");
 }
 
@@ -421,7 +421,7 @@ fn add_api_key_stdin_empty_is_structured_failure() {
     assert!(output.stderr.is_empty());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
-    assert_eq!(json["command"], "unknown");
+    assert_eq!(json["command"], "add");
     assert_eq!(json["error"]["kind"], "validation_error");
 }
 

--- a/tests/machine_interface_docs.rs
+++ b/tests/machine_interface_docs.rs
@@ -19,6 +19,7 @@ fn automation_docs_publish_the_machine_interface_contract() {
             "The current value for each is `1`.",
             "ignore unknown fields",
             "Treat an unknown version as unsupported",
+            "top-level `command` identifies the parsed operation",
             "Backup ids sort lexicographically, newest first.",
             "sort_by(.backup_id) | first | .backup_id",
         ] {

--- a/website/src/content/docs/automation.md
+++ b/website/src/content/docs/automation.md
@@ -220,6 +220,10 @@ The JSON failure envelope carries the same information in a stable shape:
 }
 ```
 
+The top-level `command` identifies the parsed operation for execution
+failures, including nested commands such as `context_use` and
+`workspace_bind`. Parse failures that do not accept a command use `unknown`.
+
 Branch on `error.kind`, not on the message text  -  `kind` is stable, the message is not. `remediation` is present only when a suggested next command exists; `safe: true` means it is read-only and can be run automatically.
 
 `aisw doctor` and `aisw verify` exit non-zero when a check fails, so they work directly as CI gates.


### PR DESCRIPTION
Closes #207

## Why

Machine-mode failures from parsed commands were reported with `command: "unknown"`, even though the operation was known. That made a stable automation envelope less useful for routing and diagnostics.

## Decision

Record the parsed leaf operation in runtime state and use it when the top-level failure handler emits JSON. Nested operations use the same names as successful envelopes (`context_use`, `workspace_bind`, `backup_restore`, and similar). Parse failures that never accept a command remain `unknown`.

## Verification

- `cargo fmt --check`
- `cargo test --locked --test gui_contract --test machine_interface_docs`
- `cargo clippy --all-targets -- -D warnings`
- `actionlint`
- `shellcheck .github/scripts/*.sh`
- repository pre-commit and pre-push hooks (full release build and test suite)
