### PR TITLE
Document recovery failure guarantees

### DIFF
--- a/tests/acceptance_matrix_consistency.rs
+++ b/tests/acceptance_matrix_consistency.rs
@@ -151,6 +151,26 @@ fn website_command_docs_preserve_compatibility_warning() {
 }
 
 #[test]
+fn website_security_docs_preserve_recovery_failure_guarantees() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let canonical = std::fs::read_to_string(repo_root.join("docs/security.md"))
+        .expect("canonical security docs should be readable");
+    let website = std::fs::read_to_string(repo_root.join("website/src/content/docs/security.md"))
+        .expect("website security docs should be readable");
+
+    for guarantee in [
+        "If the commit and its automatic rollback both fail, `aisw` reports both errors",
+        "Staged\nfile cleanup failures are reported alongside the operation error as well.",
+    ] {
+        assert!(canonical.contains(guarantee));
+        assert!(
+            website.contains(guarantee),
+            "website security docs must preserve recovery guarantee: {guarantee}"
+        );
+    }
+}
+
+#[test]
 fn credential_store_canary_is_bounded_and_fail_closed() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let workflow_path = repo_root

--- a/website/src/content/docs/security.md
+++ b/website/src/content/docs/security.md
@@ -87,6 +87,10 @@ All operations are local filesystem and OS keyring operations. You can audit thi
 
 Profile activation uses a snapshot-and-apply model. Before writing any live credential file, the current live state is captured. If any file write fails partway through, the snapshot is restored atomically. You never end up with a partially applied profile.
 
+If the commit and its automatic rollback both fail, `aisw` reports both errors
+so the operator knows that live state needs inspection before retrying. Staged
+file cleanup failures are reported alongside the operation error as well.
+
 This is particularly important for Claude Code, which stores credentials across multiple locations (the credentials file and OAuth account metadata in `~/.claude.json`). A failed write to either location triggers a full rollback.
 
 ### Backups before destructive operations


### PR DESCRIPTION
Closes #228

## Why
The canonical security documentation explains that activation reports both commit and automatic rollback errors, and reports staged-file cleanup failures alongside the operation error. The published website copy omitted both guarantees, leaving operators without important recovery guidance.

## Trade-offs
This keeps the change focused on the published security page and a consistency guard. Other intentional website metadata and wording differences remain unchanged.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --release --locked`
- `cargo test --locked` — 627 passed, 1 ignored
- commit hook — passed, including completion smoke
