### PR TITLE
fix: use stable missing-tool machine error

### DIFF
--- a/src/tool_detection.rs
+++ b/src/tool_detection.rs
@@ -5,8 +5,9 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 
+use crate::error::AiswError;
 use crate::types::Tool;
 
 const VERSION_TIMEOUT: Duration = Duration::from_secs(2);
@@ -62,22 +63,14 @@ pub fn detect_all() -> HashMap<Tool, Option<DetectedTool>> {
 pub fn require(tool: Tool) -> Result<DetectedTool> {
     match detect(tool) {
         Some(d) => Ok(d),
-        None => bail!(
-            "{} is not installed or not found on PATH.\n  \
-             Install it and make sure the binary is on your PATH.",
-            tool.binary_name()
-        ),
+        None => Err(AiswError::ToolNotInstalled { tool }.into()),
     }
 }
 
 pub(crate) fn require_in(tool: Tool, path: OsString) -> Result<DetectedTool> {
     match detect_in(tool, path) {
         Some(d) => Ok(d),
-        None => bail!(
-            "{} is not installed or not found on PATH.\n  \
-             Install it and make sure the binary is on your PATH.",
-            tool.binary_name()
-        ),
+        None => Err(AiswError::ToolNotInstalled { tool }.into()),
     }
 }
 

--- a/tests/add_cmd.rs
+++ b/tests/add_cmd.rs
@@ -142,6 +142,46 @@ fn add_claude_tool_not_installed_fails() {
 }
 
 #[test]
+fn add_claude_tool_not_installed_machine_error_is_stable() {
+    let env = TestEnv::new();
+
+    let output = env.output(&[
+        "add",
+        "claude",
+        "work",
+        "--api-key",
+        VALID_CLAUDE_KEY,
+        "--json",
+    ]);
+
+    assert!(!output.status.success(), "missing tool should fail");
+    assert!(
+        output.stderr.is_empty(),
+        "machine-mode failures should be written to stdout only; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid json");
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["command"], "add");
+    assert_eq!(json["error"]["kind"], "tool_not_installed");
+    assert!(json["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("not on PATH"));
+    assert_eq!(
+        json["error"]["remediation"]["command"],
+        "aisw doctor --json"
+    );
+    assert_eq!(json["error"]["remediation"]["safe"], true);
+    assert!(
+        !env.home_file("config.json").exists(),
+        "add should fail before creating profile state when the tool binary is missing"
+    );
+}
+
+#[test]
 fn add_claude_api_key_with_set_active() {
     let env = TestEnv::new();
     env.add_fake_tool("claude", "claude 2.3.0");


### PR DESCRIPTION
## Summary
- return `AiswError::ToolNotInstalled` from tool-detection requirement helpers
- add a machine-mode regression test for `add --json` when the agent binary is missing
- assert the command fails before profile state is created and includes `aisw doctor --json` remediation

Fixes #217

## Testing
- `cargo fmt --check`
- `cargo test add_claude_tool_not_installed --test add_cmd` *(blocked in this environment: the local linker reports rustup `libstd-*.rlib` as not found while compiling build scripts)*
