### PR TITLE
Resolve rand security advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,9 +1517,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",


### PR DESCRIPTION
Closes #194

## Why
RustSec flagged transitive `rand 0.8.5` in the Linux Secret Service dependency graph. `rand 0.8.6` backports the upstream fix.

## Scope
Update only `Cargo.lock`. Keep the existing keyring features, native backends, and Rust 1.80 MSRV unchanged.

## Verification
- `cargo audit` — no vulnerabilities or warnings
- `cargo test --locked --lib` — 624 tests, 623 passed and 1 ignored
- `cargo build --release --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- repository pre-commit and pre-push hooks
