### PR TITLE
Use stable missing tool error

### DIFF
--- a/src/tool_detection.rs
+++ b/src/tool_detection.rs
@@ -5,8 +5,9 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 
+use crate::error::AiswError;
 use crate::types::Tool;
 
 const VERSION_TIMEOUT: Duration = Duration::from_secs(2);
@@ -62,22 +63,14 @@ pub fn detect_all() -> HashMap<Tool, Option<DetectedTool>> {
 pub fn require(tool: Tool) -> Result<DetectedTool> {
     match detect(tool) {
         Some(d) => Ok(d),
-        None => bail!(
-            "{} is not installed or not found on PATH.\n  \
-             Install it and make sure the binary is on your PATH.",
-            tool.binary_name()
-        ),
+        None => Err(AiswError::ToolNotInstalled { tool }.into()),
     }
 }
 
 pub(crate) fn require_in(tool: Tool, path: OsString) -> Result<DetectedTool> {
     match detect_in(tool, path) {
         Some(d) => Ok(d),
-        None => bail!(
-            "{} is not installed or not found on PATH.\n  \
-             Install it and make sure the binary is on your PATH.",
-            tool.binary_name()
-        ),
+        None => Err(AiswError::ToolNotInstalled { tool }.into()),
     }
 }
 

--- a/tests/gui_contract.rs
+++ b/tests/gui_contract.rs
@@ -426,6 +426,31 @@ fn add_api_key_stdin_empty_is_structured_failure() {
 }
 
 #[test]
+fn add_missing_tool_is_structured_in_machine_mode() {
+    let env = TestEnv::new();
+    let output = env.output(&[
+        "add",
+        "claude",
+        "work",
+        "--api-key",
+        "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "--json",
+    ]);
+
+    assert!(!output.status.success());
+    assert!(output.stderr.is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["command"], "add");
+    assert_eq!(json["error"]["kind"], "tool_not_installed");
+    assert_eq!(
+        json["error"]["remediation"]["command"],
+        "aisw doctor --json"
+    );
+    assert!(!env.aisw_home.join("profiles").join("claude").exists());
+}
+
+#[test]
 fn add_duplicate_profile_is_structured_in_machine_mode() {
     let env = TestEnv::new();
     env.add_fake_tool("claude", "claude 2.3.0");


### PR DESCRIPTION
Closes #217

## Why
`add --json` could only report `validation_error` when the requested agent binary was absent, even though the stable taxonomy already defines `tool_not_installed` and a doctor remediation.

## Decision
Return the typed `ToolNotInstalled` error from both detection requirement helpers. This keeps the human wording and fail-before-write ordering unchanged while giving GUI and CI callers a stable kind and actionable remediation.

## Verification
- `cargo fmt --check`
- targeted GUI contract regression test
- `cargo clippy --all-targets --locked -- -D warnings`
- full repository pre-commit and pre-push hooks
