### PR TITLE
Remove internal search wording

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -152,8 +152,6 @@ See [Workspace guardrails](workspace.md) for resolution order, remote patterns, 
 | Check support before installing | [Supported tools](supported-tools.md) | [Acceptance matrix](acceptance-matrix.md) |
 | Diagnose a mismatch or failed switch | [Troubleshooting](troubleshooting.md) | [Configuration](config.md) |
 
-For direct answers to common searches such as “how do I switch between two Claude Code accounts?” or “can I manage multiple Codex CLI accounts?”, see [Frequently Asked Questions](faq.md).
-
 ## Additional reference
 
 - [Adding profiles](adding-profiles.md)

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -183,8 +183,6 @@ See [Workspace guardrails](/aisw/workspace/) for resolution order, remote patter
 | Check support before installing | [Supported tools](/aisw/supported-tools/) | [Acceptance matrix](/aisw/acceptance-matrix/) |
 | Diagnose a mismatch or failed switch | [Troubleshooting](/aisw/troubleshooting/) | [Configuration](/aisw/configuration/) |
 
-For direct answers to common searches such as “how do I switch between two Claude Code accounts?” or “can I manage multiple Codex CLI accounts?”, see [Frequently Asked Questions](/aisw/faq/).
-
 ## Additional reference
 
 - [Adding profiles](/aisw/adding-profiles/)


### PR DESCRIPTION
Closes #242

## Why
Public documentation should explain aisw's product and workflows, not expose internal content strategy.

## What changed
- remove internal search-strategy wording from the canonical docs entry point
- regenerate the website copy from the canonical source

## Verification
- `npm run sync-docs`
- repository pre-commit checks
- repository pre-push checks
