### PR TITLE
Lock Cargo dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
   test:
     name: Test
@@ -59,7 +59,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --locked
 
       - name: Completion smoke test
         if: matrix.os == 'ubuntu-latest'
@@ -113,7 +113,7 @@ jobs:
 
       - name: Run coverage with quality gates
         run: |
-          cargo +nightly llvm-cov \
+          cargo +nightly llvm-cov --locked \
             --json \
             --summary-only \
             --branch \
@@ -121,7 +121,7 @@ jobs:
           .github/scripts/coverage-gate.sh coverage-summary.json
 
       - name: Generate coverage report
-        run: cargo +nightly llvm-cov --lcov --branch --output-path lcov.info
+        run: cargo +nightly llvm-cov --locked --lcov --branch --output-path lcov.info
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/tests/acceptance_matrix_consistency.rs
+++ b/tests/acceptance_matrix_consistency.rs
@@ -190,6 +190,24 @@ fn linux_ci_dependency_install_ignores_unrelated_apt_sources() {
 }
 
 #[test]
+fn ci_cargo_invocations_use_the_committed_lockfile() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let ci = std::fs::read_to_string(repo_root.join(".github/workflows/ci.yml"))
+        .expect("CI workflow should be readable");
+
+    for line in ci.lines().filter(|line| {
+        let trimmed = line.trim_start();
+        (trimmed.starts_with("run: cargo") && !trimmed.contains("cargo fmt"))
+            || trimmed.starts_with("cargo +nightly llvm-cov")
+    }) {
+        assert!(
+            line.contains("--locked"),
+            "CI Cargo invocation must use the committed lockfile: {line}"
+        );
+    }
+}
+
+#[test]
 fn optional_docs_deploy_notification_skips_without_token() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let workflow_path = repo_root


### PR DESCRIPTION
Closes #224

## Why
Some hosted jobs resolved Cargo dependencies without consulting the committed lockfile, while Windows and release jobs were locked. That allowed lint, build, or coverage to validate a different dependency graph from the one covered by the security baseline.

## Decision
Pass `--locked` to CI build, clippy, and coverage invocations, and add a workflow consistency test that protects the lockfile requirement for future Cargo validation commands.

## Verification
- `cargo fmt --check`
- targeted workflow consistency test
- actionlint and shellcheck
- full pre-commit and pre-push hooks
