### PR TITLE
Redirect legacy documentation host

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "prebuild": "npm run sync-docs",
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "astro build && node ./scripts/generate-redirects.mjs",
     "check:seo": "node ./scripts/check-seo.mjs",
     "preview": "astro preview",
     "astro": "astro"

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,4 +1,2 @@
 User-agent: *
-Allow: /
-
-Sitemap: https://burakdede.github.io/aisw/sitemap-index.xml
+Disallow: /

--- a/website/scripts/check-seo.mjs
+++ b/website/scripts/check-seo.mjs
@@ -12,9 +12,27 @@ const requiredFiles = [
   'llms-full.txt',
   'site.webmanifest',
   'version.json',
-  'sitemap-index.xml',
-  'sitemap-0.xml',
 ];
+
+const redirects = {
+  '/aisw/': 'https://aiswitcher.dev/',
+  '/aisw/common-situations/': 'https://aiswitcher.dev/docs/common-situations/',
+  '/aisw/faq/': 'https://aiswitcher.dev/guides/',
+  '/aisw/quickstart/': 'https://aiswitcher.dev/docs/quickstart/',
+  '/aisw/commands/': 'https://aiswitcher.dev/docs/commands/',
+  '/aisw/automation/': 'https://aiswitcher.dev/docs/automation/',
+  '/aisw/shell-integration/': 'https://aiswitcher.dev/docs/shell-integration/',
+  '/aisw/workspace/': 'https://aiswitcher.dev/docs/workspace/',
+  '/aisw/adding-profiles/': 'https://aiswitcher.dev/docs/adding-profiles/',
+  '/aisw/supported-tools/': 'https://aiswitcher.dev/supported-tools/',
+  '/aisw/acceptance-matrix/': 'https://aiswitcher.dev/supported-tools/',
+  '/aisw/configuration/': 'https://aiswitcher.dev/docs/configuration/',
+  '/aisw/how-it-works/': 'https://aiswitcher.dev/docs/how-it-works/',
+  '/aisw/security/': 'https://aiswitcher.dev/security/',
+  '/aisw/why-aisw/': 'https://aiswitcher.dev/docs/why-aisw/',
+  '/aisw/troubleshooting/': 'https://aiswitcher.dev/docs/troubleshooting/',
+  '/aisw/releases/': 'https://aiswitcher.dev/releases/',
+};
 
 async function main() {
   for (const file of requiredFiles) {
@@ -27,25 +45,20 @@ async function main() {
     throw new Error('Missing version metadata in version.json');
   }
 
-  const indexHtml = await fs.readFile(path.join(distRoot, 'index.html'), 'utf8');
-  assertContains(indexHtml, `<link rel="canonical" href="${siteUrl}"/>`, 'root canonical URL');
-  assertContains(indexHtml, 'application/ld+json', 'structured data');
-  assertContains(indexHtml, `Current release: v${version}.`, 'release-aware hero tagline');
-  assertContains(indexHtml, 'href="/aisw/quickstart/"', 'base-aware internal docs link');
-  assertNotContains(indexHtml, '/aisw/aisw/', 'duplicate base path in root HTML');
-  assertNotContains(indexHtml, 'href="/quickstart/"', 'root-relative docs link without base');
-
-  const sitemap = await fs.readFile(path.join(distRoot, 'sitemap-0.xml'), 'utf8');
-  assertContains(sitemap, '<loc>https://burakdede.github.io/aisw/</loc>', 'root sitemap entry');
-  assertNotContains(sitemap, '/aisw/aisw/', 'duplicate base path in sitemap');
-
   const robotsTxt = await fs.readFile(path.join(distRoot, 'robots.txt'), 'utf8');
-  assertContains(robotsTxt, 'Sitemap: https://burakdede.github.io/aisw/sitemap-index.xml', 'robots sitemap');
+  assertContains(robotsTxt, 'User-agent: *\nDisallow: /', 'legacy robots policy');
 
-  const llmsFull = await fs.readFile(path.join(distRoot, 'llms-full.txt'), 'utf8');
-  assertContains(llmsFull, `Current version: ${version}`, 'llms-full current version');
-  assertContains(llmsFull, '## Quickstart', 'llms-full quickstart entry');
-  assertContains(llmsFull, 'Headings:', 'llms-full heading inventory');
+  for (const [route, target] of Object.entries(redirects)) {
+    const file = path.join(distRoot, route.replace(/^\/aisw\//, ''), 'index.html');
+    const html = await fs.readFile(file, 'utf8');
+    assertContains(html, `<link rel="canonical" href="${target}">`, `${route} canonical redirect`);
+    assertContains(html, `location.replace(${JSON.stringify(target)})`, `${route} redirect script`);
+    assertContains(html, 'noindex,nofollow', `${route} noindex policy`);
+  }
+
+  const llms = await fs.readFile(path.join(distRoot, 'llms.txt'), 'utf8');
+  assertContains(llms, 'https://aiswitcher.dev/', 'canonical LLM destination');
+  assertNotContains(llms, 'burakdede.github.io/aisw', 'legacy LLM URL');
   assertContains(versionJson, `"version": "${version}"`, 'version metadata artifact');
 }
 

--- a/website/scripts/generate-redirects.mjs
+++ b/website/scripts/generate-redirects.mjs
@@ -1,0 +1,60 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const distRoot = path.join(process.cwd(), 'dist');
+const canonicalRoot = 'https://aiswitcher.dev';
+const redirects = {
+  '/aisw/': '/',
+  '/aisw/common-situations/': '/docs/common-situations/',
+  '/aisw/faq/': '/guides/',
+  '/aisw/quickstart/': '/docs/quickstart/',
+  '/aisw/commands/': '/docs/commands/',
+  '/aisw/automation/': '/docs/automation/',
+  '/aisw/shell-integration/': '/docs/shell-integration/',
+  '/aisw/workspace/': '/docs/workspace/',
+  '/aisw/adding-profiles/': '/docs/adding-profiles/',
+  '/aisw/supported-tools/': '/supported-tools/',
+  '/aisw/acceptance-matrix/': '/supported-tools/',
+  '/aisw/configuration/': '/docs/configuration/',
+  '/aisw/how-it-works/': '/docs/how-it-works/',
+  '/aisw/security/': '/security/',
+  '/aisw/why-aisw/': '/docs/why-aisw/',
+  '/aisw/troubleshooting/': '/docs/troubleshooting/',
+  '/aisw/releases/': '/releases/',
+};
+const canonicalLlmText = `# AI Switcher documentation
+
+The canonical AI Switcher documentation now lives at https://aiswitcher.dev/docs/.
+
+This legacy GitHub Pages site redirects old documentation URLs to their closest canonical pages.
+`;
+
+for (const [route, targetPath] of Object.entries(redirects)) {
+  const target = `${canonicalRoot}${targetPath}`;
+  const outputPath = path.join(distRoot, route.replace(/^\/aisw\//, ''), 'index.html');
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, redirectHtml(target));
+}
+
+await fs.rm(path.join(distRoot, 'sitemap-index.xml'), { force: true });
+await fs.rm(path.join(distRoot, 'sitemap-0.xml'), { force: true });
+await fs.writeFile(path.join(distRoot, 'llms.txt'), canonicalLlmText);
+await fs.writeFile(path.join(distRoot, 'llms-full.txt'), canonicalLlmText);
+
+function redirectHtml(target) {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex,nofollow">
+    <meta http-equiv="refresh" content="0;url=${target}">
+    <link rel="canonical" href="${target}">
+    <title>Moved to AI Switcher</title>
+  </head>
+  <body>
+    <p>This page moved to <a href="${target}">${target}</a>.</p>
+    <script>location.replace(${JSON.stringify(target)});</script>
+  </body>
+</html>
+`;
+}

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -390,7 +390,7 @@ function rewriteRepoMarkdownLinks(markdown) {
 }
 
 function buildRobotsTxt() {
-  return `User-agent: *\nAllow: /\n\nSitemap: ${siteUrl}/sitemap-index.xml\n`;
+  return 'User-agent: *\nDisallow: /\n';
 }
 
 function buildLlmsTxt(currentVersion) {


### PR DESCRIPTION
Closes #240

## Why
The old GitHub Pages host still serves duplicate documentation pages as 200 responses, so search engines can discover two competing versions of the same docs after the migration to `aiswitcher.dev`.

## Trade-offs
- Generates lightweight redirect pages for the legacy host with path-specific canonical destinations, preserving the old host as a migration bridge.
- Uses no client-side-only redirect: each page includes a meta refresh, a canonical destination, and a small JavaScript navigation enhancement.
- Keeps the legacy artifact disallowed from indexing and removes its sitemap and LLM context files.

## Verification
- `npm run build` (17 pages; existing Astro warnings only for an unused internal helper import and the `/404` route conflict)
- `npm run check:seo`
- Full pre-push hook: Rust test suite passed (630 passed, 1 ignored) and release build passed
- Inspected generated `/`, `/quickstart/`, and sitemap artifacts
- After merge, verify live redirect behavior for `/aisw/`, `/aisw/quickstart/`, `/aisw/commands/`, and `/aisw/security/`
