### PR TITLE
Build Linux x86_64 releases with an old glibc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,12 @@ jobs:
         with:
           key: release-${{ matrix.target }}
 
+      # Each cross release pins its build images, and with them the glibc a
+      # Linux binary links against: 0.2.5 images ship glibc 2.23. Bump
+      # deliberately; the glibc floor check below fails if a bump raises it.
       - name: Install cross
         if: matrix.cross
-        run: cargo install cross --locked
+        run: cargo install cross --version 0.2.5 --locked
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux targets build through cross so the binary links against an
+          # old glibc; a native ubuntu-latest build requires the runner's glibc.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            cross: false
+            cross: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             cross: true
@@ -87,8 +89,23 @@ jobs:
             exit 1
           fi
 
+      - name: Check glibc floor
+        if: contains(matrix.target, 'linux-gnu')
+        shell: bash
+        env:
+          BINARY: ${{ steps.artifact.outputs.binary }}
+          MAX_GLIBC_MINOR: "28"
+        run: |
+          required="$(strings "$BINARY" | grep -o 'GLIBC_2\.[0-9]*' | sort -t. -k2 -n -u | tail -1)"
+          echo "Highest required glibc symbol: ${required:-none}"
+          minor="${required#GLIBC_2.}"
+          if [ -n "$required" ] && [ "$minor" -gt "$MAX_GLIBC_MINOR" ]; then
+            echo "Error: $BINARY requires $required; the supported floor is glibc 2.$MAX_GLIBC_MINOR" >&2
+            exit 1
+          fi
+
       - name: Cold start check
-        if: "!matrix.cross && matrix.os != 'windows-latest'"
+        if: "matrix.os != 'windows-latest' && matrix.target != 'aarch64-unknown-linux-gnu'"
         shell: bash
         env:
           BINARY: ${{ steps.artifact.outputs.binary }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "aisw"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aisw"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2021"
 rust-version = "1.80"
 description = "Manage multiple accounts for Claude Code, Codex CLI, and Gemini CLI"


### PR DESCRIPTION
Closes #245

## Why
The `aisw-x86_64-unknown-linux-gnu` release asset (0.3.8 and 0.3.9) requires `GLIBC_2.38`/`GLIBC_2.39`, so it fails to start on Ubuntu 22.04, Debian 12 and older distros. AI Switcher Desktop bundles this binary, so its Linux engine fails on the same systems. The desktop CI exposed this when it first ran the sidecar on ubuntu-22.04.

## What changed
- x86_64 Linux now builds through `cross`, the same path as aarch64. The existing aarch64 asset needs only glibc 2.18.
- A new **Check glibc floor** step fails the release if a Linux binary needs a glibc newer than 2.28, so the floor can't silently rise again.
- The cold start check still runs for x86_64, which executes natively on the runner.
- `cross` is pinned to 0.2.5. Each cross release pins its build images, and with them the glibc: the 0.2.5 images ship glibc 2.23, while cross `main` has already moved to 2.31. The install was unpinned, so a future cross release could have broken the new floor check.
- Version bumped to 0.3.10.

## Trade-offs
- I rejected building natively on `ubuntu-22.04`. It only lowers the floor to 2.35, and it would start failing again when that runner image is retired.
- I rejected musl. It would change the asset name that Homebrew, the install script and the desktop app all download, and it changes keyring and DNS behavior.
- `CHANGELOG.md` stops at 0.3.6, and releases since then use GitHub release notes. I left it alone rather than rewriting history in this PR.

## Verification
- `actionlint .github/workflows/release.yml`: clean.
- I ran the guard's shell logic against the published assets. It rejects x86_64 0.3.8 and 0.3.9 (both GLIBC_2.39) and accepts aarch64 0.3.9 (GLIBC_2.18).
- Docker isn't available on my machine, so the `cross` x86_64 build itself is proven by the release run. The new guard step fails that run if the floor isn't met.
