### PR TITLE
Restore compatibility guidance in website docs

### DIFF
--- a/tests/acceptance_matrix_consistency.rs
+++ b/tests/acceptance_matrix_consistency.rs
@@ -135,6 +135,22 @@ fn acceptance_matrix_records_current_versioned_agent_baseline() {
 }
 
 #[test]
+fn website_command_docs_preserve_compatibility_warning() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let canonical = std::fs::read_to_string(repo_root.join("docs/commands.md"))
+        .expect("canonical command docs should be readable");
+    let website = std::fs::read_to_string(repo_root.join("website/src/content/docs/commands.md"))
+        .expect("website command docs should be readable");
+    let warning = "Prerelease and build-metadata suffixes are treated as unparseable so an\nunaudited build cannot be mistaken for the pinned stable release.";
+
+    assert!(canonical.contains(warning));
+    assert!(
+        website.contains(warning),
+        "website command docs must preserve the compatibility warning"
+    );
+}
+
+#[test]
 fn credential_store_canary_is_bounded_and_fail_closed() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let workflow_path = repo_root

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -477,6 +477,9 @@ in `compatibility_baseline`; older, newer, missing, or unparseable versions
 are warnings and do not hard-fail `status`. Missing tools report `null` for
 the binary fields in JSON output.
 
+Prerelease and build-metadata suffixes are treated as unparseable so an
+unaudited build cannot be mistaken for the pinned stable release.
+
 | Flag | Effect |
 |---|---|
 | `--tool` | Filter to one tool: `claude`, `codex`, `gemini`, or `antigravity` |


### PR DESCRIPTION
Closes #226

## Why
The published command reference had drifted from the canonical docs and omitted the warning that prerelease and build-metadata versions are treated as unparseable. Without it, an unaudited upstream build could be mistaken for a verified baseline.

## Decision
Restore the compatibility warning in the website command reference and add a consistency test that checks the canonical and published copies remain aligned on this safety-critical behavior.

## Verification
- `cargo fmt --check`
- targeted documentation consistency test
- actionlint and shellcheck
- full pre-commit and pre-push hooks
