### PR TITLE
Correct Antigravity onboarding docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,8 @@ aisw add claude work --api-key "$ANTHROPIC_API_KEY"
 aisw add claude personal              # launches interactive OAuth
 aisw add codex work --api-key "$OPENAI_API_KEY"
 aisw add gemini work --api-key "$GEMINI_API_KEY"
-aisw add antigravity work             # OAuth only  -  no API-key auth upstream
+aisw add antigravity work             # shared OAuth
+aisw add antigravity api --api-key "$GEMINI_API_KEY"
 
 # Activate a profile
 aisw use claude work

--- a/tests/machine_interface_docs.rs
+++ b/tests/machine_interface_docs.rs
@@ -41,3 +41,18 @@ fn profile_onboarding_lists_every_supported_tool() {
         );
     }
 }
+
+#[test]
+fn onboarding_documents_list_antigravity_api_key_auth() {
+    for path in ["docs/index.md", "website/src/content/docs/index.md"] {
+        let content = read_repo_file(path);
+        assert!(
+            content.contains("aisw add antigravity api --api-key \"$GEMINI_API_KEY\""),
+            "Antigravity API-key onboarding is missing: {path}"
+        );
+        assert!(
+            !content.contains("OAuth only") && !content.contains("no API-key auth upstream"),
+            "Antigravity onboarding still contradicts supported API-key auth: {path}"
+        );
+    }
+}

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -85,7 +85,8 @@ aisw add claude work --api-key "$ANTHROPIC_API_KEY"
 aisw add claude personal              # launches interactive OAuth
 aisw add codex work --api-key "$OPENAI_API_KEY"
 aisw add gemini work --api-key "$GEMINI_API_KEY"
-aisw add antigravity work             # OAuth only  -  no API-key auth upstream
+aisw add antigravity work             # shared OAuth
+aisw add antigravity api --api-key "$GEMINI_API_KEY"
 
 # Activate a profile
 aisw use claude work


### PR DESCRIPTION
Closes #220

## Why
The primary onboarding guide described Antigravity as OAuth-only and said API-key auth was unavailable, while the shipped CLI supports Gemini API-key profiles and the detailed guides already document them. That contradiction can send a first-time user into an unnecessary login flow.

## Decision
Show both supported Antigravity setup paths in the repository and website entry guides. Add a consistency test covering both copies so the supported authentication modes stay aligned.

## Verification
- `cargo fmt --check`
- targeted onboarding documentation test
- full pre-commit and pre-push hooks
